### PR TITLE
docs: Fix citation file name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ See [DEVELOPMENT.md](https://github.com/quantinuum/guppylang/blob/main/DEVELOPME
 
 ## Attribution
 
-If you use this software, please cite it using [CITATION.bib](https://github.com/quantinuum/guppylang/blob/main/CITATION.bib) or [CITATION.cff](https://github.com/quantinuum/guppylang/blob/main/CITATION.cff) (click "Cite this repository" in the About section of the repository landing page).
+If you use this software, please cite it using [CITATIONS.bib](https://github.com/quantinuum/guppylang/blob/main/CITATIONS.bib) or [CITATION.cff](https://github.com/quantinuum/guppylang/blob/main/CITATION.cff) (click "Cite this repository" in the About section of the repository landing page).
 
 ## License
 


### PR DESCRIPTION
See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files#other-citation-files for accepted filenames.