### PR TITLE
chore(ci): Benchmark main with CodSpeed

### DIFF
--- a/.github/workflows/benchmarks_base.yml
+++ b/.github/workflows/benchmarks_base.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Just
         uses: extractions/setup-just@v4
 
-      - name: Benchmark main with Bencher
+      - name: Benchmark with Bencher
         run: |
           just bench-upload \
                --token '${{ secrets.BENCHER_API_TOKEN }}' \
@@ -40,7 +40,7 @@ jobs:
                --branch main \
                --github-actions '${{ secrets.GITHUB_TOKEN }}' \
 
-      - name: Benchmark main with CodSpeed
+      - name: Benchmark with CodSpeed
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation

--- a/.github/workflows/benchmarks_base.yml
+++ b/.github/workflows/benchmarks_base.yml
@@ -7,6 +7,10 @@ on:
 env:
   UV_VERSION: "0.9.5"
 
+permissions:
+  contents: read
+  id-token: write # required for OIDC auth with Codspeed
+
 jobs:
   benchmark_base_branch:
     name: Continuous Benchmarking
@@ -28,10 +32,16 @@ jobs:
       - name: Set up Just
         uses: extractions/setup-just@v4
 
-      - name: Track base branch benchmarks with Bencher
+      - name: Benchmark main with Bencher
         run: |
           just bench-upload \
                --token '${{ secrets.BENCHER_API_TOKEN }}' \
                --testbed Linux \
                --branch main \
                --github-actions '${{ secrets.GITHUB_TOKEN }}' \
+
+      - name: Benchmark main with CodSpeed
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: simulation
+          run: uv run pytest tests/ --codspeed -k "not executable"

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -7,6 +7,10 @@ on:
 env:
   UV_VERSION: "0.9.5"
 
+permissions:
+  contents: read
+  id-token: write # required for OIDC auth with Codspeed
+
 jobs:
   benchmark_pr_branch:
     name: Benchmark PR
@@ -49,5 +53,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          token: ${{ secrets.CODSPEED_API_TOKEN }}
           run: uv run pytest tests/ --codspeed -k "not executable"


### PR DESCRIPTION
Adds missing base benchmarking with CodSpeed, and changes the CodSpeed auth method to OIDC instead of the legacy token-based.