### PR TITLE
refactor: Split ArrayBorrowCompiler off from ArrayGetitemCompiler

### DIFF
--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -16,6 +16,7 @@ from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.definition.custom import CopyInoutCompiler
 from guppylang_internals.std._internal.checker import ArrayCopyChecker, NewArrayChecker
 from guppylang_internals.std._internal.compiler.array import (
+    ArrayBorrowCompiler,
     ArrayDiscardAllUsedCompiler,
     ArrayGetitemCompiler,
     ArraySetitemCompiler,
@@ -101,7 +102,7 @@ class ArrayIter(Generic[L, n]):
         self: ArrayIter[L, n] @ owned,
     ) -> Option[tuple[L, ArrayIter[L, n]]]:
         if self.i < int(n):
-            elem = _array_unsafe_getitem(self.xs, self.i)
+            elem = _barray_unsafe_borrow(self.xs, self.i)
             return some((elem, ArrayIter(self.xs, self.i + 1)))
         _array_discard_all_used(self.xs)
         return nothing()
@@ -111,8 +112,8 @@ class ArrayIter(Generic[L, n]):
 def _array_discard_all_used(xs: array[L, n] @ owned) -> None: ...
 
 
-@custom_function(ArrayGetitemCompiler())
-def _array_unsafe_getitem(xs: array[L, n], idx: int) -> L: ...
+@custom_function(ArrayBorrowCompiler())
+def _barray_unsafe_borrow(xs: array[L, n], idx: int) -> L: ...
 
 
 @extend_type(frozenarray_type_def)


### PR DESCRIPTION
The goal here is to (a) make it clearer what's going on, (b) give a bit more protection, via asserts, against changes elsewhere in the compiler accidentally generating bad code.

ArrayGetitemCompiler compiles classical and linear variants separately; and has two uses: for `fn __getitem__` of `class array` and for `fn _array_unsafe_getitem` (used only in `ArrayIter`).

First thought was that these can now be separate: ArrayIter ends in `discard_all_borrowed`, so just a borrow would suffice even in the classical case. In fact it turns out that the ArrayIter code only ever uses the linear case, because it's output as polymorphic in Hugr; so outputting `get` for the classical case would be just as efficient - it never happens. But that would be quite misleading, I argue this refactor makes it clearer what's going on.

Passes mypy. Not done any execution/integration tests yet...
