### PR TITLE
chore: Switch main branch release series to a pre-release alpha

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,8 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "separate-pull-requests": true,
   "pull-request-title-pattern": "chore: release${component} ${version}",
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
   "include-component-in-tag": true,
   "include-v-in-tag": true,
   "extra-label": "X-release",
@@ -13,7 +11,8 @@
       "component": "guppylang",
       "package-name": "guppylang",
       "draft": false,
-      "prerelease": false,
+      "prerelease": true,
+      "prerelease-type": "alpha",
       "draft-pull-request": true,
       "extra-files": [
         {
@@ -28,7 +27,8 @@
       "component": "guppylang-internals",
       "package-name": "guppylang_internals",
       "draft": false,
-      "prerelease": false,
+      "prerelease": true,
+      "prerelease-type": "alpha",
       "draft-pull-request": true,
       "extra-files": [
         {


### PR DESCRIPTION
Required changes to update the release-please PRs to follow the new alpha versioning strategy we will adopt for the break to v1.

This set of changes ensures the base version is still updated correctly, but the next release has the "-alpha.X" suffix. We have to manually update the string to be "beta" when we put the package into beta.