### PR TITLE
fix: Use of array subscript as argument of control modifiers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ devenv.local.nix
 **/.benchmarks/
 .vscode/settings.json
 guppy-exports/
+AGENTS.md

--- a/.gitignore
+++ b/.gitignore
@@ -158,4 +158,3 @@ devenv.local.nix
 **/.benchmarks/
 .vscode/settings.json
 guppy-exports/
-AGENTS.md

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -409,10 +409,10 @@ class BBLinearityChecker(ast.NodeVisitor):
         call."""
         # Places involving subscripts are given back by visiting the `__setitem__` call
         if subscript := contains_subscript(place):
-            assert subscript.setitem_call is not None
-            for leaf in leaf_places(subscript.setitem_call.value_var):
-                self.scope.assign(leaf)
-            self.visit(subscript.setitem_call.call)
+            if subscript.setitem_call is not None:
+                for leaf in leaf_places(subscript.setitem_call.value_var):
+                    self.scope.assign(leaf)
+                self.visit(subscript.setitem_call.call)
             self._reassign_single_inout_arg(subscript.parent, node)
         else:
             for leaf in leaf_places(place):

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -404,16 +404,20 @@ class BBLinearityChecker(ast.NodeVisitor):
                         err.add_sub_diagnostic(DropAfterCallError.Assign(None))
                         raise GuppyError(err)
 
-    def _reassign_single_inout_arg(self, place: Place, node: AstNode) -> None:
+    def _reassign_single_inout_arg(
+        self, place: Place, node: AstNode, visit_setitem: bool = True
+    ) -> None:
         """Helper function to reassign a single borrowed argument after a function
         call."""
         # Places involving subscripts are given back by visiting the `__setitem__` call
         if subscript := contains_subscript(place):
-            if subscript.setitem_call is not None:
+            if visit_setitem and subscript.setitem_call is not None:
                 for leaf in leaf_places(subscript.setitem_call.value_var):
                     self.scope.assign(leaf)
                 self.visit(subscript.setitem_call.call)
-            self._reassign_single_inout_arg(subscript.parent, node)
+            self._reassign_single_inout_arg(
+                subscript.parent, node, visit_setitem=visit_setitem
+            )
         else:
             for leaf in leaf_places(place):
                 assert not isinstance(leaf, SubscriptAccess)
@@ -727,7 +731,9 @@ class BBLinearityChecker(ast.NodeVisitor):
         for ctrl in node.control:
             for arg in ctrl.ctrl:
                 assert isinstance(arg, PlaceNode)  # Checked above
-                self._reassign_single_inout_arg(arg.place, arg.place.defined_at or arg)
+                self._reassign_single_inout_arg(
+                    arg.place, arg.place.defined_at or arg, visit_setitem=False
+                )
 
         # reassign captured variables
         for var, use in node.captured.values():

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -408,8 +408,12 @@ class BBLinearityChecker(ast.NodeVisitor):
         self, place: Place, node: AstNode, visit_setitem: bool = True
     ) -> None:
         """Helper function to reassign a single borrowed argument after a function
-        call."""
-        # Places involving subscripts are given back by visiting the `__setitem__` call
+        call.
+
+        For places involving subscripts, if `visit_setitem=True` (default), they are
+        given back by visiting the `__setitem__` call. If `visit_setitem=False`, only
+        the parent chain is marked as reassigned without visiting the setter call.
+        """
         if subscript := contains_subscript(place):
             if visit_setitem:
                 assert subscript.setitem_call is not None

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -411,7 +411,8 @@ class BBLinearityChecker(ast.NodeVisitor):
         call."""
         # Places involving subscripts are given back by visiting the `__setitem__` call
         if subscript := contains_subscript(place):
-            if visit_setitem and subscript.setitem_call is not None:
+            assert subscript.setitem_call is not None
+            if visit_setitem:
                 for leaf in leaf_places(subscript.setitem_call.value_var):
                     self.scope.assign(leaf)
                 self.visit(subscript.setitem_call.call)

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -411,8 +411,8 @@ class BBLinearityChecker(ast.NodeVisitor):
         call."""
         # Places involving subscripts are given back by visiting the `__setitem__` call
         if subscript := contains_subscript(place):
-            assert subscript.setitem_call is not None
             if visit_setitem:
+                assert subscript.setitem_call is not None
                 for leaf in leaf_places(subscript.setitem_call.value_var):
                     self.scope.assign(leaf)
                 self.visit(subscript.setitem_call.call)

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -428,13 +428,13 @@ class StmtChecker(AstVisitor[BBStatement]):
             # This case is handled during CFG construction.
             assert len(ctrl) > 0
             ctrl[0], ty = self._synth_expr(ctrl[0])
-            if isinstance(ctrl[0], PlaceNode):
-                ctrl[0].place = check_place_assignable(
-                    ctrl[0].place,
-                    self.ctx,
-                    ctrl[0],
-                    "able to control subscripted elements",
-                )
+            # if isinstance(ctrl[0], PlaceNode):
+            #     ctrl[0].place = check_place_assignable(
+            #         ctrl[0].place,
+            #         self.ctx,
+            #         ctrl[0],
+            #         "able to control subscripted elements",
+            #     )
 
             if is_array_type(ty):
                 if len(ctrl) > 1:
@@ -453,13 +453,13 @@ class StmtChecker(AstVisitor[BBStatement]):
                     ctrl[i], subst = self._check_expr(ctrl[i], qubit_ty())
                     assert len(subst) == 0
                     ctrl_arg = ctrl[i]
-                    assert isinstance(ctrl_arg, PlaceNode)
-                    ctrl_arg.place = check_place_assignable(
-                        ctrl_arg.place,
-                        self.ctx,
-                        ctrl_arg,
-                        "able to control subscripted elements",
-                    )
+                    if isinstance(ctrl_arg, PlaceNode):
+                        ctrl_arg.place = check_place_assignable(
+                            ctrl_arg.place,
+                            self.ctx,
+                            ctrl_arg,
+                            "able to control subscripted elements",
+                        )
                 control.qubit_num = len(ctrl)
 
         for power in node.power:

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -428,6 +428,13 @@ class StmtChecker(AstVisitor[BBStatement]):
             # This case is handled during CFG construction.
             assert len(ctrl) > 0
             ctrl[0], ty = self._synth_expr(ctrl[0])
+            if isinstance(ctrl[0], PlaceNode):
+                ctrl[0].place = check_place_assignable(
+                    ctrl[0].place,
+                    self.ctx,
+                    ctrl[0],
+                    "able to control subscripted elements",
+                )
 
             if is_array_type(ty):
                 if len(ctrl) > 1:
@@ -445,6 +452,14 @@ class StmtChecker(AstVisitor[BBStatement]):
                 for i in range(len(ctrl)):
                     ctrl[i], subst = self._check_expr(ctrl[i], qubit_ty())
                     assert len(subst) == 0
+                    ctrl_arg = ctrl[i]
+                    assert isinstance(ctrl_arg, PlaceNode)
+                    ctrl_arg.place = check_place_assignable(
+                        ctrl_arg.place,
+                        self.ctx,
+                        ctrl_arg,
+                        "able to control subscripted elements",
+                    )
                 control.qubit_num = len(ctrl)
 
         for power in node.power:

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -428,13 +428,6 @@ class StmtChecker(AstVisitor[BBStatement]):
             # This case is handled during CFG construction.
             assert len(ctrl) > 0
             ctrl[0], ty = self._synth_expr(ctrl[0])
-            # if isinstance(ctrl[0], PlaceNode):
-            #     ctrl[0].place = check_place_assignable(
-            #         ctrl[0].place,
-            #         self.ctx,
-            #         ctrl[0],
-            #         "able to control subscripted elements",
-            #     )
 
             if is_array_type(ty):
                 if len(ctrl) > 1:
@@ -447,6 +440,15 @@ class StmtChecker(AstVisitor[BBStatement]):
                     )
                     dummy_array_ty = array_type(qubit_ty(), n)
                     raise GuppyTypeError(TypeMismatchError(ctrl[0], dummy_array_ty, ty))
+                # We may have that the control is an array obtained via subscripting,
+                # e.g. `control(qs[0]) with qs: array[array[qubit, 2], 2]`.
+                if isinstance(ctrl[0], PlaceNode):
+                    ctrl[0].place = check_place_assignable(
+                        ctrl[0].place,
+                        self.ctx,
+                        ctrl[0],
+                        "able to control subscripted elements",
+                    )
                 control.qubit_num = get_array_length(ty)
             else:
                 for i in range(len(ctrl)):

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -15,6 +15,7 @@ from guppylang_internals.std._internal.compiler.arithmetic import convert_itousi
 from guppylang_internals.std._internal.compiler.array import (
     array_new,
     array_to_std_array,
+    barray_borrow,
     barray_return,
     standard_array_type,
     std_array_to_array,
@@ -45,6 +46,53 @@ def _return_control_subscript(
         idx,
         dfg[subscript],
     )
+
+
+def _borrow_control_subscript(
+    subscript: SubscriptAccess, dfg: DFContainer, ctx: CompilerContext
+) -> None:
+    """Borrow a containing array slot from the current parent array.
+    E.g. for qs[0][0], re-borrow qs[0] before borrowing from that inner array."""
+    if parent_subscript := contains_subscript(subscript.parent):
+        _borrow_control_subscript(parent_subscript, dfg, ctx)
+    parent_ty = subscript.parent.ty
+    assert is_array_type(parent_ty)
+    elem_ty = get_element_type(parent_ty).to_hugr(ctx)
+    length_arg = get_array_length(parent_ty).to_arg().to_hugr(ctx)
+    idx = dfg.builder.add_op(convert_itousize(), dfg[subscript.item])
+    dfg[subscript.parent], dfg[subscript] = dfg.builder.add_op(
+        barray_borrow(elem_ty, length_arg),
+        dfg[subscript.parent],
+        idx,
+    )
+
+
+def _write_back_control_subscript(
+    subscript: SubscriptAccess,
+    dfg: DFContainer,
+    ctx: CompilerContext,
+    expr_compiler: ExprCompiler,
+    parents_borrowed: bool = False,
+) -> None:
+    """Restore a returned control value and any containing borrowed subscripts.
+
+    For nested places, use the synthesized setter; plain array subscripts can
+    be restored directly with the borrow_array return op."""
+
+    if subscript.setitem_call is not None:
+        dfg[subscript.setitem_call.value_var] = dfg[subscript]
+        expr_compiler.visit(subscript.setitem_call.call)
+    else:
+        parent_subscript = contains_subscript(subscript.parent)
+        if parent_subscript is not None and not parents_borrowed:
+            # Nested getitem compilation returns the inner array before the modified
+            # call, so recreate the parent borrow before writing the control back.
+            _borrow_control_subscript(parent_subscript, dfg, ctx)
+        _return_control_subscript(subscript, dfg, ctx)
+        if parent_subscript is not None:
+            _write_back_control_subscript(
+                parent_subscript, dfg, ctx, expr_compiler, parents_borrowed=True
+            )
 
 
 def compile_modified_block(
@@ -208,12 +256,6 @@ def compile_modified_block(
             dfg[arg] = next(outports)
 
     for subscript in control_subscripts:
-        # For nested places, use the synthesized setter; plain array subscripts can
-        # be restored directly with the borrow_array return op.
-        if subscript.setitem_call is not None:
-            dfg[subscript.setitem_call.value_var] = dfg[subscript]
-            expr_compiler.visit(subscript.setitem_call.call)
-        else:
-            _return_control_subscript(subscript, dfg, ctx)
+        _write_back_control_subscript(subscript, dfg, ctx, expr_compiler)
 
     return call

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -23,17 +23,6 @@ from guppylang_internals.tys.builtin import int_type, is_array_type
 from guppylang_internals.tys.ty import InputFlags
 
 
-def _write_back_control_subscript(
-    subscript: SubscriptAccess,
-    dfg: DFContainer,
-    expr_compiler: ExprCompiler,
-) -> None:
-    """Restore a returned control value using the setter from type checking."""
-    assert subscript.setitem_call is not None
-    dfg[subscript.setitem_call.value_var] = dfg[subscript]
-    expr_compiler.visit(subscript.setitem_call.call)
-
-
 def compile_modified_block(
     modified_block: CheckedModifiedBlock,
     dfg: DFContainer,
@@ -78,10 +67,10 @@ def compile_modified_block(
     cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
     func_builder.set_outputs(*cfg)
 
-    # add the LoadFunc node
+    # Add the LoadFunc node
     call = dfg.builder.load_function(func_builder, hugr_ty)
 
-    # captured values to be the function inputs
+    # Captured values to be the function inputs
     captured = [v for v, _ in modified_block.captured.values()]
     captured = non_copyable_front_others_back(captured)
 
@@ -197,6 +186,9 @@ def compile_modified_block(
             dfg[arg] = next(outports)
 
     for subscript in control_subscripts:
-        _write_back_control_subscript(subscript, dfg, expr_compiler)
+        # Restore a returned control value using the setter from type checking."""
+        assert subscript.setitem_call is not None
+        dfg[subscript.setitem_call.value_var] = dfg[subscript]
+        expr_compiler.visit(subscript.setitem_call.call)
 
     return call

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -186,7 +186,7 @@ def compile_modified_block(
             dfg[arg] = next(outports)
 
     for subscript in control_subscripts:
-        # Restore a returned control value using the setter from type checking."""
+        # Restore a returned control value using the setter from type checking.
         assert subscript.setitem_call is not None
         dfg[subscript.setitem_call.value_var] = dfg[subscript]
         expr_compiler.visit(subscript.setitem_call.call)

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -4,22 +4,47 @@ from hugr import Wire, ops
 from hugr import tys as ht
 
 from guppylang_internals.ast_util import get_type
+from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
 from guppylang_internals.checker.modifier_checker import non_copyable_front_others_back
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.metadata.common import add_metadata
 from guppylang_internals.nodes import CheckedModifiedBlock, PlaceNode
+from guppylang_internals.std._internal.compiler.arithmetic import convert_itousize
 from guppylang_internals.std._internal.compiler.array import (
     array_new,
     array_to_std_array,
+    barray_return,
     standard_array_type,
     std_array_to_array,
     unpack_array,
 )
 from guppylang_internals.std._internal.compiler.tket_exts import MODIFIER_EXTENSION
-from guppylang_internals.tys.builtin import int_type, is_array_type
+from guppylang_internals.tys.builtin import (
+    get_array_length,
+    get_element_type,
+    int_type,
+    is_array_type,
+)
 from guppylang_internals.tys.ty import InputFlags
+
+
+def _return_control_subscript(
+    subscript: SubscriptAccess, dfg: DFContainer, ctx: CompilerContext
+) -> None:
+    """Write a returned control qubit back into its borrowed array slot."""
+    parent_ty = subscript.parent.ty
+    assert is_array_type(parent_ty)
+    elem_ty = get_element_type(parent_ty).to_hugr(ctx)
+    length_arg = get_array_length(parent_ty).to_arg().to_hugr(ctx)
+    idx = dfg.builder.add_op(convert_itousize(), dfg[subscript.item])
+    dfg[subscript.parent] = dfg.builder.add_op(
+        barray_return(elem_ty, length_arg),
+        dfg[subscript.parent],
+        idx,
+        dfg[subscript],
+    )
 
 
 def compile_modified_block(
@@ -66,13 +91,12 @@ def compile_modified_block(
     cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
     func_builder.set_outputs(*cfg)
 
-    # LoadFunc
+    # add the LoadFunc node
     call = dfg.builder.load_function(func_builder, hugr_ty)
 
-    # Function inputs
+    # captured values to be the function inputs
     captured = [v for v, _ in modified_block.captured.values()]
     captured = non_copyable_front_others_back(captured)
-    args = [dfg[v] for v in captured]
 
     # Apply modifiers
     if modified_block.has_dagger():
@@ -110,7 +134,7 @@ def compile_modified_block(
             qubit_num_args.append(qubit_num)
             std_array = standard_array_type(ht.Qubit, qubit_num)
 
-            # control operator
+            # Control adds a standard qubit array before the body inputs.
             input_fn_ty = hugr_ty
             output_fn_ty = ht.FunctionType(
                 [std_array, *hugr_ty.input], [std_array, *hugr_ty.output]
@@ -121,11 +145,11 @@ def compile_modified_block(
                 [qubit_num, in_out_arg, other_in_arg],
             )
             call = dfg.builder.add_op(op, call)
-            # update types
+            # Update types: later modifiers see the newly wrapped function type
             in_out_arg = ht.ListArg([std_array.type_arg(), *in_out_arg.elems])
             hugr_ty = output_fn_ty
 
-    # Prepare control arguments
+    # Compile control expressions and pack individual controls into arrays.
     ctrl_args: list[Wire] = []
     for i, control in enumerate(modified_block.control):
         if is_array_type(get_type(control.ctrl[0])):
@@ -144,7 +168,10 @@ def compile_modified_block(
             )
             ctrl_args.append(control_array)
 
-    # Call
+    # Wires corresponding to captured values before the indirect call.
+    args = [dfg[v] for v in captured]
+
+    # Call the modified block.
     call = dfg.builder.add_op(
         ops.CallIndirect(),
         call,
@@ -153,7 +180,8 @@ def compile_modified_block(
     )
     outports = iter(call)
 
-    # Unpack controls
+    # Unpack returned controls
+    control_subscripts: list[SubscriptAccess] = []
     for i, control in enumerate(modified_block.control):
         outport = next(outports)
         if is_array_type(get_type(control.ctrl[0])):
@@ -171,9 +199,21 @@ def compile_modified_block(
             for c, new_c in zip(control.ctrl, unpacked, strict=False):
                 assert isinstance(c, PlaceNode)
                 dfg[c.place] = new_c
+                if subscript := contains_subscript(c.place):
+                    control_subscripts.append(subscript)
 
     for arg in captured:
+        # captured inout values are returned after the control arrays.
         if InputFlags.Inout in arg.flags:
             dfg[arg] = next(outports)
+
+    for subscript in control_subscripts:
+        # For nested places, use the synthesized setter; plain array subscripts can
+        # be restored directly with the borrow_array return op.
+        if subscript.setitem_call is not None:
+            dfg[subscript.setitem_call.value_var] = dfg[subscript]
+            expr_compiler.visit(subscript.setitem_call.call)
+        else:
+            _return_control_subscript(subscript, dfg, ctx)
 
     return call

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -11,88 +11,27 @@ from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.metadata.common import add_metadata
 from guppylang_internals.nodes import CheckedModifiedBlock, PlaceNode
-from guppylang_internals.std._internal.compiler.arithmetic import convert_itousize
 from guppylang_internals.std._internal.compiler.array import (
     array_new,
     array_to_std_array,
-    barray_borrow,
-    barray_return,
     standard_array_type,
     std_array_to_array,
     unpack_array,
 )
 from guppylang_internals.std._internal.compiler.tket_exts import MODIFIER_EXTENSION
-from guppylang_internals.tys.builtin import (
-    get_array_length,
-    get_element_type,
-    int_type,
-    is_array_type,
-)
+from guppylang_internals.tys.builtin import int_type, is_array_type
 from guppylang_internals.tys.ty import InputFlags
-
-
-def _return_control_subscript(
-    subscript: SubscriptAccess, dfg: DFContainer, ctx: CompilerContext
-) -> None:
-    """Write a returned control qubit back into its borrowed array slot."""
-    parent_ty = subscript.parent.ty
-    assert is_array_type(parent_ty)
-    elem_ty = get_element_type(parent_ty).to_hugr(ctx)
-    length_arg = get_array_length(parent_ty).to_arg().to_hugr(ctx)
-    idx = dfg.builder.add_op(convert_itousize(), dfg[subscript.item])
-    dfg[subscript.parent] = dfg.builder.add_op(
-        barray_return(elem_ty, length_arg),
-        dfg[subscript.parent],
-        idx,
-        dfg[subscript],
-    )
-
-
-def _borrow_control_subscript(
-    subscript: SubscriptAccess, dfg: DFContainer, ctx: CompilerContext
-) -> None:
-    """Borrow a containing array slot from the current parent array.
-    E.g. for qs[0][0], re-borrow qs[0] before borrowing from that inner array."""
-    if parent_subscript := contains_subscript(subscript.parent):
-        _borrow_control_subscript(parent_subscript, dfg, ctx)
-    parent_ty = subscript.parent.ty
-    assert is_array_type(parent_ty)
-    elem_ty = get_element_type(parent_ty).to_hugr(ctx)
-    length_arg = get_array_length(parent_ty).to_arg().to_hugr(ctx)
-    idx = dfg.builder.add_op(convert_itousize(), dfg[subscript.item])
-    dfg[subscript.parent], dfg[subscript] = dfg.builder.add_op(
-        barray_borrow(elem_ty, length_arg),
-        dfg[subscript.parent],
-        idx,
-    )
 
 
 def _write_back_control_subscript(
     subscript: SubscriptAccess,
     dfg: DFContainer,
-    ctx: CompilerContext,
     expr_compiler: ExprCompiler,
-    parents_borrowed: bool = False,
 ) -> None:
-    """Restore a returned control value and any containing borrowed subscripts.
-
-    For nested places, use the synthesized setter; plain array subscripts can
-    be restored directly with the borrow_array return op."""
-
-    if subscript.setitem_call is not None:
-        dfg[subscript.setitem_call.value_var] = dfg[subscript]
-        expr_compiler.visit(subscript.setitem_call.call)
-    else:
-        parent_subscript = contains_subscript(subscript.parent)
-        if parent_subscript is not None and not parents_borrowed:
-            # Nested getitem compilation returns the inner array before the modified
-            # call, so recreate the parent borrow before writing the control back.
-            _borrow_control_subscript(parent_subscript, dfg, ctx)
-        _return_control_subscript(subscript, dfg, ctx)
-        if parent_subscript is not None:
-            _write_back_control_subscript(
-                parent_subscript, dfg, ctx, expr_compiler, parents_borrowed=True
-            )
+    """Restore a returned control value using the setter from type checking."""
+    assert subscript.setitem_call is not None
+    dfg[subscript.setitem_call.value_var] = dfg[subscript]
+    expr_compiler.visit(subscript.setitem_call.call)
 
 
 def compile_modified_block(
@@ -239,6 +178,8 @@ def compile_modified_block(
             c = control.ctrl[0]
             assert isinstance(c, PlaceNode)
             dfg[c.place] = control_array
+            if subscript := contains_subscript(c.place):
+                control_subscripts.append(subscript)
         else:
             control_array = dfg.builder.add_op(
                 std_array_to_array(ht.Qubit, qubit_num_args[i]), outport
@@ -256,6 +197,6 @@ def compile_modified_block(
             dfg[arg] = next(outports)
 
     for subscript in control_subscripts:
-        _write_back_control_subscript(subscript, dfg, ctx, expr_compiler)
+        _write_back_control_subscript(subscript, dfg, expr_compiler)
 
     return call

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -73,6 +73,15 @@ def test_control_subscript_allocated_array(validate):
     validate(bar.compile_function())
 
 
+def test_multidimensional_control_subscript(validate):
+    @guppy
+    def main(qs: array[array[qubit, 2], 2], c: qubit) -> None:
+        with control(qs[0]):
+            h(qs[1][1])
+
+    validate(main.compile_function())
+
+
 def test_control_subscript_nested(validate):
 
     @guppy

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -50,6 +50,15 @@ def test_control_array(validate):
     validate(bar.compile_function())
 
 
+def test_control_subscript(validate):
+    @guppy
+    def bar(q: array[qubit, 3]) -> None:
+        with control(q[0]):
+            h(q[1])
+
+    validate(bar.compile_function())
+
+
 def test_power_simple(validate):
     @guppy
     def bar(n: nat) -> None:

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -2,7 +2,7 @@ from guppylang.decorator import guppy
 from guppylang.std.array import array
 from guppylang.std.builtins import control, dagger, owned, power
 from guppylang.std.num import nat
-from guppylang.std.quantum import cx, h, qubit
+from guppylang.std.quantum import cx, discard, discard_array, h, qubit
 
 
 def test_dagger_simple(validate):
@@ -57,6 +57,42 @@ def test_control_subscript(validate):
             h(q[1])
 
     validate(bar.compile_function())
+
+
+def test_control_subscript_allocated_array(validate):
+    @guppy
+    def bar() -> None:
+        c = qubit()
+        qs: array[qubit, 2] = array(qubit(), qubit())
+        with control(qs[0], c):
+            h(qs[1])
+
+        discard_array(qs)
+        discard(c)
+
+    validate(bar.compile_function())
+
+
+def test_control_subscript_nested(validate):
+
+    @guppy
+    def f(array_controllers: array[qubit, 3], c: qubit) -> None:
+
+        with control(array_controllers[0], c):
+            h(array_controllers[1])
+            with control(array_controllers[1]):
+                h(array_controllers[2])
+
+    @guppy
+    def main() -> None:
+        q = qubit()
+        array_controllers: array[qubit, 3] = array(qubit(), qubit(), qubit())
+        f(array_controllers, q)
+
+        discard_array(array_controllers)
+        discard(q)
+
+    validate(main.compile())
 
 
 def test_power_simple(validate):

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -82,6 +82,33 @@ def test_multidimensional_control_subscript(validate):
     validate(main.compile_function())
 
 
+def test_nested_element_control_subscript(validate):
+    @guppy
+    def main(qs: array[array[qubit, 2], 2], target: qubit) -> None:
+        with control(qs[0][0]):
+            h(target)
+
+    validate(main.compile_function())
+
+
+def test_3d_array_control_subscript(validate):
+    @guppy
+    def main(qs: array[array[array[qubit, 2], 2], 2], target: qubit) -> None:
+        with control(qs[0][0][0]):
+            h(target)
+
+    validate(main.compile_function())
+
+
+def test_4d_array_control_subscript(validate):
+    @guppy
+    def main(qs: array[array[array[array[qubit, 2], 2], 2], 2], target: qubit) -> None:
+        with control(qs[0][0][0][0]):
+            h(target)
+
+    validate(main.compile_function())
+
+
 def test_control_subscript_nested(validate):
 
     @guppy


### PR DESCRIPTION
closes #1704 


Fixes handling of array subscripts used as control modifier arguments.

- Call `check_place_assignable` on control arguments statement checking, so subscript controls get a synthesised `setitem_call`.
- Fix modifier HUGR generation so captured arguments are read after control arguments are compiled, avoiding stale array wires. 
- Return controller qubits borrowed from array subscripts back into their parent arrays after the modified indirect call. Use the synthesised setter during the HUGR generation to write returned control values back into their parent array slots.

- Updated integration test.