### PR TITLE
fix: Prevent leaking memory in custom call compilers and checkers

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -1,6 +1,7 @@
 import ast
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Generator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
 
@@ -249,8 +250,8 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
 
         This is done by invoking the provided `CustomCallChecker`.
         """
-        self.call_checker._setup(ctx, node, self)
-        new_node, subst = self.call_checker.check(args, ty)
+        with self.call_checker._setup(ctx, node, self) as checker:
+            new_node, subst = checker.check(args, ty)
         return with_type(ty, with_loc(node, new_node)), subst
 
     @override
@@ -261,8 +262,8 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
 
         This is done by invoking the provided `CustomCallChecker`.
         """
-        self.call_checker._setup(ctx, node, self)
-        new_node, ty = self.call_checker.synthesize(args)
+        with self.call_checker._setup(ctx, node, self) as checker:
+            new_node, ty = checker.synthesize(args)
         return with_type(ty, with_loc(node, new_node)), ty
 
 
@@ -339,8 +340,10 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
             )
         hugr_ty = concrete_ty.to_hugr(ctx)
 
-        self.call_compiler._setup(self.type_args, dfg, ctx, node, hugr_ty, self)
-        return self.call_compiler.compile_with_inouts(args)
+        with self.call_compiler._setup(
+            self.type_args, dfg, ctx, node, hugr_ty, self
+        ) as compiler:
+            return compiler.compile_with_inouts(args)
 
 
 class CustomCallChecker(ABC):
@@ -350,10 +353,23 @@ class CustomCallChecker(ABC):
     node: AstNode
     func: CustomFunctionDef
 
-    def _setup(self, ctx: Context, node: AstNode, func: CustomFunctionDef) -> None:
+    @contextmanager
+    def _setup(
+        self, ctx: Context, node: AstNode, func: CustomFunctionDef
+    ) -> Generator["CustomCallChecker", None, None]:
+        """
+        A context manager to temporarily set up the checker with required arguments, and
+        properly tear down the checker afterwards to avoid memory leaks.
+        """
         self.ctx = ctx
         self.node = node
         self.func = func
+        try:
+            yield self
+        finally:
+            del self.ctx
+            del self.node
+            del self.func
 
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         """Checks the return value against a given type.
@@ -392,6 +408,7 @@ class CustomInoutCallCompiler(ABC):
     ty: ht.FunctionType
     func: CustomMonoFunctionDef | None
 
+    @contextmanager
     def _setup(
         self,
         type_args: Inst,
@@ -400,7 +417,11 @@ class CustomInoutCallCompiler(ABC):
         node: AstNode,
         hugr_ty: ht.FunctionType,
         func: CustomMonoFunctionDef | None,
-    ) -> None:
+    ) -> Generator["CustomInoutCallCompiler", None, None]:
+        """
+        A context manager to temporarily set up the checker with required arguments, and
+        properly tear down the checker afterwards to avoid memory leaks.
+        """
         self.type_args = type_args
         self.dfg = dfg
         self.ctx = ctx
@@ -412,6 +433,15 @@ class CustomInoutCallCompiler(ABC):
         # function to is the function definition itself, so we set the function
         # definition node as the AST context in the builder.
         self.builder.current_ast_node = self.node
+        try:
+            yield self
+        finally:
+            del self.type_args
+            del self.dfg
+            del self.ctx
+            del self.node
+            del self.ty
+            del self.func
 
     @abstractmethod
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -353,6 +353,8 @@ class CustomCallChecker(ABC):
     node: AstNode
     func: CustomFunctionDef
 
+    _depth = 0
+
     @contextmanager
     def _setup(
         self, ctx: Context, node: AstNode, func: CustomFunctionDef
@@ -369,9 +371,13 @@ class CustomCallChecker(ABC):
         try:
             yield self
         finally:
-            del self.ctx
-            del self.node
-            del self.func
+            self._depth -= 1
+            # Only clean when there are no parent recursions, as otherwise the fields
+            # may still be in use.
+            if self._depth == 0:
+                del self.ctx
+                del self.node
+                del self.func
 
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         """Checks the return value against a given type.
@@ -410,6 +416,8 @@ class CustomInoutCallCompiler(ABC):
     ty: ht.FunctionType
     func: CustomMonoFunctionDef | None
 
+    _depth = 0
+
     @contextmanager
     def _setup(
         self,
@@ -437,15 +445,20 @@ class CustomInoutCallCompiler(ABC):
         # function to is the function definition itself, so we set the function
         # definition node as the AST context in the builder.
         self.builder.current_ast_node = self.node
+        self._depth += 1
         try:
             yield self
         finally:
-            del self.type_args
-            del self.dfg
-            del self.ctx
-            del self.node
-            del self.ty
-            del self.func
+            self._depth -= 1
+            # Only clean when there are no parent recursions, as otherwise the fields
+            # may still be in use.
+            if self._depth == 0:
+                del self.type_args
+                del self.dfg
+                del self.ctx
+                del self.node
+                del self.ty
+                del self.func
 
     @abstractmethod
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -360,6 +360,8 @@ class CustomCallChecker(ABC):
         """
         A context manager to temporarily set up the checker with required arguments, and
         properly tear down the checker afterwards to avoid memory leaks.
+
+        See https://github.com/Quantinuum/guppylang/issues/1735.
         """
         self.ctx = ctx
         self.node = node
@@ -419,8 +421,10 @@ class CustomInoutCallCompiler(ABC):
         func: CustomMonoFunctionDef | None,
     ) -> Generator["CustomInoutCallCompiler", None, None]:
         """
-        A context manager to temporarily set up the checker with required arguments, and
-        properly tear down the checker afterwards to avoid memory leaks.
+        A context manager to temporarily set up the compiler with required arguments,
+        and properly tear down the compiler afterwards to avoid memory leaks.
+
+        See https://github.com/Quantinuum/guppylang/issues/1735.
         """
         self.type_args = type_args
         self.dfg = dfg


### PR DESCRIPTION
Prevents a memory leak the occurs when custom call compilers and checkers still hold a reference to a `DFBuilder`, which holds a reference to the compilation context, which holds a reference to a custom function definition, which holds a reference to the custom call compiler again. Breaks the reference cycle by forcing the setup as a context manager and ensuring proper teardown.

Closes #1735 

Adding a breakpoint (thus entering `pdb`), running for a while and then inspecting memory with `objgraph` yielded the above cycle.

Test program:
```python
@guppy
def main() -> None:
    arr = array(qubit())
    discard_array(arr)
```

Memory usage on 10 consecutive compilation calls, collecting garbage and measuring memory (some may be cached by the interpreter and not actually used at non-peak) as well as GC-tracked objects before the change:
```
Memory in MiB: 115.09375                                      Held objects: 125945                          
Memory in MiB: 117.546875      Diff in MiB: 2.453125          Held objects: 134171      Diff: 8226          
Memory in MiB: 118.421875      Diff in MiB: 0.875             Held objects: 142217      Diff: 8046          
Memory in MiB: 119.265625      Diff in MiB: 0.84375           Held objects: 150263      Diff: 8046          
Memory in MiB: 120.09375       Diff in MiB: 0.828125          Held objects: 158309      Diff: 8046          
Memory in MiB: 120.921875      Diff in MiB: 0.828125          Held objects: 166355      Diff: 8046          
Memory in MiB: 121.75          Diff in MiB: 0.828125          Held objects: 174401      Diff: 8046          
Memory in MiB: 122.625         Diff in MiB: 0.875             Held objects: 182447      Diff: 8046          
Memory in MiB: 123.5           Diff in MiB: 0.875             Held objects: 190493      Diff: 8046          
Memory in MiB: 124.359375      Diff in MiB: 0.859375          Held objects: 198539      Diff: 8046
```

After the change:
```
Memory in MiB: 114.953125                                     Held objects: 118869                          
Memory in MiB: 116.765625      Diff in MiB: 1.8125            Held objects: 119122      Diff: 253           
Memory in MiB: 116.8125        Diff in MiB: 0.046875          Held objects: 119374      Diff: 252           
Memory in MiB: 116.84375       Diff in MiB: 0.03125           Held objects: 119626      Diff: 252           
Memory in MiB: 116.859375      Diff in MiB: 0.015625          Held objects: 119878      Diff: 252           
Memory in MiB: 116.90625       Diff in MiB: 0.046875          Held objects: 120130      Diff: 252           
Memory in MiB: 116.9375        Diff in MiB: 0.03125           Held objects: 120382      Diff: 252           
Memory in MiB: 116.953125      Diff in MiB: 0.015625          Held objects: 120634      Diff: 252           
Memory in MiB: 117.0           Diff in MiB: 0.046875          Held objects: 120886      Diff: 252           
Memory in MiB: 117.046875      Diff in MiB: 0.046875          Held objects: 121138      Diff: 252 
```

> [!NOTE]
> There is still some leakage due to some function definitions being registered in the definition store. A stress test using a QFT pytket circuit yielded about 627 additional objects that GC tracks each call, regardless of depth. However, that number is down from about 400k before this fix, so I would still call this a success.