### PR TITLE
refactor: Add some missing override annotations

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -2,7 +2,7 @@ import ast
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, override
 
 from hugr import Wire, ops
 from hugr import tys as ht
@@ -239,6 +239,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
             type_args,
         )
 
+    @override
     def check_call(
         self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Subst]:

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -251,6 +251,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
         new_node, subst = self.call_checker.check(args, ty)
         return with_type(ty, with_loc(node, new_node)), subst
 
+    @override
     def synthesize_call(
         self, args: list[ast.expr], node: AstNode, ctx: "Context"
     ) -> tuple[ast.expr, Type]:

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -223,6 +223,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
     def params(self) -> Sequence[Parameter]:
         return self.ty.params
 
+    @override
     def check(self, type_args: Inst, globals: Globals) -> "CustomMonoFunctionDef":
         mono_ty = self.ty.instantiate(type_args) if self.has_signature else self.ty
         return CustomMonoFunctionDef(
@@ -436,11 +437,13 @@ class CustomCallCompiler(CustomInoutCallCompiler, ABC):
 class DefaultCallChecker(CustomCallChecker):
     """Checks function calls by comparing to a type signature."""
 
+    @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -127,6 +127,7 @@ class RawCustomFunctionDef(ParsableDef):
 
     description: str = field(default="function", init=False)
 
+    @override
     def parse(self, globals: "Globals", sources: SourceMap) -> "CustomFunctionDef":
         """Parses and checks the signature of the custom function.
 
@@ -224,6 +225,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
     def params(self) -> Sequence[Parameter]:
         return self.ty.params
 
+    @override
     def check(self, type_args: Inst, globals: Globals) -> "CustomMonoFunctionDef":
         mono_ty = self.ty.instantiate(type_args) if self.has_signature else self.ty
         return CustomMonoFunctionDef(
@@ -287,9 +289,11 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
 
     type_args: Inst
 
+    @override
     def check(self, type_args: Inst, globals: Globals) -> "CustomMonoFunctionDef":
         raise InternalGuppyError("Function is already monomorphized and checked")
 
+    @override
     def load(self, dfg: "DFContainer", ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the custom function as a value into a local dataflow graph.
 
@@ -317,6 +321,7 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
         # Finally, load the function into the local DFG
         return dfg.builder.load_function(func)
 
+    @override
     def compile_call(
         self,
         args: list[Wire],
@@ -430,6 +435,7 @@ class CustomCallCompiler(CustomInoutCallCompiler, ABC):
     def compile(self, args: list[Wire]) -> list[Wire]:
         """Compiles a custom function call and returns the resulting ports."""
 
+    @override
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         return CallReturnWires(self.compile(args), inout_returns=[])
 
@@ -458,6 +464,7 @@ class NotImplementedCallCompiler(CustomCallCompiler):
     thus doesn't need to be compiled.
     """
 
+    @override
     def compile(self, args: list[Wire]) -> list[Wire]:
         raise InternalGuppyError("Function should have been removed during checking")
 
@@ -477,6 +484,7 @@ class OpCompiler(CustomInoutCallCompiler):
     ) -> None:
         self.op = op
 
+    @override
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         op = self.op(self.ty, self.type_args, self.ctx)
         node = self.builder.add_op(op, *args)
@@ -506,6 +514,7 @@ class BoolOpCompiler(CustomInoutCallCompiler):
     ) -> None:
         self.op = op
 
+    @override
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         converted_in = [ht.Bool if inp == OpaqueBool else inp for inp in self.ty.input]
         converted_out = [
@@ -536,6 +545,7 @@ class BoolOpCompiler(CustomInoutCallCompiler):
 class NoopCompiler(CustomCallCompiler):
     """Call compiler for functions that are noops."""
 
+    @override
     def compile(self, args: list[Wire]) -> list[Wire]:
         return args
 
@@ -543,6 +553,7 @@ class NoopCompiler(CustomCallCompiler):
 class CopyInoutCompiler(CustomInoutCallCompiler):
     """Call compiler for functions that borrow one argument to copy it."""
 
+    @override
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         assert len(self.ty.input) == 1
         inp_ty = self.ty.input[0]

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -2,11 +2,12 @@ import ast
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, ClassVar, override
+from typing import TYPE_CHECKING, ClassVar
 
 from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
+from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -224,7 +224,6 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
     def params(self) -> Sequence[Parameter]:
         return self.ty.params
 
-    @override
     def check(self, type_args: Inst, globals: Globals) -> "CustomMonoFunctionDef":
         mono_ty = self.ty.instantiate(type_args) if self.has_signature else self.ty
         return CustomMonoFunctionDef(

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -1,7 +1,7 @@
 import ast
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import ClassVar, override
 
 from hugr import Node, Wire
 from hugr.build import function as hf
@@ -154,6 +154,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
             type_args=type_args,
         )
 
+    @override
     def check_call(
         self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Subst]:

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -165,6 +165,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
         ENGINE.register_generic_use(self, inst)
         return node, subst
 
+    @override
     def synthesize_call(
         self, args: list[ast.expr], node: AstNode, ctx: Context
     ) -> tuple[GlobalCall, Type]:

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -93,6 +93,7 @@ class RawFunctionDecl(ParsableDef, UserProvidedLinkName):
 
     metadata: FunctionMetadata | None = field(default=None, kw_only=True)
 
+    @override
     def parse(self, globals: Globals, sources: SourceMap) -> "ParsedFunctionDecl":
         """Parses and checks the user-provided signature of the function."""
         func_ast, docstring = parse_py_func(self.python_func, sources)
@@ -142,6 +143,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     def params(self) -> Sequence[Parameter]:
         return self.ty.params
 
+    @override
     def check(self, type_args: Inst, globals: Globals) -> "CheckedFunctionDecl":
         mono_ty = self.ty.instantiate_partial(type_args)
         mono_link_name = monomorphized_link_name(self.link_name, type_args)
@@ -194,6 +196,7 @@ class CheckedFunctionDecl(ParsedFunctionDecl, CompilableDef):
 
     type_args: Inst
 
+    @override
     def compile_outer(
         self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
     ) -> "CompiledFunctionDecl":
@@ -250,11 +253,13 @@ class CompiledFunctionDecl(
         """The Hugr node this definition was compiled into."""
         return self.declaration
 
+    @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the function as a value into a local Hugr dataflow graph."""
         # Use implementation from function definition.
         return load(dfg, self.declaration)
 
+    @override
     def compile_call(
         self,
         args: list[Wire],

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -1,12 +1,13 @@
 import ast
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar, override
+from typing import ClassVar
 
 from hugr import Node, Wire
 from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.metadata import HugrDebugInfo
+from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -195,6 +195,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
         ENGINE.register_generic_use(self, inst)
         return node, subst
 
+    @override
     def synthesize_call(
         self, args: list[ast.expr], node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Type]:

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -2,7 +2,7 @@ import ast
 import inspect
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import hugr.build.function as hf
 from hugr import Node, Wire
@@ -184,6 +184,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
             metadata=self.metadata,
         )
 
+    @override
     def check_call(
         self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Subst]:

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -118,6 +118,7 @@ class RawFunctionDef(ParsableDef, UserProvidedLinkName):
 
     metadata: FunctionMetadata | None = field(default=None, kw_only=True)
 
+    @override
     def parse(self, globals: Globals, sources: SourceMap) -> "ParsedFunctionDef":
         """Parses and checks the user-provided signature of the function."""
         func_ast, docstring = parse_py_func(self.python_func, sources)
@@ -169,6 +170,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
         """Generic parameters of this function."""
         return self.ty.params
 
+    @override
     def check(self, type_args: Inst, globals: Globals) -> "CheckedFunctionDef":
         """Type checks the body of the function."""
         cfg = check_global_func_def(self.defined_at, self.ty, type_args, globals)
@@ -233,6 +235,7 @@ class CheckedFunctionDef(ParsedFunctionDef, CompilableDef):
         # We should be monomorphized at this point
         assert not self.params
 
+    @override
     def compile_outer(
         self,
         module: DefinitionBuilder[OpVar],
@@ -298,10 +301,12 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
         """The Hugr node this definition was compiled into."""
         return self.func_def.parent_node
 
+    @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the function as a value into a local Hugr dataflow graph."""
         return load(dfg, self.func_def)
 
+    @override
     def compile_call(
         self,
         args: list[Wire],
@@ -312,6 +317,7 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
         """Compiles a call to the function."""
         return compile_call(args, dfg, self.ty, self.func_def, node)
 
+    @override
     def compile_inner(self, globals: CompilerContext) -> None:
         """Compiles the body of the function."""
         compile_global_func_def(self, self.func_def, globals)

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -2,13 +2,14 @@ import ast
 import inspect
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any
 
 import hugr.build.function as hf
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.debug_info import DISubprogram
 from hugr.hugr.node_port import ToNode
+from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -111,6 +111,7 @@ class OverloadedFunctionDef(CompiledCallableDef, CallableDef):
                 return defn.check_call(args_copy, ty, node_copy, ctx)
         return self._call_error(args, node, ctx, available_sigs, ty)
 
+    @override
     def synthesize_call(
         self, args: list[ast.expr], node: AstNode, ctx: "Context"
     ) -> tuple[ast.expr, Type]:

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -2,7 +2,7 @@ import ast
 import copy
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import ClassVar, NamedTuple, NoReturn
+from typing import ClassVar, NamedTuple, NoReturn, override
 
 from hugr import Wire
 
@@ -93,6 +93,7 @@ class OverloadedFunctionDef(CompiledCallableDef, CallableDef):
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         raise GuppyError(OverloadHigherOrderError(node, self.name))
 
+    @override
     def check_call(
         self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Subst]:

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -2,9 +2,10 @@ import ast
 import copy
 from contextlib import suppress
 from dataclasses import dataclass, field
-from typing import ClassVar, NamedTuple, NoReturn, override
+from typing import ClassVar, NamedTuple, NoReturn
 
 from hugr import Wire
+from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import Context

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -151,6 +151,7 @@ class OverloadedFunctionDef(CompiledCallableDef, CallableDef):
         err.add_sub_diagnostic(AvailableOverloadsHint(None, self.name, available_sigs))
         raise GuppyError(err)
 
+    @override
     def compile_call(
         self,
         args: list[Wire],

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -1,6 +1,6 @@
 import ast
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, cast, override
 
 import hugr.build.function as hf
 from guppylang.defs import GuppyDefinition
@@ -338,6 +338,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
             outer_func,
         )
 
+    @override
     def check_call(
         self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Subst]:

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -348,6 +348,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
+    @override
     def synthesize_call(
         self, args: list[ast.expr], node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Type]:

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -80,6 +80,7 @@ class RawPytketDef(ParsableDef):
 
     description: str = field(default="pytket circuit", init=False)
 
+    @override
     def parse(self, globals: Globals, sources: SourceMap) -> "ParsedPytketDef":
         """Parses and checks the user-provided signature matches the user-provided
         circuit.
@@ -132,6 +133,7 @@ class RawLoadPytketDef(ParsableDef):
 
     description: str = field(default="pytket circuit", init=False)
 
+    @override
     def parse(self, globals: Globals, sources: SourceMap) -> "ParsedPytketDef":
         """Creates a function signature based on the user-provided circuit."""
         circuit_signature = _signature_from_circuit(
@@ -170,6 +172,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
 
     description: str = field(default="pytket circuit", init=False)
 
+    @override
     def compile_outer(
         self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
     ) -> "CompiledPytketDef":
@@ -381,11 +384,13 @@ class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef, CompiledHugrNodeDe
         """The Hugr node this definition was compiled into."""
         return self.func_def.parent_node
 
+    @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the function as a value into a local Hugr dataflow graph."""
         # Use implementation from function definition.
         return load(dfg, self.func_def)
 
+    @override
     def compile_call(
         self,
         args: list[Wire],

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -1,6 +1,6 @@
 import ast
 from dataclasses import dataclass, field
-from typing import Any, cast, override
+from typing import Any, cast
 
 import hugr.build.function as hf
 from guppylang.defs import GuppyDefinition
@@ -11,6 +11,7 @@ from hugr.debug_info import DILocation, DISubprogram
 from hugr.envelope import EnvelopeConfig
 from hugr.metadata import HugrDebugInfo
 from hugr.std.float import FLOAT_T
+from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode, has_empty_body, with_loc
 from guppylang_internals.checker.core import Context, Globals

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -89,6 +89,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
+    @override
     def synthesize_call(
         self, args: list[ast.expr], node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Type]:

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -1,7 +1,7 @@
 import ast
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, override
 
 import hugr.build.function as hf
 import hugr.tys as ht
@@ -79,6 +79,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
     ty: FunctionType
     defined_at: ast.FunctionDef
 
+    @override
     def check_call(
         self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
     ) -> tuple[ast.expr, Subst]:

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -1,13 +1,14 @@
 import ast
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, override
+from typing import Any
 
 import hugr.build.function as hf
 import hugr.tys as ht
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.metadata import HugrDebugInfo
+from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode, with_loc
 from guppylang_internals.checker.core import Context, Globals

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -100,6 +100,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 
+    @override
     def compile_outer(
         self, module: DefinitionBuilder[OpVar], ctx: CompilerContext
     ) -> "CompiledTracedFunctionDef":
@@ -145,6 +146,7 @@ class CompiledTracedFunctionDef(
         """The Hugr node this definition was compiled into."""
         return self.func_def.parent_node
 
+    @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the function as a value into a local Hugr dataflow graph."""
         type_args: Inst = ()  # Comptime functions are not generic
@@ -152,6 +154,7 @@ class CompiledTracedFunctionDef(
         type_args: list[ht.TypeArg] = [arg.to_hugr(ctx) for arg in type_args]
         return dfg.builder.load_function(self.func_def, func_ty, type_args)
 
+    @override
     def compile_call(
         self,
         args: list[Wire],
@@ -173,6 +176,7 @@ class CompiledTracedFunctionDef(
             inout_returns=list(call[num_returns:]),
         )
 
+    @override
     def compile_inner(self, ctx: CompilerContext) -> None:
         """Compiles the body of the function by tracing it."""
         from guppylang_internals.tracing.function import trace_function

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -1,6 +1,6 @@
 import ast
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, override
 
 from typing_extensions import assert_never
 
@@ -79,6 +79,7 @@ class ReversingChecker(CustomCallChecker):
         assert name.startswith("r")
         return f"__{name[1:]}__"
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         [self_arg, other_arg] = args
         self_arg, self_ty = ExprSynthesizer(self.ctx).synthesize(self_arg)
@@ -93,12 +94,14 @@ class UnsupportedChecker(CustomCallChecker):
     Gives the uses a nicer error message when they try to use an unsupported feature.
     """
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         err = UnsupportedError(
             self.node, f"Builtin method `{self.func.name}`", singular=True
         )
         raise GuppyError(err)
 
+    @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         err = UnsupportedError(
             self.node, f"Builtin method `{self.func.name}`", singular=True
@@ -117,6 +120,7 @@ class DunderChecker(CustomCallChecker):
         self.dunder_name = dunder_name
         self.num_args = num_args
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         check_num_args(self.num_args, len(args), self.node)
         fst, *rest = args
@@ -132,6 +136,7 @@ class DunderChecker(CustomCallChecker):
 class CallableChecker(CustomCallChecker):
     """Call checker for the builtin `callable` function"""
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         check_num_args(1, len(args), self.node)
         [arg] = args
@@ -157,6 +162,7 @@ class ArrayCopyChecker(CustomCallChecker):
         class Explanation(Note):
             message: ClassVar[str] = "Only arrays with copyable elements can be copied"
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # First, check if we're trying to copy a non-copyable element type to give a
         # nicer error message. Then, do the full `synthesize_call` type check
@@ -247,6 +253,7 @@ class ArrayIndexChecker(CustomCallChecker):
                 )
             )
 
+    @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         """Check-mode: verify arguments against
         expected type and perform bounds check."""
@@ -261,6 +268,7 @@ class ArrayIndexChecker(CustomCallChecker):
         node = GlobalCall(def_id=self.func.id, args=args, type_args=type_args)
         return with_loc(self.node, node), subs
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         """Synthesize-mode: infer return type and perform bounds check."""
         # Run regular type synthesis for the arguments
@@ -288,6 +296,7 @@ class NewArrayChecker(CustomCallChecker):
                 "Consider adding a type annotation: `x: array[???] = ...`"
             )
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         match args:
             case []:
@@ -410,6 +419,7 @@ class AbortChecker(CustomCallChecker):
     def __init__(self, exit_kind: AbortKind):
         self.exit_kind = exit_kind
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         match args:
             case []:
@@ -465,6 +475,7 @@ def to_sized_iter(
 class BarrierChecker(CustomCallChecker):
     """Call checker for the `barrier` function."""
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         tys = [ExprSynthesizer(self.ctx).synthesize(val)[1] for val in args]
         func_ty = FunctionType(
@@ -478,12 +489,14 @@ class BarrierChecker(CustomCallChecker):
 
 
 class WasmCallChecker(CustomCallChecker):
+    @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
 
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -323,6 +323,7 @@ class NewArrayChecker(CustomCallChecker):
             case args:
                 return assert_never(args)  # type: ignore[arg-type]
 
+    @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         if not is_array_type(ty):
             dummy_array_ty = array_type_def.check_instantiate(
@@ -453,6 +454,7 @@ class AbortChecker(CustomCallChecker):
             case args:
                 return assert_never(args)  # type: ignore[arg-type]
 
+    @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Panic may return any type, so we don't have to check anything. Consequently
         # we also can't infer anything in the expected type, so we always return an

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -1,8 +1,8 @@
 import ast
 from dataclasses import dataclass
-from typing import ClassVar, override
+from typing import ClassVar
 
-from typing_extensions import assert_never
+from typing_extensions import assert_never, override
 
 from guppylang_internals.ast_util import get_type, with_loc, with_type
 from guppylang_internals.checker.core import Context, Variable

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -1,6 +1,6 @@
 import ast
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar, cast, override
 
 from guppylang_internals.ast_util import with_loc
 from guppylang_internals.checker.core import ComptimeVariable
@@ -44,6 +44,7 @@ class StateResultChecker(CustomCallChecker):
             "Qubits whose state should be reported must be passed explicitly"
         )
 
+    @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         tag, _ = ExprChecker(self.ctx).check(args[0], string_type())
         tag_value: Const

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -1,6 +1,8 @@
 import ast
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, cast, override
+from typing import TYPE_CHECKING, ClassVar, cast
+
+from typing_extensions import override
 
 from guppylang_internals.ast_util import with_loc
 from guppylang_internals.checker.core import ComptimeVariable


### PR DESCRIPTION
Done for CustomCallChecker.{check,synthesize} and CallableDef.{check_call,synthesize_call}, and everything else in the same files