### PR TITLE
fix!: Mark partial functions as experimental

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -107,6 +107,7 @@ from guppylang_internals.error import (
 from guppylang_internals.experimental import (
     check_function_tensors_enabled,
     check_lists_enabled,
+    check_partial_functions_enabled,
 )
 from guppylang_internals.nodes import (
     ComptimeExpr,
@@ -344,6 +345,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
 
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):
+            check_partial_functions_enabled(node.func)
             node.args = [*node.func.args, *node.args]
             node.func = node.func.func
             return self.visit_Call(node, ty)

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -107,7 +107,6 @@ from guppylang_internals.error import (
 from guppylang_internals.experimental import (
     check_function_tensors_enabled,
     check_lists_enabled,
-    check_partial_functions_enabled,
 )
 from guppylang_internals.nodes import (
     ComptimeExpr,
@@ -345,7 +344,6 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
 
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):
-            check_partial_functions_enabled(node.func)
             node.args = [*node.func.args, *node.args]
             node.func = node.func.func
             return self.visit_Call(node, ty)

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -38,6 +38,7 @@ from guppylang_internals.definition.value import (
 )
 from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError, InternalGuppyError
+from guppylang_internals.experimental import check_partial_functions_enabled
 from guppylang_internals.nodes import (
     AbortExpr,
     AbortKind,
@@ -457,6 +458,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         raise InternalGuppyError("Node should have been removed during type checking.")
 
     def visit_PartialApply(self, node: PartialApply) -> Wire:
+        check_partial_functions_enabled(node)
         func_ty = get_type(node.func)
         assert isinstance(func_ty, FunctionType)
         op = PartialOp.from_closure(

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -7,6 +7,7 @@ from hugr.build.function import Function
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.hugr_extension import PartialOp
+from guppylang_internals.experimental import check_partial_functions_enabled
 from guppylang_internals.nodes import CheckedNestedFunctionDef
 
 if TYPE_CHECKING:
@@ -56,6 +57,7 @@ def compile_local_func_def(
     # variable
     call_args: list[Wire] = list(func_builder.inputs())
     if len(captured) > 0 and recursive:
+        check_partial_functions_enabled()
         loaded = func_builder.load_function(func_builder, closure_ty)
         partial = func_builder.add_op(
             PartialOp.from_closure(closure_ty, captured_types),
@@ -90,6 +92,7 @@ def compile_local_func_def(
     # Finally, load the function into the local data-flow graph
     loaded = dfg.builder.load_function(func_builder, closure_ty)
     if len(captured) > 0:
+        check_partial_functions_enabled()
         loaded = dfg.builder.add_op(
             PartialOp.from_closure(closure_ty, captured_types),
             loaded,

--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -77,6 +77,11 @@ class ExperimentalFeatureError(Error):
         self.add_sub_diagnostic(ExperimentalFeatureError.Suggestion(None))
 
 
+def check_partial_functions_enabled(node: expr | None = None) -> None:
+    if not EXPERIMENTAL_FEATURES_ENABLED:
+        raise GuppyError(ExperimentalFeatureError(node, "Partial functions"))
+
+
 def check_function_tensors_enabled(node: expr | None = None) -> None:
     if not EXPERIMENTAL_FEATURES_ENABLED:
         raise GuppyError(ExperimentalFeatureError(node, "Function tensors"))

--- a/tests/error/experimental_errors/partial_function.err
+++ b/tests/error/experimental_errors/partial_function.err
@@ -1,0 +1,12 @@
+Error: Experimental feature (at $FILE:17:14)
+   | 
+15 | def main() -> None:
+16 |     t = MyStruct()
+17 |     takes_int(t.will_be_partial)
+   |               ^^^^^^^^^^^^^^^^^ Partial functions are an experimental feature
+
+Help: Experimental features are currently disabled. You can enable them by
+calling `guppylang.enable_experimental_features()`, however note that these
+features are unstable and might break in the future.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/partial_function.py
+++ b/tests/error/experimental_errors/partial_function.py
@@ -1,0 +1,19 @@
+from guppylang.decorator import guppy
+from typing import Callable
+
+@guppy.struct
+class MyStruct:
+    @guppy
+    def will_be_partial(self, a: int) -> None:
+        pass
+
+@guppy
+def takes_int(func: Callable[[int], None]) -> None:
+    pass
+
+@guppy
+def main() -> None:
+    t = MyStruct()
+    takes_int(t.will_be_partial)
+
+main.compile()


### PR DESCRIPTION
There are a few cases that we can handle partial functions in, i.e. when the actual call is not partial (such as `qubits.take(i)`. However, passing partial function values is unsupported lower down the stack, so we must mark them as experimental for now. 

Closes #1772

BREAKING CHANGE: Marks a feature that was non-experimental (but was not executable) as experimental.