### PR TITLE
refactor!: Delete redundant error message

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/protocol.py
+++ b/guppylang-internals/src/guppylang_internals/definition/protocol.py
@@ -54,11 +54,6 @@ class EmptyBodyHint(Help):
 
 
 @dataclass(frozen=True)
-class NoAnnotationHint(Help):
-    message: ClassVar[str] = "Protocol function definitions don't need to be annotated"
-
-
-@dataclass(frozen=True)
 class RawProtocolDef(ProtocolDef, ParsableDef):
     """A raw protocol definition that has not been parsed yet."""
 


### PR DESCRIPTION
This error was erroneously merged in #1754, but isn't needed for protocol checking. Pulling its removal into a separate PR so that #1765 can be non-breaking

BREAKING CHANGE: Remove `NoAnnotationHint` error message from `guppylang-internals`