### PR TITLE
refactor: narrow ASTNode types to check_call and _synthesize_binary

### DIFF
--- a/guppylang-internals/src/guppylang_internals/ast_util.py
+++ b/guppylang-internals/src/guppylang_internals/ast_util.py
@@ -420,6 +420,8 @@ def parse_source(source_lines: list[str], line_offset: int) -> tuple[str, ast.AS
     return source, node, line_offset
 
 
-def fake_call(name: str, args: list[ast.expr]) -> ast.Call:
+def fake_call(name: str, loc_from: ast.AST, args: list[ast.expr]) -> ast.Call:
     """Creates a fake call node with the given name and arguments."""
-    return ast.Call(func=ast.Name(id=name, ctx=ast.Load()), args=args, keywords=[])
+    call = ast.Call(func=ast.Name(id=name, ctx=ast.Load()), args=args, keywords=[])
+    set_location_from(call, loc_from)
+    return call

--- a/guppylang-internals/src/guppylang_internals/ast_util.py
+++ b/guppylang-internals/src/guppylang_internals/ast_util.py
@@ -418,3 +418,8 @@ def parse_source(source_lines: list[str], line_offset: int) -> tuple[str, ast.AS
     else:
         node = ast.parse(source).body[0]
     return source, node, line_offset
+
+
+def fake_call(name: str, args: list[ast.expr]) -> ast.Call:
+    """Creates a fake call node with the given name and arguments."""
+    return ast.Call(func=ast.Name(id=name, ctx=ast.Load()), args=args, keywords=[])

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -34,6 +34,7 @@ from guppylang_internals.ast_util import (
     AstNode,
     AstVisitor,
     breaks_in_loop,
+    fake_call,
     get_type,
     get_type_opt,
     return_nodes_in_ast,
@@ -1054,9 +1055,7 @@ def try_coerce_to(
         name = f"__{exp.kind.name.lower()}__"
         f = ENGINE.get_instance_func(act, name)
         assert f is not None
-        call = with_loc(
-            node, ast.Call(func=ast.Name(id=name, ctx=ast.Load()), args=[node])
-        )
+        call = with_loc(node, fake_call(name, [node]))
         node, subst = f.check_call([node], exp, call, ctx)
         assert len(subst) == 0, "Coercion methods are not generic"
         return node

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -721,7 +721,11 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         return func.synthesize_call([node.operand], node, self.ctx)
 
     def _synthesize_binary(
-        self, left_expr: ast.expr, right_expr: ast.expr, op: AstOp, node: ast.expr
+        self,
+        left_expr: ast.expr,
+        right_expr: ast.expr,
+        op: AstOp,
+        node: ast.BinOp | ast.Compare,
     ) -> tuple[ast.expr, Type]:
         """Helper method to compile binary operators by calling out to dunder methods.
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1055,7 +1055,7 @@ def try_coerce_to(
         name = f"__{exp.kind.name.lower()}__"
         f = ENGINE.get_instance_func(act, name)
         assert f is not None
-        call = with_loc(node, fake_call(name, [node]))
+        call = fake_call(name, node, [node])
         node, subst = f.check_call([node], exp, call, ctx)
         assert len(subst) == 0, "Coercion methods are not generic"
         return node

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1047,9 +1047,13 @@ def try_coerce_to(
         return None
     # Ordering on `NumericType.Kind` defines the coercion relation
     if act.kind < exp.kind:
-        f = ENGINE.get_instance_func(act, f"__{exp.kind.name.lower()}__")
+        name = f"__{exp.kind.name.lower()}__"
+        f = ENGINE.get_instance_func(act, name)
         assert f is not None
-        node, subst = f.check_call([node], exp, node, ctx)
+        call = with_loc(
+            node, ast.Call(func=ast.Name(id=name, ctx=ast.Load()), args=[node])
+        )
+        node, subst = f.check_call([node], exp, call, ctx)
         assert len(subst) == 0, "Coercion methods are not generic"
         return node
     return None

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -243,7 +243,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
 
     @override
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: Context
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type.
 

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -159,7 +159,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
 
     @override
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: Context
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -188,7 +188,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
 
     @override
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: Context
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -96,7 +96,7 @@ class OverloadedFunctionDef(CompiledCallableDef, CallableDef):
 
     @override
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: Context
     ) -> tuple[ast.expr, Subst]:
         available_sigs: list[OverloadVariant] = []
         for def_id in self.func_ids:

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -343,7 +343,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
 
     @override
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: Context
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -81,7 +81,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CompilableDef):
 
     @override
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: Context
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: Context
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker

--- a/guppylang-internals/src/guppylang_internals/definition/value.py
+++ b/guppylang-internals/src/guppylang_internals/definition/value.py
@@ -41,7 +41,7 @@ class CallableDef(ValueDef):
 
     @abstractmethod
     def check_call(
-        self, args: list[ast.expr], ty: Type, node: AstNode, ctx: "Context"
+        self, args: list[ast.expr], ty: Type, node: ast.Call, ctx: "Context"
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -4,7 +4,7 @@ from typing import ClassVar
 
 from typing_extensions import assert_never, override
 
-from guppylang_internals.ast_util import get_type, with_loc, with_type
+from guppylang_internals.ast_util import fake_call, get_type, with_loc, with_type
 from guppylang_internals.checker.core import Context, Variable
 from guppylang_internals.checker.errors.generic import UnsupportedError
 from guppylang_internals.checker.errors.type_errors import (
@@ -470,9 +470,7 @@ def to_sized_iter(
     sized_iter_ty = sized_iter_type(range_ty, size)
     make_sized_iter = ENGINE.get_instance_func(sized_iter_ty, "__new__")
     assert make_sized_iter is not None
-    call = with_loc(
-        iterator, ast.Call(func=ast.Name(id="__new__", ctx=ast.Load()), args=[iterator])
-    )
+    call = with_loc(iterator, fake_call("__new__", [iterator]))
     sized_iter, _ = make_sized_iter.check_call([iterator], sized_iter_ty, call, ctx)
     return sized_iter, sized_iter_ty
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -470,7 +470,10 @@ def to_sized_iter(
     sized_iter_ty = sized_iter_type(range_ty, size)
     make_sized_iter = ENGINE.get_instance_func(sized_iter_ty, "__new__")
     assert make_sized_iter is not None
-    sized_iter, _ = make_sized_iter.check_call([iterator], sized_iter_ty, iterator, ctx)
+    call = with_loc(
+        iterator, ast.Call(func=ast.Name(id="__new__", ctx=ast.Load()), args=[iterator])
+    )
+    sized_iter, _ = make_sized_iter.check_call([iterator], sized_iter_ty, call, ctx)
     return sized_iter, sized_iter_ty
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -470,7 +470,7 @@ def to_sized_iter(
     sized_iter_ty = sized_iter_type(range_ty, size)
     make_sized_iter = ENGINE.get_instance_func(sized_iter_ty, "__new__")
     assert make_sized_iter is not None
-    call = with_loc(iterator, fake_call("__new__", [iterator]))
+    call = fake_call("__new__", iterator, [iterator])
     sized_iter, _ = make_sized_iter.check_call([iterator], sized_iter_ty, call, ctx)
     return sized_iter, sized_iter_ty
 


### PR DESCRIPTION
For check_call, a couple of cases here requires building a "fake" ast.Call node to represent the call, using `with_loc` to identify the same location.

For synthesize_call the problem is much worse: there are many more such non-ast.Call nodes (e.g. BinOp and Compare), and moreover there is https://github.com/Quantinuum/guppylang/blob/e4324d5194ad5213719b1de7322159a11d124904/guppylang-internals/src/guppylang_internals/tracing/function.py#L186
where the AST location `state.node` can be a FunctionDef or a variety of other things. `synthesize_call` then calls into `CustomCallChecker` so I couldn't update that either....which is to say: I didn't really get to where I wanted, but it seemed worthwhile to keep even just this.