### PR TITLE
chore: Correctly set prerelease versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,7 @@
       "package-name": "guppylang",
       "draft": false,
       "prerelease": true,
-      "prerelease-type": "alpha",
+      "prerelease-type": "a",
       "versioning": "prerelease",
       "draft-pull-request": true,
       "extra-files": [
@@ -29,7 +29,7 @@
       "package-name": "guppylang_internals",
       "draft": false,
       "prerelease": true,
-      "prerelease-type": "alpha",
+      "prerelease-type": "a",
       "versioning": "prerelease",
       "draft-pull-request": true,
       "extra-files": [

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -13,6 +13,7 @@
       "draft": false,
       "prerelease": true,
       "prerelease-type": "alpha",
+      "versioning": "prerelease",
       "draft-pull-request": true,
       "extra-files": [
         {
@@ -29,6 +30,7 @@
       "draft": false,
       "prerelease": true,
       "prerelease-type": "alpha",
+      "versioning": "prerelease",
       "draft-pull-request": true,
       "extra-files": [
         {


### PR DESCRIPTION
Corrects the setup for prerelease versions by including the `prerelease` versioning strategy. Also shortens the `alpha` identifier to `a` to more closely comply with the versioning recommendations: https://packaging.python.org/en/latest/discussions/versioning/.

However, we cannot be fully compliant with `release-please`: It always inserts a `-` in front of the version and on the first release does not insert a number (so the next release is `1.0.0-a`), when instead we need no dash, but a number (so it should be `1.0.0a0`. `release-please` also does not recognise any custom pre-release segments without `-`. It seems that maybe this tool is not particularly fit for dealing with Python packages...

EDIT: After reading https://packaging.python.org/en/latest/specifications/version-specifiers/#pre-release-separators, seems fine to allow separators, and omitting the number. In our case, to avoid confusion, we want to include the number anyway, so for the first release in each series we will have to manually add it.

Closes #1771

BEGIN_COMMIT_OVERRIDE
chore: Correctly set prerelease versioning
Release-As: 1.0.0-a0
END_COMMIT_OVERRIDE