### PR TITLE
chore: Do not run benchmarks on PR edit

### DIFF
--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -2,7 +2,7 @@ name: Benchmark PRs
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 
 env:
   UV_VERSION: "0.9.5"


### PR DESCRIPTION
The inclusion of `edited` caused the benchmarks to run on every change of the PR title, which quickly blocks all runners available in the GH org.