### PR TITLE
revert: Do not not create gh releases as draft

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,8 @@
       "release-type": "python",
       "component": "guppylang",
       "package-name": "guppylang",
-      "draft": false,
+      "draft": true,
+      "force-tag-creation": true,
       "prerelease": false,
       "draft-pull-request": true,
       "extra-files": [
@@ -27,7 +28,8 @@
       "release-type": "python",
       "component": "guppylang-internals",
       "package-name": "guppylang_internals",
-      "draft": false,
+      "draft": true,
+      "force-tag-creation": true,
       "prerelease": false,
       "draft-pull-request": true,
       "extra-files": [


### PR DESCRIPTION
Reverts #1710 so release-please goes back to creating github releases as draft (so we can check their description is fine before publishing).

The problem of that is that draft releases do not create tags and trigger releases.
Instead we add release-please's `force-tag-creation` option, which should keep the rest of the infrastructure that depends on release tags working.