### PR TITLE
ci: Don't create gh releases as draft

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
       "release-type": "python",
       "component": "guppylang",
       "package-name": "guppylang",
-      "draft": true,
+      "draft": false,
       "prerelease": false,
       "draft-pull-request": true,
       "extra-files": [
@@ -27,7 +27,7 @@
       "release-type": "python",
       "component": "guppylang-internals",
       "package-name": "guppylang_internals",
-      "draft": true,
+      "draft": false,
       "prerelease": false,
       "draft-pull-request": true,
       "extra-files": [


### PR DESCRIPTION
Github draft releases are annoying.

- They do not trigger workflow. This means that the wheel building CI doesn't get triggered.
- They do not create the git tag. This means that release-please gets lost when trying to compute changes since the last release tag.

The solution is to just mark releases as final. In tket/hugr we have the wheel release workflows make them draft while the wheels are being built, but this shouldn't be necessary here since the process is quick.

Note that this config was already correct in `main`.