### PR TITLE
feat!: Protocol parsing

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/errors/type_errors.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/type_errors.py
@@ -362,3 +362,14 @@ class IntOverflowError(Error):
     @property
     def signed_unsigned(self) -> str:
         return "signed" if self.signed else "unsigned"
+
+
+@dataclass(frozen=True)
+class KindMismatch(Error):
+    title: ClassVar[str] = "Kind mismatch"
+    span_label: ClassVar[str] = (
+        "`{arg}` is the wrong kind for param `{param}`. Expected a `{expected}` arg"
+    )
+    arg: str
+    param: str
+    expected: str

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -337,7 +337,9 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(func_ty, FunctionType)
                 raise GuppyError(
-                    UnsupportedError(node.func, "Checking protocol method calls")
+                    UnsupportedError(
+                        node.func, "Checking protocol method calls", singular=True
+                    )
                 )
 
         # When calling a `PartialApply` node, we just move the args into this call
@@ -899,7 +901,9 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 raise GuppyError(
-                    UnsupportedError(node.func, "Checking protocol method calls")
+                    UnsupportedError(
+                        node.func, "Checking protocol method calls", singular=True
+                    )
                 )
 
         # When calling a `PartialApply` node, we just move the args into this call

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -24,7 +24,7 @@ import ast
 import copy
 import sys
 import traceback
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from dataclasses import replace
 from types import ModuleType
@@ -78,6 +78,7 @@ from guppylang_internals.checker.errors.type_errors import (
     ConstMismatchError,
     IllegalConstant,
     IntOverflowError,
+    KindMismatch,
     ModuleMemberNotFoundError,
     NonLinearInstantiateError,
     NotCallableError,
@@ -126,7 +127,7 @@ from guppylang_internals.nodes import (
     TypeApply,
 )
 from guppylang_internals.span import Span, to_span
-from guppylang_internals.tys.arg import ConstArg, TypeArg
+from guppylang_internals.tys.arg import Argument, ConstArg, TypeArg
 from guppylang_internals.tys.builtin import (
     bool_type,
     float_type,
@@ -148,7 +149,12 @@ from guppylang_internals.tys.const import (
     ConstValue,
     ExistentialConstVar,
 )
-from guppylang_internals.tys.param import TypeParam, check_all_args
+from guppylang_internals.tys.param import (
+    ConstParam,
+    Parameter,
+    TypeParam,
+    check_all_args,
+)
 from guppylang_internals.tys.parsing import arg_from_ast
 from guppylang_internals.tys.subst import Inst, Subst
 from guppylang_internals.tys.ty import (
@@ -323,6 +329,16 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             defn = self.ctx.globals[node.func.def_id]
             if isinstance(defn, CallableDef):
                 return defn.check_call(node.args, ty, node, self.ctx)
+
+            from guppylang_internals.definition.protocol import ParsedProtocolDef
+
+            # Protocol methods don't have their own definition, we have to look up the
+            # protocol definition itself first.
+            if isinstance(defn, ParsedProtocolDef):
+                assert isinstance(func_ty, FunctionType)
+                raise GuppyError(
+                    UnsupportedError(node.func, "Checking protocol method calls")
+                )
 
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):
@@ -877,6 +893,15 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             if isinstance(defn, CallableDef):
                 return defn.synthesize_call(node.args, node, self.ctx)
 
+            from guppylang_internals.definition.protocol import ParsedProtocolDef
+
+            # Protocol methods don't have their own definition, we have to look up the
+            # protocol definition itself first.
+            if isinstance(defn, ParsedProtocolDef):
+                raise GuppyError(
+                    UnsupportedError(node.func, "Checking protocol method calls")
+                )
+
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):
             node.args = [*node.func.args, *node.args]
@@ -1119,6 +1144,7 @@ def type_check_args(
     inputs: list[ast.expr],
     func_ty: FunctionType,
     subst: Subst,
+    free_var_mapping: Mapping[ExistentialVar, Parameter],
     ctx: Context,
     node: AstNode,
 ) -> tuple[list[ast.expr], Subst]:
@@ -1134,6 +1160,28 @@ def type_check_args(
     comptime_args = iter(func_ty.comptime_args)
     for inp, func_inp in zip(inputs, func_ty.inputs, strict=True):
         a, s = ExprChecker(ctx).check(inp, func_inp.ty.substitute(subst), "argument")
+        # For each new substitution we find for any previously uninstantiated parameter,
+        # we check it in order to possibly infer more substitutions through protocol
+        # checking.
+        for var in s:
+            if var in free_var_mapping:
+                param = free_var_mapping[var]
+                arg = s[var].to_arg()
+                match param, arg:
+                    case TypeParam(), TypeArg() as arg:
+                        check_arg, check_subst = param.check_arg(arg, a)
+                        subst |= check_subst
+                        subst[var] = check_arg.ty
+                    case ConstParam(), ConstArg() as arg:
+                        subst[var] = param.check_arg(arg, a).const
+                    case TypeParam(), _:
+                        raise GuppyError(
+                            KindMismatch(node, str(arg), str(param), "Type")
+                        )
+                    case ConstParam(), _:
+                        raise GuppyError(
+                            KindMismatch(node, str(arg), str(param), "Const")
+                        )
         subst |= s
         if InputFlags.Inout in func_inp.flags and isinstance(a, PlaceNode):
             a.place = check_place_assignable(
@@ -1271,7 +1319,16 @@ def synthesize_call(
     # Replace quantified variables with free unification variables and try to infer an
     # instantiation by checking the arguments
     unquantified, free_vars = func_ty.unquantified()
-    args, subst = type_check_args(args, unquantified, {}, ctx, node)
+    var_mapping = {}
+    inst_tele: list[Argument | None] = [None for _ in free_vars]
+    for ix, (var, param) in enumerate(zip(free_vars, func_ty.params, strict=True)):
+        var_mapping[var] = param.instantiate_bounds(inst_tele)
+        if isinstance(var, ExistentialTypeVar):
+            inst_tele[ix] = TypeArg(var)
+        elif isinstance(var, ExistentialConstVar):
+            inst_tele[ix] = ConstArg(var)
+
+    args, subst = type_check_args(args, unquantified, {}, var_mapping, ctx, node)
 
     # Success implies that the substitution is closed
     assert all(not t.unsolved_vars for t in subst.values())
@@ -1346,7 +1403,7 @@ def check_call(
         raise GuppyTypeError(TypeMismatchError(node, ty, unquantified.output, kind))
 
     # Try to infer more by checking against the arguments
-    inputs, subst = type_check_args(inputs, unquantified, subst, ctx, node)
+    inputs, subst = type_check_args(inputs, unquantified, subst, {}, ctx, node)
 
     # Also make sure we found an instantiation for all free vars in the type we're
     # checking against

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -348,7 +348,7 @@ def check_signature(
                     "TypeDef", ENGINE.get_checked(self_def_id, mono_args=())
                 )
                 assert isinstance(self_defn, TypeDef)
-                input = parse_self_arg_type(inp, self_defn, ctx, func_def)
+                input = parse_self_arg(inp, self_defn, ctx)
 
             if input.name is None:
                 input = replace(input, name="self")
@@ -368,9 +368,7 @@ def check_signature(
     )
 
 
-def parse_self_arg_type(
-    arg: ast.arg, self_defn: TypeDef, ctx: TypeParsingCtx, _loc: AstNode
-) -> FuncInput:
+def parse_self_arg(arg: ast.arg, self_defn: TypeDef, ctx: TypeParsingCtx) -> FuncInput:
     """Handles parsing of the `self` argument on methods.
 
     This argument is special since its type annotation may be omitted. Furthermore, if a
@@ -387,7 +385,7 @@ def parse_self_arg_type(
         [param.to_existential()[0] for param in self_defn.params]
     )
     self_ty_placeholder = ExistentialTypeVar.fresh(
-        "Self", copyable=True, droppable=True
+        "Self", copyable=self_ty_head.copyable, droppable=self_ty_head.droppable
     )
     assert ctx.self_ty is None
     ctx = replace(ctx, self_ty=self_ty_placeholder)

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -457,7 +457,7 @@ def parse_self_arg_proto(
         # Check that the annotation matches the parent type. We can do this by unifying
         # with the expected self type where all params are instantiated with unification
         # vars
-        raise GuppyError(UnsupportedError(loc, "Protocol checking"))
+        raise GuppyError(UnsupportedError(loc, "Protocol checking", singular=True))
     else:
         # I'm pretty sure the first arg is *not* a protocol
         # This raises future problems for trying to backport protocols to std

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -414,8 +414,7 @@ def parse_self_arg_proto(
 ) -> FuncInput:
     """Handles parsing of the `self` argument on methods of protocols.
 
-    This argument is special since its type annotation may be omitted. Furthermore, if a
-    type is provided then it must match the parent type.
+    If a type is provided then it must match the parent type.
     """
     assert self_defn.params is not None
     if arg.annotation is None:

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -11,7 +11,7 @@ import sys
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, ClassVar, cast
 
-from guppylang_internals.ast_util import return_nodes_in_ast, with_loc
+from guppylang_internals.ast_util import AstNode, return_nodes_in_ast, with_loc
 from guppylang_internals.cfg.bb import BB
 from guppylang_internals.cfg.builder import CFGBuilder
 from guppylang_internals.checker.cfg_checker import CheckedCFG, check_cfg
@@ -25,6 +25,7 @@ from guppylang_internals.engine import DEF_STORE, ENGINE
 from guppylang_internals.error import GuppyError
 from guppylang_internals.experimental import check_capturing_closures_enabled
 from guppylang_internals.nodes import CheckedNestedFunctionDef, NestedFunctionDef
+from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.parsing import (
     TypeParsingCtx,
     check_function_arg,
@@ -34,6 +35,7 @@ from guppylang_internals.tys.parsing import (
 )
 from guppylang_internals.tys.subst import Inst
 from guppylang_internals.tys.ty import (
+    BoundTypeVar,
     ExistentialTypeVar,
     FuncInput,
     FunctionType,
@@ -44,11 +46,12 @@ from guppylang_internals.tys.ty import (
     unify,
 )
 
+if TYPE_CHECKING:
+    from guppylang_internals.definition.protocol import CheckedProtocolDef
+
+
 if sys.version_info >= (3, 12):
     from guppylang_internals.tys.parsing import parse_parameter
-
-if TYPE_CHECKING:
-    from guppylang_internals.tys.param import Parameter
 
 
 @dataclass(frozen=True)
@@ -276,6 +279,7 @@ def check_signature(
     func_def: ast.FunctionDef,
     globals: Globals,
     def_id: DefId | None = None,
+    param_var_mapping: dict[str, Parameter] | None = None,
     unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
 ) -> FunctionType:
     """Checks the signature of a function definition and returns the corresponding
@@ -285,6 +289,8 @@ def check_signature(
     passed. This will be used to check or infer the type annotation for the `self`
     argument.
     """
+    from guppylang_internals.definition.protocol import CheckedProtocolDef, ProtocolDef
+
     if len(func_def.args.posonlyargs) != 0:
         raise GuppyError(
             UnsupportedError(func_def.args.posonlyargs[0], "Positional-only parameters")
@@ -311,26 +317,41 @@ def check_signature(
         raise GuppyError(err)
 
     # Prepopulate parameter mapping when using Python 3.12 style generic syntax
-    param_var_mapping: dict[str, Parameter] = {}
+    if param_var_mapping is None:
+        param_var_mapping = {}
     if sys.version_info >= (3, 12):
         for i, param_node in enumerate(func_def.type_params):
             param = parse_parameter(param_node, i, globals, param_var_mapping)
             param_var_mapping[param.name] = param
 
     # Figure out if this is a method
-    self_defn: TypeDef | None = None
-    if def_id is not None and def_id in DEF_STORE.type_member_parents:
-        self_def_id = DEF_STORE.type_member_parents[def_id]
-        self_defn = cast("TypeDef", ENGINE.get_checked(self_def_id, mono_args=()))
-        assert isinstance(self_defn, TypeDef)
-
+    self_defn: ProtocolDef | TypeDef | None = None
     inputs = []
     ctx = TypeParsingCtx(globals, param_var_mapping, allow_free_vars=True)
+    has_parent = def_id is not None and def_id in DEF_STORE.type_member_parents
     for i, inp in enumerate(func_def.args.args):
         # Special handling for `self` arguments. Note that `__new__` is excluded here
         # since it's not a method so doesn't take `self`.
-        if self_defn and i == 0 and func_def.name != "__new__":
-            input = parse_self_arg(inp, self_defn, ctx)
+        if i == 0 and func_def.name != "__new__" and has_parent and def_id is not None:
+            self_def_id = DEF_STORE.type_member_parents[def_id]
+            self_defn_untyped = ENGINE.get_checked(self_def_id, mono_args=())
+            input: FuncInput
+            if isinstance(self_defn_untyped, ProtocolDef):
+                self_defn = cast(
+                    "CheckedProtocolDef",
+                    ENGINE.get_checked(self_def_id, mono_args=()),
+                )
+                assert isinstance(self_defn, CheckedProtocolDef)
+                input = parse_self_arg_proto(inp, self_defn, ctx, func_def)
+            else:
+                self_defn = cast(
+                    "TypeDef", ENGINE.get_checked(self_def_id, mono_args=())
+                )
+                assert isinstance(self_defn, TypeDef)
+                input = parse_self_arg_type(inp, self_defn, ctx, func_def)
+
+            if input.name is None:
+                input = replace(input, name="self")
             ctx = replace(ctx, self_ty=input.ty)
         else:
             ty_ast = inp.annotation
@@ -347,7 +368,9 @@ def check_signature(
     )
 
 
-def parse_self_arg(arg: ast.arg, self_defn: TypeDef, ctx: TypeParsingCtx) -> FuncInput:
+def parse_self_arg_type(
+    arg: ast.arg, self_defn: TypeDef, ctx: TypeParsingCtx, _loc: AstNode
+) -> FuncInput:
     """Handles parsing of the `self` argument on methods.
 
     This argument is special since its type annotation may be omitted. Furthermore, if a
@@ -364,7 +387,7 @@ def parse_self_arg(arg: ast.arg, self_defn: TypeDef, ctx: TypeParsingCtx) -> Fun
         [param.to_existential()[0] for param in self_defn.params]
     )
     self_ty_placeholder = ExistentialTypeVar.fresh(
-        "Self", copyable=self_ty_head.copyable, droppable=self_ty_head.droppable
+        "Self", copyable=True, droppable=True
     )
     assert ctx.self_ty is None
     ctx = replace(ctx, self_ty=self_ty_placeholder)
@@ -386,6 +409,68 @@ def parse_self_arg(arg: ast.arg, self_defn: TypeDef, ctx: TypeParsingCtx) -> Fun
         raise GuppyError(InvalidSelfError(arg.annotation, arg.arg, self_ty_head))
 
     return check_function_arg(user_ty, user_flags, arg, arg.arg, ctx)
+
+
+def parse_self_arg_proto(
+    arg: ast.arg, self_defn: "CheckedProtocolDef", ctx: TypeParsingCtx, loc: AstNode
+) -> FuncInput:
+    """Handles parsing of the `self` argument on methods of protocols.
+
+    This argument is special since its type annotation may be omitted. Furthermore, if a
+    type is provided then it must match the parent type.
+    """
+    assert self_defn.params is not None
+    if arg.annotation is None:
+        raise GuppyError(
+            UnsupportedError(
+                arg, "Inference of type for `self`", True, "protocol methods"
+            )
+        )
+
+    # If the user has provided an annotation for `self`, then we go ahead and parse it.
+    # However, in the annotation the user is also allowed to use `Self`, so we have to
+    # specify a `self_ty` in the context.
+    self_ty_head = self_defn.check_instantiate(
+        [param.to_existential()[0] for param in self_defn.params]
+    )
+    self_ty_placeholder = ExistentialTypeVar.fresh(
+        "Self",
+        copyable=True,
+        droppable=True,
+    )
+    assert ctx.self_ty is None
+    ctx = replace(ctx, self_ty=self_ty_placeholder)
+    user_ty, _user_flags = type_with_flags_from_ast(arg.annotation, ctx)
+
+    # If the user just annotates `self: Self` then we can fall back to the case where
+    # no annotation is provided at all
+    if user_ty == self_ty_placeholder:
+        raise GuppyError(
+            UnsupportedError(
+                arg.annotation, "`Self` type annotation", True, "protocol methods"
+            )
+        )
+
+    # Annotations like `self: Foo[Self]` are not allowed (would be an infinite type)
+    if self_ty_placeholder in user_ty.unsolved_vars:
+        raise GuppyError(RecursiveSelfError(arg.annotation, arg.arg))
+
+    if isinstance(user_ty, BoundTypeVar):
+        # Check that the annotation matches the parent type. We can do this by unifying
+        # with the expected self type where all params are instantiated with unification
+        # vars
+        raise GuppyError(UnsupportedError(loc, "Protocol checking"))
+    else:
+        # I'm pretty sure the first arg is *not* a protocol
+        # This raises future problems for trying to backport protocols to std
+        # This isn't well scoped!
+        raise GuppyError(
+            InvalidSelfError(
+                arg.annotation,
+                arg.arg,
+                BoundTypeVar("self", 0, True, True, (self_ty_head,)),
+            )
+        )
 
 
 def handle_implicit_self_arg(

--- a/guppylang-internals/src/guppylang_internals/definition/enum.py
+++ b/guppylang-internals/src/guppylang_internals/definition/enum.py
@@ -185,7 +185,9 @@ class RawEnumDef(TypeDef, ParsableDef, UserProvidedLinkName):
             v = getattr(self.python_class, func_name)
             if not isinstance(v, GuppyDefinition):
                 raise GuppyError(
-                    NonGuppyMethodError(func_def, self.name, func_name, "enum")
+                    NonGuppyMethodError(
+                        func_def, self.name, func_name, "enum", "@guppy"
+                    )
                 )
 
         link_name_prefix = (

--- a/guppylang-internals/src/guppylang_internals/definition/protocol.py
+++ b/guppylang-internals/src/guppylang_internals/definition/protocol.py
@@ -1,0 +1,189 @@
+import ast
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, ClassVar
+
+from guppylang_internals.ast_util import AstNode
+from guppylang_internals.checker.core import Globals
+from guppylang_internals.checker.errors.generic import (
+    UnexpectedError,
+    UnsupportedError,
+)
+from guppylang_internals.definition.common import (
+    CheckableDef,
+    CompiledDef,
+    DefId,
+    Definition,
+    ParsableDef,
+)
+from guppylang_internals.definition.declaration import ParsedFunctionDecl
+from guppylang_internals.definition.util import (
+    NonGuppyMethodError,
+    RedundantParamsError,
+    params_from_ast,
+    parse_py_class,
+    try_parse_generic_base,
+)
+from guppylang_internals.diagnostic import Help
+from guppylang_internals.engine import DEF_STORE, ENGINE
+from guppylang_internals.error import GuppyError
+from guppylang_internals.span import SourceMap, Span, to_span
+from guppylang_internals.tys.arg import Argument
+from guppylang_internals.tys.param import Parameter, check_all_args
+from guppylang_internals.tys.protocol import ProtocolInst
+from guppylang_internals.tys.ty import FunctionType
+
+if TYPE_CHECKING:
+    from guppylang_internals.diagnostic import Error
+
+if sys.version_info >= (3, 12):
+    from guppylang_internals.tys.parsing import parse_parameter
+
+
+@dataclass(frozen=True)
+class ProtocolDef(Definition):
+    """Abstract base class for protocol definitions."""
+
+    description: str = field(default="protocol", init=False)
+
+
+@dataclass(frozen=True)
+class EmptyBodyHint(Help):
+    message: ClassVar[str] = "The body of protocol function definitions must be empty"
+
+
+@dataclass(frozen=True)
+class NoAnnotationHint(Help):
+    message: ClassVar[str] = "Protocol function definitions don't need to be annotated"
+
+
+@dataclass(frozen=True)
+class RawProtocolDef(ProtocolDef, ParsableDef):
+    """A raw protocol definition that has not been parsed yet."""
+
+    python_class: type
+
+    def parse(self, globals: Globals, sources: SourceMap) -> "ParsedProtocolDef":
+        """Parses the raw class object into an AST and checks that it is well-formed."""
+        # Mostly copied from RawStructDef.parse, but only allowing function declarations
+        # in the body and allowing `Protocol` as a base class.
+        frame = DEF_STORE.frames[self.id]
+        cls_def = parse_py_class(self.python_class, frame, sources)
+        if cls_def.keywords:
+            raise GuppyError(UnexpectedError(cls_def.keywords[0], "keyword"))
+
+        # Look for generic parameters from Python 3.12 style syntax.
+        params = []
+        params_span: Span | None = None
+        if sys.version_info >= (3, 12):
+            if cls_def.type_params:
+                first, last = cls_def.type_params[0], cls_def.type_params[-1]
+                params_span = Span(to_span(first).start, to_span(last).end)
+                param_vars_mapping: dict[str, Parameter] = {}
+                for idx, param_node in enumerate(cls_def.type_params):
+                    param = parse_parameter(
+                        param_node, idx, globals, param_vars_mapping
+                    )
+                    param_vars_mapping[param.name] = param
+                    params.append(param)
+
+        match cls_def.bases:
+            case []:
+                pass
+            # We allow `Generic[...]` or `Protocol[...]` to specify  parameters with the
+            # legacy syntax.
+            case [base] if elems := try_parse_generic_base(
+                base, "Generic"
+            ) or try_parse_generic_base(base, "Protocol"):
+                # Complain if we already have Python 3.12 generic params
+                if params_span is not None:
+                    err: Error = RedundantParamsError(base, self.name)
+                    err.add_sub_diagnostic(RedundantParamsError.PrevSpec(params_span))
+                    raise GuppyError(err)
+                params = params_from_ast(elems, globals)
+            # Specifying `Protocol` is redundant but we allow it optionally.
+            case [base] if isinstance(base, ast.Name) and base.id == "Protocol":
+                pass
+            case bases:
+                err = UnsupportedError(bases[0], "Protocol inheritance", singular=True)
+                raise GuppyError(err)
+
+        func_defs = {}
+        for i, node in enumerate(cls_def.body):
+            match i, node:
+                # Docstrings are fine if they occur at the start.
+                case 0, ast.Expr(value=ast.Constant(value=v)) if isinstance(v, str):
+                    pass
+                # Parse the function definitions into types.
+                case _, ast.FunctionDef(name=name) as node:
+                    from guppylang.defs import GuppyDefinition
+
+                    py_func = getattr(self.python_class, name, None)
+
+                    if not isinstance(py_func, GuppyDefinition):
+                        raise GuppyError(
+                            NonGuppyMethodError(
+                                node, self.name, name, "protocol", "@guppy.require"
+                            )
+                        )
+                    assert isinstance(py_func, GuppyDefinition)
+                    func_defs[name] = py_func.id
+                # Fields are not allowed in protocols.
+                case _, ast.AnnAssign(target=ast.Name(_)) as node:
+                    err = UnsupportedError(
+                        node, "Fields", unsupported_in="a protocol definition"
+                    )
+                    raise GuppyError(err)
+                case _, node:
+                    err = UnexpectedError(
+                        node, "statement", unexpected_in="protocol definition"
+                    )
+                    raise GuppyError(err)
+
+        return ParsedProtocolDef(self.id, self.name, cls_def, params, func_defs)
+
+
+@dataclass(frozen=True)
+class ParsedProtocolDef(ProtocolDef, CheckableDef):
+    """A protocol definition where members have been parsed but not checked yet."""
+
+    defined_at: ast.ClassDef
+    params: Sequence[Parameter]
+    members: Mapping[str, DefId]
+
+    def check(self, globals: Globals) -> "CheckedProtocolDef":
+        """Checks the member function types and returns a checked definition."""
+        # It would be nice to check here that all of the methods are well
+        # formed, but they're all already individually queued in the engine.
+        return CheckedProtocolDef(
+            self.id, self.name, self.defined_at, self.params, self.members
+        )
+
+    def check_instantiate(
+        self, args: Sequence[Argument], loc: AstNode | None = None
+    ) -> ProtocolInst:
+        """Checks if the protocol can be instantiated with the given arguments."""
+        check_all_args(self.params, args, self.name, loc)
+        return ProtocolInst(tuple(args), self.id)
+
+
+@dataclass(frozen=True)
+class CheckedProtocolDef(ProtocolDef, CompiledDef):
+    """A fully checked protocol definition."""
+
+    defined_at: ast.ClassDef
+    params: Sequence[Parameter]
+    member_defs: Mapping[str, DefId]
+
+    def check_instantiate(
+        self, args: Sequence[Argument], loc: AstNode | None = None
+    ) -> ProtocolInst:
+        """Checks if the protocol can be instantiated with the given arguments."""
+        check_all_args(self.params, args, self.name, loc)
+        return ProtocolInst(tuple(args), self.id)
+
+    def member_sig(self, name: str) -> FunctionType:
+        def_ = ENGINE.get_parsed(self.member_defs[name])
+        assert isinstance(def_, ParsedFunctionDecl)
+        return def_.ty

--- a/guppylang-internals/src/guppylang_internals/definition/struct.py
+++ b/guppylang-internals/src/guppylang_internals/definition/struct.py
@@ -58,6 +58,13 @@ class FieldFormHint(Help):
 
 
 @dataclass(frozen=True)
+class ProtocolHint(Help):
+    message: ClassVar[str] = (
+        "Add a `@guppy.protocol` annotation to turn this struct into a protocol"
+    )
+
+
+@dataclass(frozen=True)
 class RawStructDef(TypeDef, ParsableDef, UserProvidedLinkName):
     """A raw struct type definition that has not been parsed yet."""
 
@@ -91,7 +98,9 @@ class RawStructDef(TypeDef, ParsableDef, UserProvidedLinkName):
                     v = getattr(self.python_class, name)
                     if not isinstance(v, GuppyDefinition):
                         raise GuppyError(
-                            NonGuppyMethodError(node, self.name, name, "struct")
+                            NonGuppyMethodError(
+                                node, self.name, name, "struct", "@guppy"
+                            )
                         )
                     used_func_names[name] = node
                     if name in used_field_names:

--- a/guppylang-internals/src/guppylang_internals/definition/struct.py
+++ b/guppylang-internals/src/guppylang_internals/definition/struct.py
@@ -58,13 +58,6 @@ class FieldFormHint(Help):
 
 
 @dataclass(frozen=True)
-class ProtocolHint(Help):
-    message: ClassVar[str] = (
-        "Add a `@guppy.protocol` annotation to turn this struct into a protocol"
-    )
-
-
-@dataclass(frozen=True)
 class RawStructDef(TypeDef, ParsableDef, UserProvidedLinkName):
     """A raw struct type definition that has not been parsed yet."""
 

--- a/guppylang-internals/src/guppylang_internals/definition/util.py
+++ b/guppylang-internals/src/guppylang_internals/definition/util.py
@@ -67,11 +67,12 @@ class NonGuppyMethodError(Error):
     class_name: str
     method_name: str
     class_type: str
+    ann: str
 
     @dataclass(frozen=True)
     class Suggestion(Help):
         message: ClassVar[str] = (
-            "Add a `@guppy` annotation to turn `{method_name}` into a Guppy method"
+            "Add a `{ann}` annotation to turn `{method_name}` into a Guppy method"
         )
 
     def __post_init__(self) -> None:
@@ -83,6 +84,13 @@ class RepeatedTypeParamError(Error):
     title: ClassVar[str] = "Duplicate type parameter"
     span_label: ClassVar[str] = "Type parameter `{name}` cannot be used multiple times"
     name: str
+
+
+@dataclass(frozen=True)
+class ProtocolHint(Help):
+    message: ClassVar[str] = (
+        "Add a `@guppy.protocol` annotation to turn this struct into a protocol"
+    )
 
 
 @dataclass(frozen=True)
@@ -140,13 +148,13 @@ def parse_py_class(
     return cls_ast
 
 
-def try_parse_generic_base(node: ast.expr) -> list[ast.expr] | None:
-    """Checks if an AST node corresponds to a `Generic[T1, ..., Tn]` base class.
+def try_parse_generic_base(node: ast.expr, base_name: str) -> list[ast.expr] | None:
+    """Checks if an AST node corresponds to a `base_name[T1, ..., Tn]` base class.
 
     Returns the generic parameters or `None` if the AST has a different shape
     """
     match node:
-        case ast.Subscript(value=ast.Name(id="Generic"), slice=elem):
+        case ast.Subscript(value=ast.Name(id=name), slice=elem) if base_name == name:
             return elem.elts if isinstance(elem, ast.Tuple) else [elem]
         case _:
             return None
@@ -156,7 +164,7 @@ def extract_generic_params(
     cls_def: ast.ClassDef, class_name: str, globals: Globals, class_kind: str
 ) -> list[Parameter]:
     """Extracts generic parameters from a class definition."""
-    params = []
+    params: list[Parameter] = []
     params_span: Span | None = None
 
     # Look for generic parameters from Python 3.12 style syntax
@@ -170,27 +178,38 @@ def extract_generic_params(
                 param_vars_mapping[param.name] = param
                 params.append(param)
 
-    # The only base we allow is `Generic[...]` to specify generic parameters with
-    # the legacy syntax
-    match cls_def.bases:
-        case []:
-            pass
-        case [base] if elems := try_parse_generic_base(base):
+    base_params: list[Parameter] = []
+    for base in cls_def.bases:
+        if elems := try_parse_generic_base(base, "Generic"):
+            # Complain if there's already been a `Generic[T]` parent
+            if base_params != []:
+                raise GuppyError(
+                    UnsupportedError(
+                        base,
+                        "Multiple `Generic` inheritance",
+                        singular=True,
+                    )
+                )
+
             # Complain if we already have Python 3.12 generic params
             if params_span is not None:
                 err: Error = RedundantParamsError(base, class_name)
                 err.add_sub_diagnostic(RedundantParamsError.PrevSpec(params_span))
                 raise GuppyError(err)
-            params = params_from_ast(elems, globals)
-        case bases:
+            base_params = params_from_ast(elems, globals)
+        elif elems := try_parse_generic_base(base, "Protocol"):
+            err = UnsupportedError(base, "Protocol base", singular=True)
+            err.add_sub_diagnostic(ProtocolHint(None))
+            raise GuppyError(err)
+        else:
             err = UnsupportedError(
-                bases[0],
+                base,
                 f"{class_kind} inheritance",
                 singular=True,
             )
             raise GuppyError(err)
 
-    return params
+    return params + base_params
 
 
 def params_from_ast(nodes: Sequence[ast.expr], globals: Globals) -> list[Parameter]:

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -15,6 +15,7 @@ from guppylang_internals.checker.errors.type_errors import (
     UnaryOperatorNotDefinedError,
 )
 from guppylang_internals.definition.common import CheckableGenericDef, DefId, Definition
+from guppylang_internals.definition.protocol import ProtocolDef
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import (
     CallableDef,
@@ -576,7 +577,7 @@ class TracingDefMixin(DunderMixin):
     def __getitem__(self, item: Any) -> Any:
         # If this is a type definition, then `__getitem__` might be called when
         # specifying generic arguments
-        if isinstance(self.wrapped, TypeDef):
+        if isinstance(self.wrapped, TypeDef | ProtocolDef):
             # It doesn't really matter what we return here since we don't support types
             # as comptime values yet, so just give back the definition
             return self

--- a/guppylang-internals/src/guppylang_internals/tys/builtin.py
+++ b/guppylang-internals/src/guppylang_internals/tys/builtin.py
@@ -85,7 +85,7 @@ class _TupleTypeDef(TypeDef, CompiledDef):
         args = [
             # TODO: Better error location
             TypeParam(0, f"T{i}", must_be_copyable=False, must_be_droppable=False)
-            .check_arg(arg, loc)
+            .check_arg(arg, loc)[0]
             .ty
             for i, arg in enumerate(args)
         ]

--- a/guppylang-internals/src/guppylang_internals/tys/param.py
+++ b/guppylang-internals/src/guppylang_internals/tys/param.py
@@ -127,7 +127,9 @@ class TypeParam(ParameterBase):
                     )
                     raise GuppyTypeError(err)
                 if self.must_implement:
-                    raise GuppyError(UnsupportedError(loc, "Protocol checking"))
+                    raise GuppyError(
+                        UnsupportedError(loc, "Protocol checking", singular=True)
+                    )
                 return arg, subst
 
     def to_existential(self) -> tuple[Argument, ExistentialVar]:

--- a/guppylang-internals/src/guppylang_internals/tys/param.py
+++ b/guppylang-internals/src/guppylang_internals/tys/param.py
@@ -6,16 +6,19 @@ from typing import TYPE_CHECKING, TypeAlias
 from typing_extensions import Self
 
 from guppylang_internals.ast_util import AstNode
-from guppylang_internals.checker.errors.generic import ExpectedError
+from guppylang_internals.checker.errors.generic import ExpectedError, UnsupportedError
 from guppylang_internals.checker.errors.type_errors import TypeMismatchError
 from guppylang_internals.error import GuppyError, GuppyTypeError
 from guppylang_internals.tys.arg import Argument, ConstArg, TypeArg
 from guppylang_internals.tys.const import BoundConstVar, ExistentialConstVar
-from guppylang_internals.tys.errors import WrongNumberOfTypeArgsError
+from guppylang_internals.tys.errors import (
+    WrongNumberOfTypeArgsError,
+)
+from guppylang_internals.tys.protocol import ProtocolInst
 from guppylang_internals.tys.var import ExistentialVar
 
 if TYPE_CHECKING:
-    from guppylang_internals.tys.subst import PartialInst
+    from guppylang_internals.tys.subst import PartialInst, Subst
     from guppylang_internals.tys.ty import Type
 
 # We define the `Parameter` type as a union of all `ParameterBase` subclasses defined
@@ -52,7 +55,9 @@ class ParameterBase(ABC):
         """Returns a copy of the parameter with a new index."""
 
     @abstractmethod
-    def check_arg(self, arg: Argument, loc: AstNode | None = None) -> Argument:
+    def check_arg(
+        self, arg: Argument, loc: AstNode | None = None
+    ) -> "Argument | tuple[Argument, Subst]":
         """Checks that this parameter can be instantiated with a given argument.
 
         Raises a user error if the argument is not valid.
@@ -83,6 +88,7 @@ class TypeParam(ParameterBase):
 
     must_be_copyable: bool
     must_be_droppable: bool
+    must_implement: Sequence[ProtocolInst] = field(default_factory=list)
 
     @property
     def can_be_linear(self) -> bool:
@@ -93,11 +99,14 @@ class TypeParam(ParameterBase):
         """Returns a copy of the parameter with a new index."""
         return TypeParam(idx, self.name, self.must_be_copyable, self.must_be_droppable)
 
-    def check_arg(self, arg: Argument, loc: AstNode | None = None) -> TypeArg:
+    def check_arg(
+        self, arg: Argument, loc: AstNode | None = None
+    ) -> "tuple[TypeArg, Subst]":
         """Checks that this parameter can be instantiated with a given argument.
 
         Raises a user error if the argument is not valid.
         """
+        subst: Subst = {}
         match arg:
             case ConstArg(const):
                 err = ExpectedError(loc, "a type", got=f"value of type `{const.ty}`")
@@ -117,7 +126,9 @@ class TypeParam(ParameterBase):
                         got=f"type `{ty}` which is not implicitly droppable",
                     )
                     raise GuppyTypeError(err)
-                return arg
+                if self.must_implement:
+                    raise GuppyError(UnsupportedError(loc, "Protocol checking"))
+                return arg, subst
 
     def to_existential(self) -> tuple[Argument, ExistentialVar]:
         """Creates a fresh existential variable that can be instantiated for this
@@ -128,7 +139,10 @@ class TypeParam(ParameterBase):
         from guppylang_internals.tys.ty import ExistentialTypeVar
 
         var = ExistentialTypeVar.fresh(
-            self.name, self.must_be_copyable, self.must_be_droppable
+            self.name,
+            self.must_be_copyable,
+            self.must_be_droppable,
+            tuple(self.must_implement),
         )
         return TypeArg(var), var
 
@@ -141,13 +155,25 @@ class TypeParam(ParameterBase):
         if idx is None:
             idx = self.idx
         return TypeArg(
-            BoundTypeVar(self.name, idx, self.must_be_copyable, self.must_be_droppable)
+            BoundTypeVar(
+                self.name,
+                idx,
+                self.must_be_copyable,
+                self.must_be_droppable,
+                tuple(self.must_implement),
+            )
         )
 
     def instantiate_bounds(self, inst: "PartialInst") -> "TypeParam":
         """Instantiates bound variables mentioned in parameter bounds"""
         # For now, type parameters don't have any bounds that could be instantiated
-        return self
+        from guppylang_internals.tys.subst import Instantiator
+
+        impls = tuple(
+            impl.transform(Instantiator(inst)) for impl in self.must_implement
+        )
+
+        return replace(self, must_implement=impls)
 
     def __str__(self) -> str:
         """User-facing string representation of the parameter."""

--- a/guppylang-internals/src/guppylang_internals/tys/param.py
+++ b/guppylang-internals/src/guppylang_internals/tys/param.py
@@ -97,7 +97,13 @@ class TypeParam(ParameterBase):
 
     def with_idx(self, idx: int) -> "TypeParam":
         """Returns a copy of the parameter with a new index."""
-        return TypeParam(idx, self.name, self.must_be_copyable, self.must_be_droppable)
+        return TypeParam(
+            idx,
+            self.name,
+            self.must_be_copyable,
+            self.must_be_droppable,
+            self.must_implement,
+        )
 
     def check_arg(
         self, arg: Argument, loc: AstNode | None = None

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -3,6 +3,7 @@ import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from types import ModuleType
+from typing import TYPE_CHECKING, ClassVar
 
 from guppylang_internals.ast_util import (
     AstNode,
@@ -15,6 +16,7 @@ from guppylang_internals.checker.errors.generic import ExpectedError, Unsupporte
 from guppylang_internals.definition.common import Definition
 from guppylang_internals.definition.parameter import ParamDef
 from guppylang_internals.definition.ty import TypeDef
+from guppylang_internals.diagnostic import Error
 from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError
 from guppylang_internals.tys.arg import Argument, ConstArg, TypeArg
@@ -39,6 +41,7 @@ from guppylang_internals.tys.errors import (
     WrongNumberOfTypeArgsError,
 )
 from guppylang_internals.tys.param import ConstParam, Parameter, TypeParam
+from guppylang_internals.tys.protocol import ProtocolInst
 from guppylang_internals.tys.ty import (
     FuncInput,
     FunctionType,
@@ -48,6 +51,16 @@ from guppylang_internals.tys.ty import (
     TupleType,
     Type,
 )
+
+if TYPE_CHECKING:
+    from guppylang_internals.definition.protocol import ParsedProtocolDef
+
+
+@dataclass(frozen=True)
+class UnrecognisedBound(Error):
+    title: ClassVar[str] = "Unrecognised Bound"
+    span_label: ClassVar[str] = "Unrecognised type `{ty}` as type bound."
+    ty: str
 
 
 @dataclass(frozen=True)
@@ -181,6 +194,8 @@ def _arg_from_instantiated_defn(
     defn: Definition, arg_nodes: list[ast.expr], node: AstNode, ctx: TypeParsingCtx
 ) -> Argument:
     """Parses a globals definition with type args into an argument."""
+    from guppylang_internals.definition.protocol import ParsedProtocolDef
+
     match defn:
         # Special case for the `Callable` type
         case CallableTypeDef():
@@ -208,9 +223,33 @@ def _arg_from_instantiated_defn(
                 else:
                     raise GuppyError(FreeTypeVarError(node, defn))
             return ctx.param_var_mapping[defn.name].to_bound()
+        # Or a protocol in which case we need to desugar the annotation to a parameter
+        # (e.g. `x: "MyProto"` to `[MyProto: "MyProto"]`and `x: MyProto`)
+        case ParsedProtocolDef() as defn:
+            return _arg_from_proto(defn, arg_nodes, node, ctx)
         case defn:
             err = ExpectedError(node, "a type", got=f"{defn.description} `{defn.name}`")
             raise GuppyError(err)
+
+
+def _arg_from_proto(
+    proto_defn: "ParsedProtocolDef",
+    arg_nodes: list[ast.expr],
+    node: AstNode,
+    ctx: TypeParsingCtx,
+) -> Argument:
+    """Parses a protocol definition with type args into an argument."""
+    proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
+    inst = proto_defn.check_instantiate(proto_args, node)
+    param = TypeParam(
+        len(ctx.param_var_mapping),
+        proto_defn.name,
+        must_implement=[inst],
+        must_be_copyable=True,
+        must_be_droppable=True,
+    )
+    ctx.param_var_mapping[proto_defn.name] = param
+    return param.to_bound()
 
 
 def _parse_delayed_annotation(ast_str: str, node: ast.Constant) -> ast.expr:
@@ -331,24 +370,84 @@ if sys.version_info >= (3, 12):
                 )
             # Copy and drop is annotated as `T: (Copy, Drop)`
             # TODO: Should we also allow `T: Copy + Drop`? Mypy would complain about it
-            case ast.Tuple(elts=[ast.Name(id=id1), ast.Name(id=id2)]) if {id1, id2} == {
-                "Copy",
-                "Drop",
-            }:
+            case ast.Tuple(elts=elts):
+                bounds: list[ProtocolInst] = []
+                for elt in elts:
+                    match elt:
+                        case ast.Name(id="Copy"):
+                            continue
+                        case ast.Name(id="Drop"):
+                            continue
+                        case _:
+                            if proto_inst := parse_bound(
+                                elt, globals, param_var_mapping, allow_free_vars
+                            ):
+                                bounds.append(proto_inst)
+                            else:
+                                raise GuppyError(
+                                    UnrecognisedBound(elt, ast.unparse(elt))
+                                )
                 return TypeParam(
-                    idx, node.name, must_be_copyable=True, must_be_droppable=True
+                    idx,
+                    node.name,
+                    must_be_copyable=True,
+                    must_be_droppable=True,
+                    must_implement=bounds,
                 )
-            # Otherwise, it must be a const parameter
+
+            # Otherwise, it must be either a protocol or a const parameter
             case bound:
-                # For now, we don't allow the types of const params to refer to previous
-                # parameters, so we pass an empty dict as the `param_var_mapping`.
-                # TODO: In the future we might want to allow stuff like
-                #   `def foo[T, XS: array[T, 42]]` and so on
-                ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
-                ty = type_from_ast(bound, ctx)
-                if not ty.copyable or not ty.droppable:
-                    raise GuppyError(LinearConstParamError(bound, ty))
-                return ConstParam(idx, node.name, ty)
+                if proto_inst := parse_bound(
+                    bound, globals, param_var_mapping, allow_free_vars
+                ):
+                    return TypeParam(
+                        idx,
+                        node.name,
+                        must_be_copyable=True,
+                        must_be_droppable=True,
+                        must_implement=[proto_inst],
+                    )
+                else:
+                    # TODO: In the future we might want to allow stuff like
+                    #   `def foo[T, XS: array[T, 42]]` and so on
+                    ctx = TypeParsingCtx(
+                        globals, param_var_mapping, {}, allow_free_vars
+                    )
+                    ty = type_from_ast(bound, ctx)
+                    if not ty.copyable or not ty.droppable:
+                        raise GuppyError(LinearConstParamError(bound, ty))
+                    return ConstParam(idx, node.name, ty)
+
+    def parse_bound(
+        bound: ast.expr,
+        globals: Globals,
+        param_var_mapping: dict[str, Parameter],
+        allow_free_vars: bool,
+    ) -> ProtocolInst | None:
+        from guppylang_internals.definition.protocol import ParsedProtocolDef
+
+        ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
+
+        # First, try to see if this is a protocol bound by checking if can find
+        # a protocol definition with this name. In contrast to normal
+        # parameters, protocol parameters could be parametrised themselves.
+        proto_defn = None
+        proto_args = []
+        if isinstance(bound, ast.Subscript):
+            proto_defn = _try_parse_defn(bound.value, ctx.globals)
+            arg_nodes = (
+                bound.slice.elts
+                if isinstance(bound.slice, ast.Tuple)
+                else [bound.slice]
+            )
+            proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
+        else:
+            proto_defn = _try_parse_defn(bound, ctx.globals)
+
+        if isinstance(proto_defn, ParsedProtocolDef):
+            inst = proto_defn.check_instantiate(proto_args, bound)
+            return inst
+        return None
 
 
 _type_param = TypeParam(0, "T", False, False)
@@ -378,7 +477,7 @@ def type_with_flags_from_ast(
     else:
         # Parse an argument and check that it's valid for a `TypeParam`
         arg = arg_from_ast(node, ctx)
-        tyarg = _type_param.check_arg(arg, node)
+        tyarg, _ = _type_param.check_arg(arg, node)
         return tyarg.ty, InputFlags.NoFlags
 
 

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -241,14 +241,17 @@ def _arg_from_proto(
     """Parses a protocol definition with type args into an argument."""
     proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
     inst = proto_defn.check_instantiate(proto_args, node)
-    param = TypeParam(
-        len(ctx.param_var_mapping),
-        proto_defn.name,
-        must_implement=[inst],
-        must_be_copyable=True,
-        must_be_droppable=True,
-    )
-    ctx.param_var_mapping[proto_defn.name] = param
+    if proto_defn.name in ctx.param_var_mapping:
+        param = ctx.param_var_mapping[proto_defn.name]
+    else:
+        param = TypeParam(
+            len(ctx.param_var_mapping),
+            proto_defn.name,
+            must_be_copyable=True,
+            must_be_droppable=True,
+            must_implement=[inst],
+        )
+        ctx.param_var_mapping[proto_defn.name] = param
     return param.to_bound()
 
 

--- a/guppylang-internals/src/guppylang_internals/tys/protocol.py
+++ b/guppylang-internals/src/guppylang_internals/tys/protocol.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, replace
+
+from guppylang_internals.definition.common import DefId
+from guppylang_internals.tys.arg import Argument
+from guppylang_internals.tys.common import Transformer
+
+
+@dataclass(frozen=True)
+class ProtocolInst:
+    type_args: tuple[Argument, ...]
+    def_id: DefId
+
+    def transform(self, transformer: Transformer) -> "ProtocolInst":
+        new_type_args = tuple(arg.transform(transformer) for arg in self.type_args)
+        return replace(self, type_args=new_type_args)
+
+    @property
+    def copyable(self) -> bool:
+        return True
+
+    @property
+    def droppable(self) -> bool:
+        return True
+
+    @property
+    def linear(self) -> bool:
+        return False

--- a/guppylang-internals/src/guppylang_internals/tys/subst.py
+++ b/guppylang-internals/src/guppylang_internals/tys/subst.py
@@ -75,7 +75,7 @@ class Instantiator(Transformer):
             ty.idx - len(self.inst),
             ty.copyable,
             ty.droppable,
-            ty.implements,
+            [self.transform(impl) or impl for impl in ty.implements],
         )
 
     @transform.register

--- a/guppylang-internals/src/guppylang_internals/tys/subst.py
+++ b/guppylang-internals/src/guppylang_internals/tys/subst.py
@@ -71,7 +71,11 @@ class Instantiator(Transformer):
 
         # Otherwise, lower the de Bruijn index
         return BoundTypeVar(
-            ty.display_name, ty.idx - len(self.inst), ty.copyable, ty.droppable
+            ty.display_name,
+            ty.idx - len(self.inst),
+            ty.copyable,
+            ty.droppable,
+            ty.implements,
         )
 
     @transform.register

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -20,6 +20,7 @@ from guppylang_internals.tys.common import (
 )
 from guppylang_internals.tys.const import Const, ConstValue, ExistentialConstVar
 from guppylang_internals.tys.param import ConstParam, Parameter
+from guppylang_internals.tys.protocol import ProtocolInst
 from guppylang_internals.tys.var import BoundVar, ExistentialVar
 
 if TYPE_CHECKING:
@@ -193,6 +194,7 @@ class BoundTypeVar(TypeBase, BoundVar):
 
     copyable: bool
     droppable: bool
+    implements: Sequence[ProtocolInst] = field(default_factory=tuple)
 
     @property
     def bound_vars(self) -> set[BoundVar]:
@@ -236,13 +238,18 @@ class ExistentialTypeVar(ExistentialVar, TypeBase):
 
     copyable: bool
     droppable: bool
+    implements: Sequence[ProtocolInst] = field(default_factory=tuple)
 
     @classmethod
     def fresh(
-        cls, display_name: str, copyable: bool, droppable: bool
+        cls,
+        display_name: str,
+        copyable: bool,
+        droppable: bool,
+        implements: Sequence[ProtocolInst] = (),
     ) -> "ExistentialTypeVar":
         return ExistentialTypeVar(
-            display_name, next(cls._fresh_id), copyable, droppable
+            display_name, next(cls._fresh_id), copyable, droppable, implements
         )
 
     @cached_property

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -322,7 +322,7 @@ class _Guppy:
             @guppy.protocol
             class MyProtocol:
 
-                @guppy.declare
+                @guppy.require
                 def describe(self: Self) -> str: ...
         """
         defn = RawProtocolDef(DefId.fresh(), cls.__name__, None, cls)
@@ -331,7 +331,7 @@ class _Guppy:
         for val in cls.__dict__.values():
             if isinstance(val, GuppyDefinition):
                 DEF_STORE.register_type_member(defn.id, val.wrapped.name, val.id)
-        # We need the the `__firstlineno__` attribute to look up the source later.
+        # We need the `__firstlineno__` attribute to look up the source later.
         cls = _set_firstlineno(cls, frame)
         # We're pretending to return the class unchanged, but in fact we return
         # a `GuppyDefinition` that handles the comptime logic

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -33,6 +33,7 @@ from guppylang_internals.definition.parameter import (
     RawConstVarDef,
     TypeVarDef,
 )
+from guppylang_internals.definition.protocol import RawProtocolDef
 from guppylang_internals.definition.pytket_circuits import (
     RawLoadPytketDef,
     RawPytketDef,
@@ -310,6 +311,57 @@ class _Guppy:
             return GuppyEnumDefinition(defn)
 
         return _with_optional_kwargs(decorator, args, kwargs)  # type: ignore[return-value]
+
+    @dataclass_transform()
+    def protocol(self, cls: builtins.type[T]) -> builtins.type[T]:
+        """Registers a class as a Guppy protocol.
+
+        .. code-block:: python
+            from guppylang import guppy
+
+            @guppy.protocol
+            class MyProtocol:
+
+                @guppy.declare
+                def describe(self: Self) -> str: ...
+        """
+        defn = RawProtocolDef(DefId.fresh(), cls.__name__, None, cls)
+        frame = get_calling_frame()
+        DEF_STORE.register_def(defn, frame)
+        for val in cls.__dict__.values():
+            if isinstance(val, GuppyDefinition):
+                DEF_STORE.register_type_member(defn.id, val.wrapped.name, val.id)
+        # We need the the `__firstlineno__` attribute to look up the source later.
+        cls = _set_firstlineno(cls, frame)
+        # We're pretending to return the class unchanged, but in fact we return
+        # a `GuppyDefinition` that handles the comptime logic
+        return GuppyDefinition(defn)  # type: ignore[return-value]
+
+    def require(
+        self, *args: Any, **kwargs: Unpack[GuppyKwargs]
+    ) -> (
+        GuppyFunctionDefinition[P, T]
+        | Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]
+    ):
+        """Declares a required method for a protocol."""
+
+        def decorator(
+            f: Callable[P, T], kwargs: GuppyKwargs
+        ) -> GuppyFunctionDefinition[P, T]:
+            parsed = _parse_kwargs(kwargs)
+            defn = RawFunctionDecl(
+                DefId.fresh(),
+                f.__name__,
+                None,
+                f,
+                unitary_flags=parsed.flags,
+                link_name=parsed.link_name,
+                metadata=parsed.metadata,
+            )
+            DEF_STORE.register_def(defn, get_calling_frame())
+            return GuppyFunctionDefinition(defn)
+
+        return _with_optional_kwargs(decorator, args, kwargs)
 
     def type_var(
         self,
@@ -695,6 +747,19 @@ def _find_load_call(sources: SourceMap) -> Span | None:
             end = Loc(filename, lineno, max_offset)
             return Span(start, end)
     return None
+
+
+def _set_firstlineno(cls: builtins.type[T], frame: FrameType) -> builtins.type[T]:
+    """Helper function to set the `__firstlineno__` attribute on a class if it is not
+    already there.
+
+    Prior to Python 3.13, the `__firstlineno__` attribute on classes is not set.
+    However, we need this information to precisely look up the source for the
+    class later. If it's not there, we can set it from the calling frame.
+    """
+    if not hasattr(cls, "__firstlineno__"):
+        cls.__firstlineno__ = frame.f_lineno  # type: ignore[attr-defined]
+    return cls
 
 
 def custom_guppy_decorator(f: F) -> F:

--- a/tests/error/errors_on_usage/protocols.err
+++ b/tests/error/errors_on_usage/protocols.err
@@ -1,0 +1,8 @@
+Error: Unsupported (at $FILE:20:8)
+   | 
+18 | @guppy
+19 | def main() -> None:
+20 |     bar(FooStruct())
+   |         ^^^^^^^^^^^ Protocol checking is not supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/protocols.py
+++ b/tests/error/errors_on_usage/protocols.py
@@ -1,0 +1,22 @@
+from guppylang import guppy
+
+@guppy.protocol
+class Foo:
+    @guppy.require
+    def foo(self: "Foo") -> None: ...
+
+@guppy
+def bar(f: "Foo") -> None:
+    return
+
+@guppy.struct
+class FooStruct:
+    @guppy
+    def foo(self) -> None:
+        return
+
+@guppy
+def main() -> None:
+    bar(FooStruct())
+
+main.check()

--- a/tests/error/poly_errors/non_linear1.err
+++ b/tests/error/poly_errors/non_linear1.err
@@ -1,9 +1,9 @@
-Error: Not defined for linear argument (at $FILE:14:4)
+Error: Expected a copyable type (at $FILE:14:8)
    | 
 12 | @guppy
 13 | def main(q: qubit) -> None:
 14 |     foo(q)
-   |     ^^^^^^ Cannot instantiate copyable type parameter `T` in type
-   |            `forall T. T -> None` with non-copyable type `qubit`
+   |         ^ Expected a copyable type, got type `qubit` which is not
+   |           implicitly copyable
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/non_linear2.err
+++ b/tests/error/poly_errors/non_linear2.err
@@ -1,9 +1,9 @@
-Error: Not defined for linear argument (at $FILE:15:4)
+Error: Expected a copyable type (at $FILE:15:8)
    | 
 13 | @guppy
 14 | def main() -> None:
 15 |     foo(h)
-   |     ^^^^^^ Cannot instantiate copyable type parameter `T` in type
-   |            `forall T. (T -> T) -> None` with non-copyable type `qubit`
+   |         ^ Expected a copyable type, got type `qubit` which is not
+   |           implicitly copyable
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/non_linear3.err
+++ b/tests/error/poly_errors/non_linear3.err
@@ -1,10 +1,9 @@
-Error: Not defined for linear argument (at $FILE:19:4)
+Error: Expected a copyable type (at $FILE:19:8)
    | 
 17 | @guppy
 18 | def main() -> None:
 19 |     foo(h)
-   |     ^^^^^^ Cannot instantiate copyable type parameter `T` in type
-   |            `forall T. (T -> None) -> None` with non-copyable type
-   |            `qubit`
+   |         ^ Expected a copyable type, got type `qubit` which is not
+   |           implicitly copyable
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/non_linear4.err
+++ b/tests/error/poly_errors/non_linear4.err
@@ -1,9 +1,9 @@
-Error: Not defined for linear argument (at $FILE:14:4)
+Error: Expected a droppable type (at $FILE:14:8)
    | 
 12 | @guppy
 13 | def main(q: qubit) -> None:
 14 |     foo(q)
-   |     ^^^^^^ Cannot instantiate droppable type parameter `T` in type
-   |            `forall T. T -> None` with non-droppable type `qubit`
+   |         ^ Expected a droppable type, got type `qubit` which is not
+   |           implicitly droppable
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors_py312/bogus_bound.err
+++ b/tests/error/poly_errors_py312/bogus_bound.err
@@ -1,0 +1,8 @@
+Error: Unrecognised Bound (at $FILE:4:18)
+  | 
+2 | 
+3 | @guppy
+4 | def foo[T: (Copy, Bogus, Drop)](t: T) -> T:
+  |                   ^^^^^ Unrecognised type `Bogus` as type bound.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors_py312/bogus_bound.py
+++ b/tests/error/poly_errors_py312/bogus_bound.py
@@ -1,0 +1,11 @@
+from guppylang import guppy
+
+@guppy
+def foo[T: (Copy, Bogus, Drop)](t: T) -> T:
+    return t
+
+@guppy
+def main() -> None:
+    foo(42)
+
+main.check()

--- a/tests/error/poly_errors_py312/invalid_bound2.err
+++ b/tests/error/poly_errors_py312/invalid_bound2.err
@@ -1,8 +1,8 @@
-Error: Expected a type (at $FILE:5:19)
+Error: Unrecognised Bound (at $FILE:5:19)
   | 
 3 | 
 4 | @guppy.struct
 5 | class MyStruct[x: (42, 43)]:
-  |                    ^^ Expected a type, got value of type `nat`
+  |                    ^^ Unrecognised type `42` as type bound.
 
 Guppy compilation failed due to 1 previous error


### PR DESCRIPTION
Closes #1675, #1396, #1653 

BREAKING CHANGE:
(guppy-internals)
* Add an extra arg to `NonGuppyMethodError` to say which annotation needs added
* Add extra arg to `try_parse_generic_base` to specify whether we're looking for a `Generic` super or a `Protocol`
* Add a parameter to type vars saying which protocols they must implement
* Add an argument to `type_check_args`