### PR TITLE
ci: Add docs build to release-checks workflow for 0.21 branch (#1684)

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -114,3 +114,60 @@ jobs:
         run: uv run --no-sync ruff check guppylang
       - name: Run tests
         run: UV_NO_SYNC=1 just test
+
+
+  check-guppy-docs-build:
+    name: Check the guppy-docs build for `guppylang` release 
+    runs-on: ubuntu-latest
+    if: |
+     github.event_name == 'workflow_dispatch' ||
+     (startsWith(github.head_ref, 'release-please--') && endsWith(github.head_ref, '--components--guppylang'))
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: Quantinuum/guppy-docs
+          submodules: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          path: guppy-docs
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+      - name: Set up Just
+        uses: extractions/setup-just@v4
+      - name: Install a develop wheel of guppylang
+        run: |
+          cd guppy-docs
+          uv add "guppylang @ git+https://github.com/Quantinuum/guppylang.git@${{ github.event.pull_request.head.sha }}#subdirectory=guppylang" || uv sync --group docs
+      - name: Checkout guppylang release-please manifest
+        uses: actions/checkout@v6
+        with:
+          repository: Quantinuum/guppylang
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: guppylang
+          sparse-checkout: |
+            .release-please-manifest.json
+          sparse-checkout-cone-mode: false
+      - name: Verify guppylang version
+        run: |
+          cd guppy-docs
+          uv run python <<'PY'
+          import json
+          from pathlib import Path
+          import guppylang
+
+          GUPPYLANG_PACKAGE_VERSION = guppylang.__version__
+
+          with Path.open(Path("../guppylang/.release-please-manifest.json")) as json_data:
+              release_please_data = json.load(json_data)
+              MANIFEST_GUPPYLANG_VERSION = release_please_data["guppylang"]
+
+          assert GUPPYLANG_PACKAGE_VERSION == MANIFEST_GUPPYLANG_VERSION
+          print(f"Verification complete! Verified Guppy version is {GUPPYLANG_PACKAGE_VERSION}")
+          PY
+      - name: Run docs build
+        run: |
+          cd guppy-docs
+          just build-docs
+


### PR DESCRIPTION
Cherry-picked the changes from #1684 so that we can run the docs build as part of the pre release C.I. checks for guppylang 0.21.*

comment -> https://github.com/Quantinuum/guppylang/pull/1684#issuecomment-4421623812