### PR TITLE
docs: Add parameters in error model snippet

### DIFF
--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -88,7 +88,15 @@ on the emulator instance.
 
     from selene_sim.backends.bundled_error_models import DepolarizingErrorModel
 
-    foo.emulator(1).with_error_model(DepolarizingErrorModel()).run()
+    error_model = DepolarizingErrorModel(
+        random_seed=123141,
+        p_1q=1e-5,
+        p_2q=1.4e-4,
+        p_meas=1e-3,
+        p_init=1e-5
+    )
+
+    foo.emulator(1).with_error_model(error_model).run()
 
 State results
 -----------------


### PR DESCRIPTION
Adding some error parameters to this noise model snippet.

Passing the depolarizing error model without parameters would be a noise free simulation as all of the parameters are zero by default.