### PR TITLE
chore(ci): Lock instead of freezing in PR CI during dependency sync

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -41,7 +41,7 @@ jobs:
           enable-cache: true
 
       - name: Install Guppy
-        run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
+        run: uv sync --locked --python ${{ env.PYTHON_VERSION }}
 
       - name: Type check with mypy
         run: uv run mypy guppylang guppylang-internals
@@ -80,7 +80,7 @@ jobs:
           enable-cache: true
 
       - name: Install Guppy
-        run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
+        run: uv sync --locked --python ${{ env.PYTHON_VERSION }}
 
       - name: Run python tests with coverage instrumentation
         run: uv run pytest -n auto --cov=./ --cov-report=xml


### PR DESCRIPTION
This fails when the `uv.lock` is not up to date, which has been a problem in a number of instances (such that subsequent PRs find themselves needing to include seemingly random `uv.lock` changes). `--locked` vs `--frozen` strictly tightens the requirements for success.

Also happy to pursue a separate action instead of modifying this one if required.