### PR TITLE
refactor(tiny): Remove inherited FunctionType fields from CallableDef subclasses

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -209,7 +209,6 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
     """
 
     defined_at: AstNode | None
-    ty: FunctionType
     call_checker: "CustomCallChecker"
     call_compiler: "CustomInoutCallCompiler"
     higher_order_value: bool

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -155,7 +155,6 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     """
 
     defined_at: ast.FunctionDef
-    ty: FunctionType
     docstring: str | None
     link_name: str
 

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -161,7 +161,6 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         use_arrays: Whether the circuit function should use arrays as input types.
     """
 
-    ty: FunctionType
     input_circuit: Any
     use_arrays: bool
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -40,7 +40,7 @@ from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
 from guppylang_internals.tys.subst import Inst, Subst
-from guppylang_internals.tys.ty import FunctionType, Type, UnitaryFlags, type_to_row
+from guppylang_internals.tys.ty import Type, UnitaryFlags, type_to_row
 
 PyFunc = Callable[..., Any]
 
@@ -76,7 +76,6 @@ class RawTracedFunctionDef(ParsableDef):
 
 @dataclass(frozen=True)
 class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
-    ty: FunctionType
     defined_at: ast.FunctionDef
 
     def check_call(

--- a/guppylang-internals/src/guppylang_internals/definition/value.py
+++ b/guppylang-internals/src/guppylang_internals/definition/value.py
@@ -58,8 +58,6 @@ class CallableDef(ValueDef):
 class CompiledCallableDef(CallableDef, CompiledValueDef):  # type: ignore[misc, unused-ignore]
     """Abstract base class a global module-level function."""
 
-    ty: FunctionType
-
     @abstractmethod
     def compile_call(
         self,


### PR DESCRIPTION
No need to add a new field, it's there already (and mypy confirms this)