### PR TITLE
fix: Prevent leaking memory in custom call compilers and checkers

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -1,6 +1,7 @@
 import ast
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Generator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
 
@@ -219,8 +220,8 @@ class CustomFunctionDef(CompiledCallableDef):
 
         This is done by invoking the provided `CustomCallChecker`.
         """
-        self.call_checker._setup(ctx, node, self)
-        new_node, subst = self.call_checker.check(args, ty)
+        with self.call_checker._setup(ctx, node, self) as checker:
+            new_node, subst = checker.check(args, ty)
         return with_type(ty, with_loc(node, new_node)), subst
 
     def synthesize_call(
@@ -230,8 +231,8 @@ class CustomFunctionDef(CompiledCallableDef):
 
         This is done by invoking the provided `CustomCallChecker`.
         """
-        self.call_checker._setup(ctx, node, self)
-        new_node, ty = self.call_checker.synthesize(args)
+        with self.call_checker._setup(ctx, node, self) as checker:
+            new_node, ty = checker.synthesize(args)
         return with_type(ty, with_loc(node, new_node)), ty
 
     def load_with_args(
@@ -296,8 +297,10 @@ class CustomFunctionDef(CompiledCallableDef):
             )
         hugr_ty = concrete_ty.to_hugr(ctx)
 
-        self.call_compiler._setup(type_args, dfg, ctx, node, hugr_ty, self)
-        return self.call_compiler.compile_with_inouts(args)
+        with self.call_compiler._setup(
+            type_args, dfg, ctx, node, hugr_ty, self
+        ) as compiler:
+            return compiler.compile_with_inouts(args)
 
 
 class CustomCallChecker(ABC):
@@ -307,10 +310,31 @@ class CustomCallChecker(ABC):
     node: AstNode
     func: CustomFunctionDef
 
-    def _setup(self, ctx: Context, node: AstNode, func: CustomFunctionDef) -> None:
+    _depth = 0
+
+    @contextmanager
+    def _setup(
+        self, ctx: Context, node: AstNode, func: CustomFunctionDef
+    ) -> Generator["CustomCallChecker", None, None]:
+        """
+        A context manager to temporarily set up the checker with required arguments, and
+        properly tear down the checker afterwards to avoid memory leaks.
+
+        See https://github.com/Quantinuum/guppylang/issues/1735.
+        """
         self.ctx = ctx
         self.node = node
         self.func = func
+        try:
+            yield self
+        finally:
+            self._depth -= 1
+            # Only clean when there are no parent recursions, as otherwise the fields
+            # may still be in use.
+            if self._depth == 0:
+                del self.ctx
+                del self.node
+                del self.func
 
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         """Checks the return value against a given type.
@@ -349,6 +373,9 @@ class CustomInoutCallCompiler(ABC):
     ty: ht.FunctionType
     func: CustomFunctionDef | None
 
+    _depth = 0
+
+    @contextmanager
     def _setup(
         self,
         type_args: Inst,
@@ -357,7 +384,13 @@ class CustomInoutCallCompiler(ABC):
         node: AstNode,
         hugr_ty: ht.FunctionType,
         func: CustomFunctionDef | None,
-    ) -> None:
+    ) -> Generator["CustomInoutCallCompiler", None, None]:
+        """
+        A context manager to temporarily set up the compiler with required arguments,
+        and properly tear down the compiler afterwards to avoid memory leaks.
+
+        See https://github.com/Quantinuum/guppylang/issues/1735.
+        """
         self.type_args = type_args
         self.dfg = dfg
         self.ctx = ctx
@@ -369,6 +402,20 @@ class CustomInoutCallCompiler(ABC):
         # function to is the function definition itself, so we set the function
         # definition node as the AST context in the builder.
         self.builder.current_ast_node = self.node
+        self._depth += 1
+        try:
+            yield self
+        finally:
+            self._depth -= 1
+            # Only clean when there are no parent recursions, as otherwise the fields
+            # may still be in use.
+            if self._depth == 0:
+                del self.type_args
+                del self.dfg
+                del self.ctx
+                del self.node
+                del self.ty
+                del self.func
 
     @abstractmethod
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:


### PR DESCRIPTION
Cherry picks 100b974cd6da8da901b7beefc0558a939a548ddc onto the 0.X series.

Related to #1735 