### PR TITLE
test: Add memory usage benchmarks

### DIFF
--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -53,4 +53,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: uv run pytest tests/ --codspeed -k "not executable"
+          run: uv run pytest tests/ --codspeed -k "not executable and not mem_compile"

--- a/justfile
+++ b/justfile
@@ -96,6 +96,9 @@ bench-compare *BENCHER_FLAGS:
             --threshold-measure hugr_nodes \
             --threshold-test percentage \
             --threshold-upper-boundary 0.01 \
+            --threshold-measure compile_mem \
+            --threshold-test percentage \
+            --threshold-upper-boundary 0.05 \
             --err \
             --quiet \
             {{BENCHER_FLAGS}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,10 +55,9 @@ exclude_also = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--benchmark-disable -m 'not test_exported_hugrs'"  # benchmarks run explicitly with `just bench`
+addopts = "--benchmark-disable -m 'not test_exported_hugrs'" # benchmarks run explicitly with `just bench`
 markers = "test_exported_hugrs"
 filterwarnings = [
-  "ignore::DeprecationWarning",  # TODO remove after removing guppy.compile()
-  "ignore::SyntaxWarning",  # Python 3.14 complains about guppy tuple callables
-  "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",  # benchmark fixture not used in the mem usage tests
+  "ignore::DeprecationWarning", # TODO remove after removing guppy.compile()
+  "ignore::SyntaxWarning",      # Python 3.14 complains about guppy tuple callables
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,4 +60,5 @@ markers = "test_exported_hugrs"
 filterwarnings = [
   "ignore::DeprecationWarning",  # TODO remove after removing guppy.compile()
   "ignore::SyntaxWarning",  # Python 3.14 complains about guppy tuple callables
+  "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",  # benchmark fixture not used in the mem usage tests
 ]

--- a/tests/bencher.py
+++ b/tests/bencher.py
@@ -26,6 +26,12 @@ def create_bencher_BMF(pytest_benchmark_file: str, bencher_file: str) -> None:
             if extra_info.get("nodes"):
                 nodes_info = extra_info["nodes"]
                 BMF[name]["hugr_nodes"] = {"value": nodes_info}
+            if extra_info.get("mem_compile_once"):
+                mem_info = extra_info["mem_compile_once"]
+                BMF[name]["mem_compile_once"] = {"value": mem_info}
+            if extra_info.get("mem_compile_multiple"):
+                mem_info = extra_info["mem_compile_multiple"]
+                BMF[name]["mem_compile_multiple"] = {"value": mem_info}
 
     with Path(bencher_file).open("w") as bmf_file:
         json.dump(BMF, bmf_file)

--- a/tests/bencher.py
+++ b/tests/bencher.py
@@ -26,12 +26,9 @@ def create_bencher_BMF(pytest_benchmark_file: str, bencher_file: str) -> None:
             if extra_info.get("nodes"):
                 nodes_info = extra_info["nodes"]
                 BMF[name]["hugr_nodes"] = {"value": nodes_info}
-            if extra_info.get("mem_compile_once"):
-                mem_info = extra_info["mem_compile_once"]
-                BMF[name]["mem_compile_once"] = {"value": mem_info}
-            if extra_info.get("mem_compile_multiple"):
-                mem_info = extra_info["mem_compile_multiple"]
-                BMF[name]["mem_compile_multiple"] = {"value": mem_info}
+            if extra_info.get("memory"):
+                mem_info = extra_info["memory"]
+                BMF[name]["compile_mem"] = {"value": mem_info}
 
     with Path(bencher_file).open("w") as bmf_file:
         json.dump(BMF, bmf_file)

--- a/tests/benchmarks/test_big_array.py
+++ b/tests/benchmarks/test_big_array.py
@@ -5,6 +5,8 @@ from guppylang.std.builtins import array, py
 from guppylang.std.quantum import cx, discard_array, h, qubit
 from hugr.package import Package
 
+from tests.util import compile_and_get_peak_memory
+
 n_q = 20
 n_a = 5
 
@@ -256,6 +258,7 @@ def test_big_array_compile(benchmark) -> None:
     hugr: Package = benchmark(big_array_compile)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
+    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(big_array)
 
 
 def test_big_array_check(benchmark) -> None:

--- a/tests/benchmarks/test_big_array.py
+++ b/tests/benchmarks/test_big_array.py
@@ -258,7 +258,7 @@ def test_big_array_compile(benchmark) -> None:
     hugr: Package = benchmark(big_array_compile)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
-    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(big_array)
+    benchmark.extra_info["memory"] = compile_and_get_peak_memory(big_array)
 
 
 def test_big_array_check(benchmark) -> None:

--- a/tests/benchmarks/test_ctrl_flow.py
+++ b/tests/benchmarks/test_ctrl_flow.py
@@ -5,6 +5,8 @@ from guppylang.std.builtins import array, py
 from guppylang.std.quantum import cx, discard_array, h, measure, project_z, qubit
 from hugr.package import Package
 
+from tests.util import compile_and_get_peak_memory
+
 n_q = 20
 
 
@@ -53,6 +55,10 @@ def test_many_ctrl_flow_compile(benchmark):
     hugr = benchmark(comp)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
+
+    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(
+        many_ctrl_flow
+    )
 
 
 def test_many_ctrl_flow_check(benchmark) -> None:

--- a/tests/benchmarks/test_ctrl_flow.py
+++ b/tests/benchmarks/test_ctrl_flow.py
@@ -55,10 +55,7 @@ def test_many_ctrl_flow_compile(benchmark):
     hugr = benchmark(comp)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
-
-    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(
-        many_ctrl_flow
-    )
+    benchmark.extra_info["memory"] = compile_and_get_peak_memory(many_ctrl_flow)
 
 
 def test_many_ctrl_flow_check(benchmark) -> None:

--- a/tests/benchmarks/test_mem_usage.py
+++ b/tests/benchmarks/test_mem_usage.py
@@ -1,0 +1,55 @@
+import guppylang
+import pytest
+from guppylang.decorator import guppy
+from guppylang.std.builtins import array, py
+from guppylang.std.quantum import discard_array, measure, qubit
+
+from tests.util import compile_and_get_peak_memory
+
+guppylang.enable_experimental_features()
+
+array_size = 10
+n_compilations = 10
+
+
+@guppy
+def main_array() -> None:
+    q_array = array(qubit() for _ in range(py(array_size)))
+    discard_array(q_array)
+
+
+@guppy
+def main_single_qubit() -> None:
+    q = qubit()
+    _ = measure(q)
+
+
+@guppy
+def main_list() -> None:
+    q_list = [qubit() for _ in range(py(array_size))]
+    for q in q_list:
+        measure(q)
+
+
+@pytest.mark.parametrize(
+    "guppy_fn",
+    [main_array, main_single_qubit, main_list],
+    ids=["array", "qubit", "list"],
+)
+def test_compile_one_time(benchmark, guppy_fn) -> None:
+    benchmark(guppy_fn.compile)
+
+    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(guppy_fn)
+
+
+@pytest.mark.parametrize(
+    "guppy_fn",
+    [main_array, main_single_qubit, main_list],
+    ids=["array", "qubit", "list"],
+)
+def test_compile_multiple_times(benchmark, guppy_fn) -> None:
+    benchmark(guppy_fn.compile)
+
+    benchmark.extra_info["mem_compile_multiple"] = compile_and_get_peak_memory(
+        guppy_fn, n_compilations
+    )

--- a/tests/benchmarks/test_mem_usage.py
+++ b/tests/benchmarks/test_mem_usage.py
@@ -36,10 +36,9 @@ def main_list() -> None:
     [main_array, main_single_qubit, main_list],
     ids=["array", "qubit", "list"],
 )
-def test_compile_one_time(benchmark, guppy_fn) -> None:
+def test_mem_compile_once(benchmark, guppy_fn) -> None:
     benchmark(guppy_fn.compile)
-
-    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(guppy_fn)
+    benchmark.extra_info["memory"] = compile_and_get_peak_memory(guppy_fn)
 
 
 @pytest.mark.parametrize(
@@ -47,9 +46,8 @@ def test_compile_one_time(benchmark, guppy_fn) -> None:
     [main_array, main_single_qubit, main_list],
     ids=["array", "qubit", "list"],
 )
-def test_compile_multiple_times(benchmark, guppy_fn) -> None:
+def test_mem_compile_multiple(benchmark, guppy_fn) -> None:
     benchmark(guppy_fn.compile)
-
-    benchmark.extra_info["mem_compile_multiple"] = compile_and_get_peak_memory(
+    benchmark.extra_info["memory"] = compile_and_get_peak_memory(
         guppy_fn, n_compilations
     )

--- a/tests/benchmarks/test_queue_push_pop.py
+++ b/tests/benchmarks/test_queue_push_pop.py
@@ -2,11 +2,13 @@ from guppylang.decorator import guppy
 from guppylang.std.collections import Queue, empty_queue
 from hugr.package import Package
 
+from tests.util import compile_and_get_peak_memory
+
 
 @guppy
 def queue_push_benchmark() -> int:
-    q: Queue[int, 10000] = empty_queue()
-    for i in range(10000):
+    q: Queue[int, 10_000] = empty_queue()
+    for i in range(10_000):
         q = q.push(i)
     # Return the length so the value is used and not optimized away.
     return len(q)
@@ -14,8 +16,8 @@ def queue_push_benchmark() -> int:
 
 @guppy
 def queue_push_pop_benchmark() -> int:
-    q: Queue[int, 10000] = empty_queue()
-    for i in range(10000):
+    q: Queue[int, 10_000] = empty_queue()
+    for i in range(10_000):
         q = q.push(i)
     total = 0
     while len(q) > 0:
@@ -39,6 +41,9 @@ def test_queue_push_benchmark_compile(benchmark):
     hugr: Package = benchmark(queue_push_compile)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
+    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(
+        queue_push_benchmark
+    )
 
 
 def test_queue_push_pop_benchmark(benchmark):
@@ -56,3 +61,6 @@ def test_queue_push_pop_benchmark_compile(benchmark):
     hugr: Package = benchmark(queue_push_pop_compile)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
+    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(
+        queue_push_pop_benchmark
+    )

--- a/tests/benchmarks/test_queue_push_pop.py
+++ b/tests/benchmarks/test_queue_push_pop.py
@@ -41,9 +41,7 @@ def test_queue_push_benchmark_compile(benchmark):
     hugr: Package = benchmark(queue_push_compile)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
-    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(
-        queue_push_benchmark
-    )
+    benchmark.extra_info["memory"] = compile_and_get_peak_memory(queue_push_benchmark)
 
 
 def test_queue_push_pop_benchmark(benchmark):
@@ -61,6 +59,6 @@ def test_queue_push_pop_benchmark_compile(benchmark):
     hugr: Package = benchmark(queue_push_pop_compile)
     benchmark.extra_info["nodes"] = hugr.modules[0].num_nodes()
     benchmark.extra_info["bytes"] = len(hugr.to_bytes())
-    benchmark.extra_info["mem_compile_once"] = compile_and_get_peak_memory(
+    benchmark.extra_info["memory"] = compile_and_get_peak_memory(
         queue_push_pop_benchmark
     )

--- a/tests/util.py
+++ b/tests/util.py
@@ -34,3 +34,19 @@ def get_wasm_file() -> str:
 
 def get_h2_wasm_file() -> str:
     return str(Path(__file__).parent.resolve() / "resources/test.h2.wasm")
+
+
+def compile_and_get_peak_memory(
+    guppy_fn: GuppyFunctionDefinition, n_compilations: int = 1
+) -> float:
+    """Compile the given Guppy function `n_compilations` times and
+    return the peak memory used in bytes as reported by
+    `tracemalloc.get_traced_memory()`."""
+    import tracemalloc
+
+    tracemalloc.start()
+    for _ in range(n_compilations):
+        guppy_fn.compile()
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    return peak

--- a/tests/util.py
+++ b/tests/util.py
@@ -38,19 +38,26 @@ def get_h2_wasm_file() -> str:
 
 def compile_and_get_peak_memory(
     guppy_fn: GuppyFunctionDefinition, n_compilations: int = 1
-) -> float:
+) -> int:
     """Compile the given Guppy function `n_compilations` times and
     return the peak memory used in bytes as reported by
     `tracemalloc.get_traced_memory()`."""
     import gc
     import tracemalloc
 
-    gc.disable()
-    tracemalloc.start()
-    for _ in range(n_compilations):
-        guppy_fn.compile()
-    _, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-    gc.enable()
-    _ = gc.collect()
-    return peak
+    was_tracing = tracemalloc.is_tracing()
+    if not was_tracing:
+        tracemalloc.start()
+    tracemalloc.clear_traces()
+
+    try:
+        gc.disable()
+        for _ in range(n_compilations):
+            guppy_fn.compile()
+        _, peak = tracemalloc.get_traced_memory()
+        gc.enable()
+        _ = gc.collect()
+        return peak
+    finally:
+        if not was_tracing:
+            tracemalloc.stop()

--- a/tests/util.py
+++ b/tests/util.py
@@ -42,11 +42,15 @@ def compile_and_get_peak_memory(
     """Compile the given Guppy function `n_compilations` times and
     return the peak memory used in bytes as reported by
     `tracemalloc.get_traced_memory()`."""
+    import gc
     import tracemalloc
 
+    gc.disable()
     tracemalloc.start()
     for _ in range(n_compilations):
         guppy_fn.compile()
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
+    gc.enable()
+    _ = gc.collect()
     return peak


### PR DESCRIPTION
Includes:
- New `compile_and_get_peak_memory` util to get the memory used when compiling a guppy function using `tracemalloc.get_traced_memory()`.
- The `*_compile` tests in the big array, many ctrl flow and queue suites now report used peak memory.
- Adds a new `test_mem_usage` suite that benchmarks mem usage of single and multiple compilations of guppy funcs that use array and list comprehensions.