### PR TITLE
fix!: Metadata Generation with Nested Modifiers

### DIFF
--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -360,10 +360,11 @@ class CFGBuilder(AstVisitor[BB | None]):
         accumulated_flags = self.cfg.unitary_flags | modifiers.flags()
         cfg = CFGBuilder().build(node.body, True, self.globals, accumulated_flags)
         new_node = ModifiedBlock(
-            cfg=cfg,
-            modifiers=modifiers,
+            cfg,
+            modifiers,
             # we save the first modifier node for a better error rendering
-            first_modifier_node=node.items[0].context_expr,
+            node.items[0].context_expr,
+            accumulated_flags,
             **dict(ast.iter_fields(node)),
         )
 

--- a/guppylang-internals/src/guppylang_internals/checker/modifier_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/modifier_checker.py
@@ -102,7 +102,9 @@ def check_modified_block_signature(
 ) -> FunctionType:
     """Check and create the signature of a function definition for a body
     of a `With` block."""
-    unitary_flags = modified_block.flags()
+    # We use accumulated_flags here so we can have the correct metadata on modifier the
+    # block when nested under others modifiers.
+    unitary_flags = modified_block.accumulated_flags
 
     func_ty = FunctionType(
         [

--- a/guppylang-internals/src/guppylang_internals/checker/modifier_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/modifier_checker.py
@@ -102,8 +102,8 @@ def check_modified_block_signature(
 ) -> FunctionType:
     """Check and create the signature of a function definition for a body
     of a `With` block."""
-    # We use accumulated_flags here so we can have the correct metadata on modifier the
-    # block when nested under others modifiers.
+    # We use accumulated_flags here so the block has the correct modifier
+    # metadata when it is nested under other modifiers.
     unitary_flags = modified_block.accumulated_flags
 
     func_ty = FunctionType(

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -829,12 +829,14 @@ class ModifiedBlock(ast.With):
 
     cfg: "CFG"
     first_modifier_node: ast.expr
+    accumulated_flags: UnitaryFlags
 
     def __init__(
         self,
         cfg: "CFG",
         modifiers: "Modifiers",
         first_modifier_node: ast.expr,
+        accumulated_flags: UnitaryFlags,
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -842,6 +844,7 @@ class ModifiedBlock(ast.With):
         self.cfg = cfg
         self.modifiers = modifiers
         self.first_modifier_node = first_modifier_node
+        self.accumulated_flags = accumulated_flags
 
     @property
     def dagger(self) -> list[Dagger]:
@@ -873,16 +876,6 @@ class ModifiedBlock(ast.With):
             to_span(self.items[0].context_expr).start,
             to_span(self.items[-1].context_expr).end,
         )
-
-    def flags(self) -> UnitaryFlags:
-        flags = UnitaryFlags.NoFlags
-        if self.has_dagger():
-            flags |= UnitaryFlags.Dagger
-        if self.has_control():
-            flags |= UnitaryFlags.Control
-        if self.has_power():
-            flags |= UnitaryFlags.Power
-        return flags
 
 
 class CheckedModifiedBlock(ast.With):

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -825,6 +825,7 @@ class ModifiedBlock(ast.With):
     parameters:
     - `cfg`: the CFG of the body of the block
     - `first_modifier_node`: the AST node of the first modifier, used in error reporting
+    - `accumulated_flags`: the UnitaryFlags accumulated from outer modified blocks
     """
 
     cfg: "CFG"

--- a/tests/metadata/test_modifier_metadata.py
+++ b/tests/metadata/test_modifier_metadata.py
@@ -29,6 +29,7 @@ def _check_block_metadata(
 
     return blocks
 
+
 # Test single modifiers metadata
 def test_unitary_metadata_dagger_only():
     @guppy
@@ -87,9 +88,7 @@ def test_unitary_metadata_power_dagger_control():
         [
             UnitaryFlags.Power.value,
             (UnitaryFlags.Dagger | UnitaryFlags.Power).value,
-            (
-                UnitaryFlags.Control | UnitaryFlags.Dagger | UnitaryFlags.Power
-            ).value,
+            (UnitaryFlags.Control | UnitaryFlags.Dagger | UnitaryFlags.Power).value,
         ],
     )
 
@@ -112,9 +111,7 @@ def test_unitary_metadata_dagger_power_control():
         [
             UnitaryFlags.Dagger.value,
             (UnitaryFlags.Power | UnitaryFlags.Dagger).value,
-            (
-                UnitaryFlags.Control | UnitaryFlags.Power | UnitaryFlags.Dagger
-            ).value,
+            (UnitaryFlags.Control | UnitaryFlags.Power | UnitaryFlags.Dagger).value,
         ],
     )
 

--- a/tests/metadata/test_modifier_metadata.py
+++ b/tests/metadata/test_modifier_metadata.py
@@ -29,7 +29,6 @@ def _check_block_metadata(
 
     return blocks
 
-
 # Test single modifiers metadata
 def test_unitary_metadata_dagger_only():
     @guppy
@@ -87,10 +86,10 @@ def test_unitary_metadata_power_dagger_control():
         h,
         [
             UnitaryFlags.Power.value,
-            UnitaryFlags.Dagger.value + UnitaryFlags.Power.value,
-            UnitaryFlags.Control.value
-            + UnitaryFlags.Dagger.value
-            + UnitaryFlags.Power.value,
+            (UnitaryFlags.Dagger | UnitaryFlags.Power).value,
+            (
+                UnitaryFlags.Control | UnitaryFlags.Dagger | UnitaryFlags.Power
+            ).value,
         ],
     )
 
@@ -112,10 +111,10 @@ def test_unitary_metadata_dagger_power_control():
         h,
         [
             UnitaryFlags.Dagger.value,
-            UnitaryFlags.Power.value + UnitaryFlags.Dagger.value,
-            UnitaryFlags.Control.value
-            + UnitaryFlags.Power.value
-            + UnitaryFlags.Dagger.value,
+            (UnitaryFlags.Power | UnitaryFlags.Dagger).value,
+            (
+                UnitaryFlags.Control | UnitaryFlags.Power | UnitaryFlags.Dagger
+            ).value,
         ],
     )
 
@@ -137,10 +136,8 @@ def test_unitary_metadata_control_dagger_power():
         h,
         [
             UnitaryFlags.Control.value,
-            UnitaryFlags.Dagger.value + UnitaryFlags.Control.value,
-            UnitaryFlags.Power.value
-            + UnitaryFlags.Dagger.value
-            + UnitaryFlags.Control.value,
+            (UnitaryFlags.Dagger | UnitaryFlags.Control).value,
+            (UnitaryFlags.Power | UnitaryFlags.Dagger | UnitaryFlags.Control).value,
         ],
     )
 
@@ -162,10 +159,8 @@ def test_unitary_metadata_power_control_dagger():
         h,
         [
             UnitaryFlags.Power.value,
-            UnitaryFlags.Control.value + UnitaryFlags.Power.value,
-            UnitaryFlags.Dagger.value
-            + UnitaryFlags.Control.value
-            + UnitaryFlags.Power.value,
+            (UnitaryFlags.Control | UnitaryFlags.Power).value,
+            (UnitaryFlags.Dagger | UnitaryFlags.Control | UnitaryFlags.Power).value,
         ],
     )
 
@@ -187,10 +182,8 @@ def test_unitary_metadata_dagger_control_power():
         h,
         [
             UnitaryFlags.Dagger.value,
-            UnitaryFlags.Control.value + UnitaryFlags.Dagger.value,
-            UnitaryFlags.Power.value
-            + UnitaryFlags.Control.value
-            + UnitaryFlags.Dagger.value,
+            (UnitaryFlags.Control | UnitaryFlags.Dagger).value,
+            (UnitaryFlags.Power | UnitaryFlags.Control | UnitaryFlags.Dagger).value,
         ],
     )
 
@@ -212,9 +205,7 @@ def test_unitary_metadata_control_power_dagger():
         h,
         [
             UnitaryFlags.Control.value,
-            UnitaryFlags.Power.value + UnitaryFlags.Control.value,
-            UnitaryFlags.Dagger.value
-            + UnitaryFlags.Power.value
-            + UnitaryFlags.Control.value,
+            (UnitaryFlags.Power | UnitaryFlags.Control).value,
+            (UnitaryFlags.Dagger | UnitaryFlags.Power | UnitaryFlags.Control).value,
         ],
     )

--- a/tests/metadata/test_modifier_metadata.py
+++ b/tests/metadata/test_modifier_metadata.py
@@ -1,0 +1,220 @@
+"""Tests that modifier blocks have the correct `unitary` metadata attached."""
+
+import guppylang as _guppylang
+from guppylang import guppy
+from guppylang.std.angles import angle
+from guppylang.std.builtins import control, dagger, power, qubit
+from guppylang.std.quantum import discard, rx
+from guppylang_internals.tys.ty import UnitaryFlags
+from hugr.hugr.base import Hugr
+from hugr.ops import FuncDefn
+
+_guppylang.enable_experimental_features()
+
+
+def _check_block_metadata(
+    hugr_module: Hugr, unitary_values: list[int] | None = None
+) -> list:
+    """Return the metadata dicts of all __WithBlock__ FuncDefn nodes."""
+
+    blocks = []
+    for _, data in hugr_module.nodes():
+        if isinstance(data.op, FuncDefn) and data.op.f_name.startswith("__WithBlock__"):
+            blocks.append(data.metadata)
+
+    if unitary_values is not None:
+        assert len(blocks) == len(unitary_values)
+        for block, unitary_value in zip(blocks, unitary_values, strict=True):
+            assert block["unitary"] == unitary_value
+
+    return blocks
+
+
+# Test single modifiers metadata
+def test_unitary_metadata_dagger_only():
+    @guppy
+    def main() -> None:
+        t = qubit()
+        with dagger:
+            rx(t, angle(1 / 3))
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(h, [UnitaryFlags.Dagger.value])
+
+
+def test_unitary_metadata_control_only():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with control(c1):
+            rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(h, [UnitaryFlags.Control.value])
+
+
+def test_unitary_metadata_power_only():
+    @guppy
+    def main() -> None:
+        t = qubit()
+        with power(3):
+            rx(t, angle(1 / 3))
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(h, [UnitaryFlags.Power.value])
+
+
+# Tests nested modifiers metadata
+def test_unitary_metadata_power_dagger_control():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with power(3):  # noqa: SIM117
+            with dagger:
+                with control(c1):
+                    rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(
+        h,
+        [
+            UnitaryFlags.Power.value,
+            UnitaryFlags.Dagger.value + UnitaryFlags.Power.value,
+            UnitaryFlags.Control.value
+            + UnitaryFlags.Dagger.value
+            + UnitaryFlags.Power.value,
+        ],
+    )
+
+
+def test_unitary_metadata_dagger_power_control():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with dagger:  # noqa: SIM117
+            with power(3):
+                with control(c1):
+                    rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(
+        h,
+        [
+            UnitaryFlags.Dagger.value,
+            UnitaryFlags.Power.value + UnitaryFlags.Dagger.value,
+            UnitaryFlags.Control.value
+            + UnitaryFlags.Power.value
+            + UnitaryFlags.Dagger.value,
+        ],
+    )
+
+
+def test_unitary_metadata_control_dagger_power():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with control(c1):  # noqa: SIM117
+            with dagger:
+                with power(3):
+                    rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(
+        h,
+        [
+            UnitaryFlags.Control.value,
+            UnitaryFlags.Dagger.value + UnitaryFlags.Control.value,
+            UnitaryFlags.Power.value
+            + UnitaryFlags.Dagger.value
+            + UnitaryFlags.Control.value,
+        ],
+    )
+
+
+def test_unitary_metadata_power_control_dagger():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with power(3):  # noqa: SIM117
+            with control(c1):
+                with dagger:
+                    rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(
+        h,
+        [
+            UnitaryFlags.Power.value,
+            UnitaryFlags.Control.value + UnitaryFlags.Power.value,
+            UnitaryFlags.Dagger.value
+            + UnitaryFlags.Control.value
+            + UnitaryFlags.Power.value,
+        ],
+    )
+
+
+def test_unitary_metadata_dagger_control_power():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with dagger:  # noqa: SIM117
+            with control(c1):
+                with power(3):
+                    rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(
+        h,
+        [
+            UnitaryFlags.Dagger.value,
+            UnitaryFlags.Control.value + UnitaryFlags.Dagger.value,
+            UnitaryFlags.Power.value
+            + UnitaryFlags.Control.value
+            + UnitaryFlags.Dagger.value,
+        ],
+    )
+
+
+def test_unitary_metadata_control_power_dagger():
+    @guppy
+    def main() -> None:
+        c1 = qubit()
+        t = qubit()
+        with control(c1):  # noqa: SIM117
+            with power(3):
+                with dagger:
+                    rx(t, angle(1 / 3))
+        discard(c1)
+        discard(t)
+
+    h = main.compile_function().modules[0]
+    _check_block_metadata(
+        h,
+        [
+            UnitaryFlags.Control.value,
+            UnitaryFlags.Power.value + UnitaryFlags.Control.value,
+            UnitaryFlags.Dagger.value
+            + UnitaryFlags.Power.value
+            + UnitaryFlags.Control.value,
+        ],
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1020,7 +1020,7 @@ requires-dist = [
     { name = "tket", specifier = ">=0.13.0" },
     { name = "tket-exts", specifier = "~=0.12.0" },
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
-    { name = "wasmtime", specifier = ">=38.0,<43.1" },
+    { name = "wasmtime", specifier = ">=38.0,<44.1" },
 ]
 provides-extras = ["pytket"]
 


### PR DESCRIPTION
Previously, when multiple modifiers were nested, inner modifiers did not inherit metadata from the outer ones. This caused a bug during pass resolution, which has now been fixed.


* The `ModifiedBlock` class now has an `accumulated_flags` attribute, which tracks all modifier flags applied to the block, including those inherited from nesting. This replaces the old `flags()` method. [[1]](diffhunk://#diff-6cd5c729fdf52a3e6a9dd9a468582fc9f49f7a68995845093f88d3e89d499dabR832-R847) [[2]](diffhunk://#diff-6cd5c729fdf52a3e6a9dd9a468582fc9f49f7a68995845093f88d3e89d499dabL877-L886)
* The control flow graph (CFG) builder and modifier checker are updated to use and propagate `accumulated_flags`, ensuring that metadata and type signatures reflect all active modifiers, even in nested contexts. [[1]](diffhunk://#diff-eb6972436fbc83bbc8d18700eab1d1d066aa62a6b32dc4487b5912d431c5f97fL363-R367) [[2]](diffhunk://#diff-dc0b997af6db2c778960b29570cd008671b1f161dde7f3159f023a5796185086L105-R107)
* Added  (`test_modifier_metadata.py`)  to verify that modifier blocks have the correct `unitary` metadata attached.

BREAKING CHANGE: deleted `guppylang_internals/nodes.py::def flags(self)` replaced by `accumulated_flags`