### PR TITLE
feat!: Mutable structs

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/errors/linearity.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/linearity.py
@@ -56,6 +56,27 @@ class AlreadyUsedError(Error):
 
 
 @dataclass(frozen=True)
+class ParentAlreadyUsedError(Error):
+    title: ClassVar[str] = "Copy violation"
+    span_label: ClassVar[str] = "{place.describe} cannot be {kind.subjunctive} ..."
+    place: Place
+    kind: UseKind
+
+    @dataclass(frozen=True)
+    class ParentUse(Note):
+        span_label: ClassVar[str] = (
+            "... since {parent_place_lower} with non-copyable type `{parent_place.ty}` "
+            "was already {use_kind.subjunctive} here"
+        )
+        parent_place: Place
+        use_kind: UseKind
+
+        @property
+        def parent_place_lower(self) -> str:
+            return self.parent_place.describe.lower()
+
+
+@dataclass(frozen=True)
 class ComprAlreadyUsedError(Error):
     title: ClassVar[str] = "Copy violation"
     span_label: ClassVar[str] = (

--- a/guppylang-internals/src/guppylang_internals/checker/errors/type_errors.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/type_errors.py
@@ -125,6 +125,13 @@ class ModuleMemberNotFoundError(Error):
 
 
 @dataclass(frozen=True)
+class StructImmutableError(Error):
+    title: ClassVar[str] = "Immutable"
+    span_label: ClassVar[str] = "Struct `{ty}` is immutable"
+    ty: Type
+
+
+@dataclass(frozen=True)
 class AttributeNotFoundError(Error):
     title: ClassVar[str] = "Attribute not found"
     span_label: ClassVar[str] = "`{ty}` has no {element_name} `{attribute}`"

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -706,8 +706,8 @@ class BBLinearityChecker(ast.NodeVisitor):
         # On the other hand, we have to ensure that no linear places from the
         # outer scope have been used inside the comprehension (they would be used
         # multiple times since the comprehension body is executed repeatedly)
-        for x, use in inner_scope.used_parent.items():
-            place = inner_scope[x]
+        for use in inner_scope.used_parent.values():
+            place = use.origin_place
             # The only exception are values that are only borrowed from the outer
             # scope. These can be safely reassigned.
             if use.kind == UseKind.BORROW:

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -1008,7 +1008,6 @@ def check_cfg_linearity(
                 place = use_scope[x]
                 use = use_scope.used_parent[x]
                 if not place.ty.copyable and (prev_use := scope.used(x)):
-                    use = use_scope.used_parent[x]
                     # Special case if this is a use arising from the implicit returning
                     # of a borrowed argument
                     if isinstance(use.node, InoutReturnSentinel):

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -138,6 +138,11 @@ class Use(NamedTuple):
     #: The kind of use, i.e. is the value consumed, borrowed, returned, ...?
     kind: UseKind
 
+    #: Reference to the original place that invoked the use. For example, the use of a
+    #: struct is tracked as uses of all their leaf projections, but for each of them,
+    #: we remember the original root place that was actually used here.
+    origin_place: Place
+
 
 class Scope(Locals[PlaceId, Place]):
     """Scoped collection of assigned places indexed by their id.
@@ -171,7 +176,9 @@ class Scope(Locals[PlaceId, Place]):
             return self.parent_scope.used(x)
         return None
 
-    def use_leaf(self, place: Place, node: AstNode, kind: UseKind) -> None:
+    def use_leaf(
+        self, place: Place, node: AstNode, kind: UseKind, origin_place: Place
+    ) -> None:
         """Records a use of a leaf place.
 
         Works for places in the current scope as well as places in any parent scope.
@@ -179,12 +186,12 @@ class Scope(Locals[PlaceId, Place]):
         assert not immediate_child_places(place), "Must be a leaf"
         x = place.id
         if x in self.vars:
-            self.used_local[x] = Use(node, kind)
+            self.used_local[x] = Use(node, kind, place)
         else:
             assert self.parent_scope is not None
             assert x in self.parent_scope
-            self.used_parent[x] = Use(node, kind)
-            self.parent_scope.use_leaf(place, node, kind)
+            self.used_parent[x] = Use(node, kind, origin_place)
+            self.parent_scope.use_leaf(place, node, kind, origin_place)
 
     def use(self, place: Place, node: AstNode, kind: UseKind) -> None:
         """Records a use of a place.
@@ -192,9 +199,9 @@ class Scope(Locals[PlaceId, Place]):
         Works for places in the current scope as well as places in any parent scope.
         """
         for leaf in leaf_places(place):
-            self.use_leaf(leaf, node, kind)
+            self.use_leaf(leaf, node, kind, place)
         for proj in projections(place):
-            self.used_projections[proj.id] = Use(node, kind)
+            self.used_projections[proj.id] = Use(node, kind, place)
 
     def assign_leaf(self, place: Place) -> None:
         """Records an assignment of a leaf place."""
@@ -350,7 +357,7 @@ class BBLinearityChecker(ast.NodeVisitor):
                     raise GuppyError(err)
 
             # Also check if parents have been moved
-            use = Use(node, use_kind)
+            use = Use(node, use_kind, node.place)
             check_mutable_parent_already_used(node.place, use, self.scope)
 
             # Finally, mark the place as used
@@ -922,7 +929,7 @@ def check_mutable_parent_already_used(place: Place, use: Use, scope: Scope) -> N
             case _:
                 mutable = False
         if mutable and (prev_use := scope.used(parent.id)):
-            err = ParentAlreadyUsedError(use.node, place, use.kind)
+            err = ParentAlreadyUsedError(use.node, use.origin_place, use.kind)
             sub = ParentAlreadyUsedError.ParentUse(prev_use.node, parent, prev_use.kind)
             err.add_sub_diagnostic(sub)
             raise GuppyError(err)

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -782,9 +782,13 @@ def leaf_places(place: Place) -> Iterator[Place]:
     while stack:
         place = stack.pop()
         if isinstance(place.ty, StructType):
-            stack += [
-                FieldAccess(place, field, place.defined_at) for field in place.ty.fields
-            ]
+            if place.ty.fields:
+                stack += [
+                    FieldAccess(place, field, place.defined_at)
+                    for field in place.ty.fields
+                ]
+            else:
+                yield place
         elif isinstance(place.ty, TupleType):
             stack += [
                 TupleAccess(place, elem_ty, idx, None)

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -926,14 +926,13 @@ def check_mutable_parent_already_used(place: Place, use: Use, scope: Scope) -> N
     for parent in parent_places(place, include_self=True):
         match parent.ty:
             case StructType(frozen=False):
-                mutable = True
-            case _:
-                mutable = False
-        if mutable and (prev_use := scope.used(parent.id)):
-            err = ParentAlreadyUsedError(use.node, use.origin_place, use.kind)
-            sub = ParentAlreadyUsedError.ParentUse(prev_use.node, parent, prev_use.kind)
-            err.add_sub_diagnostic(sub)
-            raise GuppyError(err)
+                if prev_use := scope.used(parent.id):
+                    err = ParentAlreadyUsedError(use.node, use.origin_place, use.kind)
+                    sub = ParentAlreadyUsedError.ParentUse(
+                        prev_use.node, parent, prev_use.kind
+                    )
+                    err.add_sub_diagnostic(sub)
+                    raise GuppyError(err)
 
 
 def check_cfg_linearity(

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -314,9 +314,8 @@ class BBLinearityChecker(ast.NodeVisitor):
         # Places involving subscripts are handled differently since we ignore everything
         # after the subscript for the purposes of linearity checking.
         if subscript := contains_subscript(node.place):
-            # We have to check the item type to determine if we can move out of the
-            # subscript.
-            if not is_inout_arg and not subscript.ty.copyable:
+            # We are only allowed to move copyable data out of a subscript
+            if not is_inout_arg and not node.place.ty.copyable:
                 err = MoveOutOfSubscriptError(node, use_kind, subscript.parent)
                 err.add_sub_diagnostic(MoveOutOfSubscriptError.Explanation(None))
                 raise GuppyError(err)

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -40,6 +40,7 @@ from guppylang_internals.checker.errors.linearity import (
     NonCopyableCaptureError,
     NonCopyablePartialApplyError,
     NotOwnedError,
+    ParentAlreadyUsedError,
     PlaceNotUsedError,
     UnnamedExprNotUsedError,
     UnnamedFieldNotUsedError,
@@ -145,20 +146,30 @@ class Scope(Locals[PlaceId, Place]):
     """
 
     parent_scope: "Scope | None"
+
+    #: Tracks all leaf projections of used places that were defined in this scope
     used_local: dict[PlaceId, Use]
+
+    #: Tracks all leaf projections of used places that were defined in a parent scope
     used_parent: dict[PlaceId, Use]
+
+    #: Tracks all projections (not just the leaves) of used places. Includes places
+    #: defined in this or any parent scope
+    used_projections: dict[PlaceId, Use]
 
     def __init__(self, parent: "Scope | None" = None):
         self.used_local = {}
         self.used_parent = {}
+        self.used_projections = {}
         super().__init__({}, parent)
 
     def used(self, x: PlaceId) -> Use | None:
         """Checks whether a place has already been used."""
-        if x in self.vars:
-            return self.used_local.get(x, None)
-        assert self.parent_scope is not None
-        return self.parent_scope.used(x)
+        if x in self.used_projections:
+            return self.used_projections[x]
+        if self.parent_scope:
+            return self.parent_scope.used(x)
+        return None
 
     def use_leaf(self, place: Place, node: AstNode, kind: UseKind) -> None:
         """Records a use of a leaf place.
@@ -182,6 +193,8 @@ class Scope(Locals[PlaceId, Place]):
         """
         for leaf in leaf_places(place):
             self.use_leaf(leaf, node, kind)
+        for proj in projections(place):
+            self.used_projections[proj.id] = Use(node, kind)
 
     def assign_leaf(self, place: Place) -> None:
         """Records an assignment of a leaf place."""
@@ -196,6 +209,8 @@ class Scope(Locals[PlaceId, Place]):
         """Records an assignment of a place."""
         for leaf in leaf_places(place):
             self.assign_leaf(leaf)
+        for proj in projections(place):
+            self.used_projections.pop(proj.id, None)
 
     def stats(self) -> VariableStats[PlaceId]:
         assigned = {}
@@ -334,6 +349,10 @@ class BBLinearityChecker(ast.NodeVisitor):
                     if has_explicit_copy(place.ty):
                         err.add_sub_diagnostic(AlreadyUsedError.MakeCopy(None))
                     raise GuppyError(err)
+
+            # Also check if parents have been moved
+            use = Use(node, use_kind)
+            check_mutable_parent_already_used(node.place, use, self.scope)
 
             # Finally, mark the place as used
             self.scope.use(node.place, node, use_kind)
@@ -689,6 +708,9 @@ class BBLinearityChecker(ast.NodeVisitor):
             elif not place.ty.copyable:
                 raise GuppyTypeError(ComprAlreadyUsedError(use.node, place, use.kind))
 
+            # Also check if parents have been moved
+            check_mutable_parent_already_used(place, use, self.scope)
+
     def visit_CheckedModifiedBlock(self, node: CheckedModifiedBlock) -> None:
         # Linear usage of variables in a with statement
         # ```
@@ -773,6 +795,32 @@ def leaf_places(place: Place) -> Iterator[Place]:
             yield place
 
 
+def parent_places(place: Place, /, include_self: bool = False) -> Iterator[Place]:
+    """Returns an iterator over all parents of the given place, optionally including the
+    given place itself."""
+    if include_self:
+        yield place
+    while not isinstance(place, Variable):
+        yield place.parent
+        place = place.parent
+
+
+def projections(place: Place, /, include_self: bool = True) -> Iterator[Place]:
+    """Returns an iterator over the tree of all possible descendant projections of the
+    given place.
+
+    Includes the given place itself by default.
+    """
+    if include_self:
+        yield place
+    stack = [place]
+    while stack:
+        place = stack.pop()
+        children = immediate_child_places(place)
+        yield from children
+        stack += children
+
+
 def immediate_child_places(place: Place) -> list[Place]:
     """Returns a list of all immediate child projections of the given place."""
     if isinstance(place.ty, StructType):
@@ -855,6 +903,26 @@ def is_simple_literal_subscript(
         return None
 
     return (subscript, literal_idx)
+
+
+def check_mutable_parent_already_used(place: Place, use: Use, scope: Scope) -> None:
+    """Helper function to check uses of mutable projections.
+
+    If the given place is a projection of a mutable place, then we need to check that
+    the parent has not been moved. Note that this is independent of whether the
+    projection itself has an affine type.
+    """
+    for parent in parent_places(place, include_self=True):
+        match parent.ty:
+            case StructType(frozen=False):
+                mutable = True
+            case _:
+                mutable = False
+        if mutable and (prev_use := scope.used(parent.id)):
+            err = ParentAlreadyUsedError(use.node, place, use.kind)
+            sub = ParentAlreadyUsedError.ParentUse(prev_use.node, parent, prev_use.kind)
+            err.add_sub_diagnostic(sub)
+            raise GuppyError(err)
 
 
 def check_cfg_linearity(
@@ -953,6 +1021,9 @@ def check_cfg_linearity(
                     if has_explicit_copy(place.ty):
                         err.add_sub_diagnostic(AlreadyUsedError.MakeCopy(None))
                     raise GuppyError(err)
+
+                # Also check if parents have been moved
+                check_mutable_parent_already_used(place, use, scope)
 
         # On the other hand, unused variables that are not droppable *must* be outputted
         for place in scope.values():

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -150,6 +150,7 @@ class Scope(Locals[PlaceId, Place]):
     Keeps track of which places have already been used.
     """
 
+    #: Enclosing scope tracking variables defined in other basic blocks
     parent_scope: "Scope | None"
 
     #: Tracks all leaf projections of used places that were defined in this scope

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -160,26 +160,42 @@ class Scope(Locals[PlaceId, Place]):
         assert self.parent_scope is not None
         return self.parent_scope.used(x)
 
-    def use(self, x: PlaceId, node: AstNode, kind: UseKind) -> None:
-        """Records a use of a place.
+    def use_leaf(self, place: Place, node: AstNode, kind: UseKind) -> None:
+        """Records a use of a leaf place.
 
         Works for places in the current scope as well as places in any parent scope.
         """
+        assert not immediate_child_places(place), "Must be a leaf"
+        x = place.id
         if x in self.vars:
             self.used_local[x] = Use(node, kind)
         else:
             assert self.parent_scope is not None
             assert x in self.parent_scope
             self.used_parent[x] = Use(node, kind)
-            self.parent_scope.use(x, node, kind)
+            self.parent_scope.use_leaf(place, node, kind)
 
-    def assign(self, place: Place) -> None:
-        """Records an assignment of a place."""
+    def use(self, place: Place, node: AstNode, kind: UseKind) -> None:
+        """Records a use of a place.
+
+        Works for places in the current scope as well as places in any parent scope.
+        """
+        for leaf in leaf_places(place):
+            self.use_leaf(leaf, node, kind)
+
+    def assign_leaf(self, place: Place) -> None:
+        """Records an assignment of a leaf place."""
         assert place.defined_at is not None
+        assert not immediate_child_places(place), "Must be a leaf"
         x = place.id
         self.vars[x] = place
         if x in self.used_local:
             self.used_local.pop(x)
+
+    def assign(self, place: Place) -> None:
+        """Records an assignment of a place."""
+        for leaf in leaf_places(place):
+            self.assign_leaf(leaf)
 
     def stats(self) -> VariableStats[PlaceId]:
         assigned = {}
@@ -215,8 +231,7 @@ class BBLinearityChecker(ast.NodeVisitor):
         # of this BB
         input_scope = Scope()
         for var in bb.sig.input_row:
-            for place in leaf_places(var):
-                input_scope.assign(place)
+            input_scope.assign(var)
         self.func_name = func_name
         self.func_inputs = func_inputs
         self.globals = globals
@@ -319,7 +334,9 @@ class BBLinearityChecker(ast.NodeVisitor):
                     if has_explicit_copy(place.ty):
                         err.add_sub_diagnostic(AlreadyUsedError.MakeCopy(None))
                     raise GuppyError(err)
-                self.scope.use(x, node, use_kind)
+
+            # Finally, mark the place as used
+            self.scope.use(node.place, node, use_kind)
 
     def visit_Assign(self, node: ast.Assign) -> None:
         self.visit(node.value)
@@ -417,17 +434,15 @@ class BBLinearityChecker(ast.NodeVisitor):
         if subscript := contains_subscript(place):
             if visit_setitem:
                 assert subscript.setitem_call is not None
-                for leaf in leaf_places(subscript.setitem_call.value_var):
-                    self.scope.assign(leaf)
+                self.scope.assign(subscript.setitem_call.value_var)
                 self.visit(subscript.setitem_call.call)
             self._reassign_single_inout_arg(
                 subscript.parent, node, visit_setitem=visit_setitem
             )
         else:
-            for leaf in leaf_places(place):
-                assert not isinstance(leaf, SubscriptAccess)
-                leaf = leaf.replace_defined_at(node)
-                self.scope.assign(leaf)
+            assert not isinstance(place, SubscriptAccess)
+            place = place.replace_defined_at(node)
+            self.scope.assign(place)
 
     def _call_name(self, node: AnyCall | None) -> str | None:
         """Tries to extract the name of a called function from a call AST node."""
@@ -545,8 +560,7 @@ class BBLinearityChecker(ast.NodeVisitor):
                     NonCopyableCaptureError.DefinedHere(var.defined_at)
                 )
                 raise GuppyError(err)
-            for place in leaf_places(var):
-                self.scope.use(place.id, use, UseKind.COPY)
+            self.scope.use(var, use, UseKind.COPY)
         self.scope.assign(Variable(node.name, node.ty, node))
 
     def _check_assign_targets(self, targets: list[ast.expr]) -> None:
@@ -579,7 +593,7 @@ class BBLinearityChecker(ast.NodeVisitor):
                             err = PlaceNotUsedError(place.defined_at, place)
                             err.add_sub_diagnostic(PlaceNotUsedError.Fix(None))
                             raise GuppyError(err)
-                    self.scope.assign(tgt_place)
+                self.scope.assign(tgt.place)
 
     def _check_comprehension(
         self, gens: list[DesugaredGenerator], elt: ast.expr
@@ -650,14 +664,10 @@ class BBLinearityChecker(ast.NodeVisitor):
                     # borrow expires.
                     # Also mark this place as implicitly used so we don't complain about
                     # it later.
-                    for leaf in leaf_places(place):
-                        inner_scope.use(
-                            leaf.id, InoutReturnSentinel(leaf), UseKind.RETURN
-                        )
+                    inner_scope.use(place, InoutReturnSentinel(place), UseKind.RETURN)
 
             # Mark the iterator as used since it's carried into the next iteration
-            for leaf in leaf_places(gen.iter.place):
-                self.scope.use(leaf.id, gen.iter, UseKind.CONSUME)
+            self.scope.use(gen.iter.place, gen.iter, UseKind.CONSUME)
 
             # We have to make sure that all linear variables that were introduced in the
             # inner scope have been used
@@ -716,11 +726,10 @@ class BBLinearityChecker(ast.NodeVisitor):
 
         # check captured variables
         for var, use in node.captured.values():
+            use_kind = (
+                UseKind.BORROW if InputFlags.Inout in var.flags else UseKind.CONSUME
+            )
             for place in leaf_places(var):
-                use_kind = (
-                    UseKind.BORROW if InputFlags.Inout in var.flags else UseKind.CONSUME
-                )
-
                 x = place.id
                 if (prev_use := self.scope.used(x)) and not place.ty.copyable:
                     used_err = AlreadyUsedError(use, place, use_kind)
@@ -730,7 +739,7 @@ class BBLinearityChecker(ast.NodeVisitor):
                     if has_explicit_copy(place.ty):
                         used_err.add_sub_diagnostic(AlreadyUsedError.MakeCopy(None))
                     raise GuppyError(used_err)
-                self.scope.use(x, node, use_kind)
+            self.scope.use(var, node, use_kind)
 
         # reassign controls
         for ctrl in node.control:
@@ -762,6 +771,20 @@ def leaf_places(place: Place) -> Iterator[Place]:
             ]
         else:
             yield place
+
+
+def immediate_child_places(place: Place) -> list[Place]:
+    """Returns a list of all immediate child projections of the given place."""
+    if isinstance(place.ty, StructType):
+        return [
+            FieldAccess(place, field, place.defined_at) for field in place.ty.fields
+        ]
+    elif isinstance(place.ty, TupleType):
+        return [
+            TupleAccess(place, elem_ty, idx, None)
+            for idx, elem_ty in enumerate(place.ty.element_types)
+        ]
+    return []
 
 
 def is_inout_var(place: Place) -> TypeGuard[Variable]:
@@ -865,8 +888,7 @@ def check_cfg_linearity(
     exit_scope = scopes[cfg.exit_bb]
     for var in cfg.entry_bb.sig.input_row:
         if InputFlags.Inout in var.flags:
-            for leaf in leaf_places(var):
-                exit_scope.use(leaf.id, InoutReturnSentinel(var=var), UseKind.RETURN)
+            exit_scope.use(var, InoutReturnSentinel(var=var), UseKind.RETURN)
 
     # Edge case: If the exit is unreachable, then the function will never terminate, so
     # there is no need to give the borrowed values back to the caller. To ensure that
@@ -906,6 +928,7 @@ def check_cfg_linearity(
             for x, use_bb in live.items():
                 use_scope = scopes[use_bb]
                 place = use_scope[x]
+                use = use_scope.used_parent[x]
                 if not place.ty.copyable and (prev_use := scope.used(x)):
                     use = use_scope.used_parent[x]
                     # Special case if this is a use arising from the implicit returning

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -41,6 +41,7 @@ from guppylang_internals.checker.errors.type_errors import (
     AttributeNotFoundError,
     MissingReturnValueError,
     StarredTupleUnpackError,
+    StructImmutableError,
     TypeInferenceError,
     TypeMismatchError,
     UnpackableError,
@@ -176,12 +177,11 @@ class StmtChecker(AstVisitor[BBStatement]):
             err = UnsupportedError(value, "Assigning to this expression", singular=True)
             err.add_sub_diagnostic(AssignNonPlaceHelp(None, field))
             raise GuppyError(err)
-        if field.ty.copyable:
-            raise GuppyError(
-                UnsupportedError(
-                    attr_span, "Mutation of classical fields", singular=True
-                )
-            )
+        # TODO: To avoid breakage, we currently allow mutation of non-copyable fields,
+        #  even if `frozen` is set. For the 1.0 release, we should drop the extra
+        #  `field.ty.copyable` check below:
+        if struct_ty.frozen and field.ty.copyable:  # Just `if struct_ty.frozen:` in 1.0
+            raise GuppyTypeError(StructImmutableError(lhs, struct_ty))
         place = FieldAccess(value.place, struct_ty.field_dict[attr], lhs)
         place = check_place_assignable(place, self.ctx, lhs, "assignable")
         return with_loc(lhs, with_type(rhs_ty, PlaceNode(place=place)))

--- a/guppylang-internals/src/guppylang_internals/definition/struct.py
+++ b/guppylang-internals/src/guppylang_internals/definition/struct.py
@@ -62,6 +62,7 @@ class RawStructDef(TypeDef, ParsableDef, UserProvidedLinkName):
     """A raw struct type definition that has not been parsed yet."""
 
     python_class: type
+    frozen: bool
     params: None = field(default=None, init=False)  # Params not known yet
 
     def parse(self, globals: Globals, sources: SourceMap) -> "ParsedStructDef":
@@ -136,7 +137,7 @@ class RawStructDef(TypeDef, ParsableDef, UserProvidedLinkName):
         )
 
         return ParsedStructDef(
-            self.id, self.name, cls_def, params, fields, link_name_prefix
+            self.id, self.name, cls_def, params, fields, self.frozen, link_name_prefix
         )
 
     def check_instantiate(
@@ -152,6 +153,7 @@ class ParsedStructDef(TypeDef, CheckableDef):
     defined_at: ast.ClassDef
     params: Sequence[Parameter]
     fields: Sequence[UncheckedField]
+    frozen: bool
     link_name_prefix: str
 
     def check(self, globals: Globals) -> "CheckedStructDef":
@@ -168,7 +170,7 @@ class ParsedStructDef(TypeDef, CheckableDef):
             CheckedField(f.name, type_from_ast(f.type_ast, ctx)) for f in self.fields
         ]
         return CheckedStructDef(
-            self.id, self.name, self.defined_at, self.params, fields
+            self.id, self.name, self.defined_at, self.params, fields, self.frozen
         )
 
     def check_instantiate(
@@ -195,6 +197,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
     defined_at: ast.ClassDef
     params: Sequence[Parameter]
     fields: Sequence[CheckedField]
+    frozen: bool
 
     def check_instantiate(
         self, args: Sequence[Argument], loc: AstNode | None = None

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -720,6 +720,11 @@ class StructType(ParametrizedTypeBase):
         """Whether objects of this type can be dropped."""
         return all(f.ty.droppable for f in self.fields)
 
+    @property
+    def frozen(self) -> bool:
+        """Whether objects of this type are immutable."""
+        return self.defn.frozen
+
     def cast(self) -> "Type":
         """Casts an implementor of `TypeBase` into a `Type`."""
         return self

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -712,8 +712,8 @@ class StructType(ParametrizedTypeBase):
 
     @cached_property
     def intrinsically_copyable(self) -> bool:
-        """Whether objects of this type can be  implicitly copied."""
-        return all(f.ty.copyable for f in self.fields)
+        """Whether objects of this type can be implicitly copied."""
+        return self.frozen and all(f.ty.copyable for f in self.fields)
 
     @cached_property
     def intrinsically_droppable(self) -> bool:

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -106,6 +106,7 @@ class GuppyStructKwargs(TypedDict, total=False):
     `@guppy.struct` decorator.
     """
 
+    frozen: bool
     link_name: str
 
 
@@ -250,6 +251,7 @@ class _Guppy:
                 cls.__name__,
                 None,
                 cls,
+                frozen=kwargs.pop("frozen", True),  # Immutable by default
                 link_name=kwargs.pop("link_name", None),
             )
             frame = get_calling_frame()

--- a/tests/error/comprehension_errors/capture3.err
+++ b/tests/error/comprehension_errors/capture3.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:13:12)
 11 | @guppy
 12 | def foo(xs: list[int], s: MyStruct @owned) -> list[MyStruct]:
 13 |     return [s for x in xs]
-   |             ^ Field `s.q` with non-copyable type `qubit` would be moved
-   |               multiple times when evaluating this comprehension
+   |             ^ Variable `s` with non-copyable type `MyStruct` would be
+   |               moved multiple times when evaluating this comprehension
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct1.err
+++ b/tests/error/comprehension_errors/mutable_struct1.err
@@ -1,0 +1,9 @@
+Error: Copy violation (at $FILE:12:5)
+   | 
+10 | @guppy
+11 | def foo(s: MyStruct @ owned) -> None:
+12 |     [s for _ in range(10)]
+   |      ^ Variable `s` with non-copyable type `MyStruct` would be
+   |        moved multiple times when evaluating this comprehension
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct1.py
+++ b/tests/error/comprehension_errors/mutable_struct1.py
@@ -1,0 +1,16 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @ owned) -> None:
+    [s for _ in range(10)]
+
+
+
+foo.compile()

--- a/tests/error/comprehension_errors/mutable_struct2.err
+++ b/tests/error/comprehension_errors/mutable_struct2.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:16:5)
+   | 
+14 | @guppy
+15 | def foo(ss: list[MyStruct] @ owned) -> None:
+16 |     [s.x for s in ss if bar(s)]
+   |      ^^^ Field `s.x` cannot be moved ...
+
+Note:
+   | 
+15 | def foo(ss: list[MyStruct] @ owned) -> None:
+16 |     [s.x for s in ss if bar(s)]
+   |                             - ... since variable `s` with non-copyable type `MyStruct` was
+   |                               already consumed here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct2.py
+++ b/tests/error/comprehension_errors/mutable_struct2.py
@@ -1,0 +1,19 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy.declare
+def bar(s: MyStruct @ owned) -> bool: ...
+
+
+@guppy
+def foo(ss: list[MyStruct] @ owned) -> None:
+    [s.x for s in ss if bar(s)]
+
+
+foo.compile()

--- a/tests/error/comprehension_errors/mutable_struct3.err
+++ b/tests/error/comprehension_errors/mutable_struct3.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:17:5)
+   | 
+15 | def foo(s: MyStruct @ owned) -> None:
+16 |     t = s
+17 |     [s.x for _ in range(10)]
+   |      ^^^ Field `s.x` cannot be moved ...
+
+Note:
+   | 
+15 | def foo(s: MyStruct @ owned) -> None:
+16 |     t = s
+   |         - ... since variable `s` with non-copyable type `MyStruct` was
+   |           already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct3.py
+++ b/tests/error/comprehension_errors/mutable_struct3.py
@@ -1,0 +1,20 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy.declare
+def bar(s: MyStruct @ owned) -> bool: ...
+
+
+@guppy
+def foo(s: MyStruct @ owned) -> None:
+    t = s
+    [s.x for _ in range(10)]
+
+
+foo.compile()

--- a/tests/error/comprehension_errors/mutable_struct4.err
+++ b/tests/error/comprehension_errors/mutable_struct4.err
@@ -1,0 +1,9 @@
+Error: Copy violation (at $FILE:16:33)
+   | 
+14 | @guppy
+15 | def foo(s: MyStruct @ owned) -> None:
+16 |     [0 for _ in range(10) if bar(s)]
+   |                                  ^ Variable `s` with non-copyable type `MyStruct` would be
+   |                                    consumed multiple times when evaluating this comprehension
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct4.py
+++ b/tests/error/comprehension_errors/mutable_struct4.py
@@ -1,0 +1,19 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy.declare
+def bar(s: MyStruct @ owned) -> bool: ...
+
+
+@guppy
+def foo(s: MyStruct @ owned) -> None:
+    [0 for _ in range(10) if bar(s)]
+
+
+foo.compile()

--- a/tests/error/comprehension_errors/mutable_struct5.err
+++ b/tests/error/comprehension_errors/mutable_struct5.err
@@ -1,0 +1,9 @@
+Error: Copy violation (at $FILE:16:39)
+   | 
+14 | @guppy
+15 | def foo(s: MyStruct @ owned) -> None:
+16 |     [0 for _ in range(20) for _ in bar(s)]
+   |                                        ^ Variable `s` with non-copyable type `MyStruct` would be
+   |                                          consumed multiple times when evaluating this comprehension
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct5.py
+++ b/tests/error/comprehension_errors/mutable_struct5.py
@@ -1,0 +1,19 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy.declare
+def bar(s: MyStruct @ owned) -> list[int]: ...
+
+
+@guppy
+def foo(s: MyStruct @ owned) -> None:
+    [0 for _ in range(20) for _ in bar(s)]
+
+
+foo.compile()

--- a/tests/error/comprehension_errors/mutable_struct6.err
+++ b/tests/error/comprehension_errors/mutable_struct6.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:16:5)
+   | 
+14 | @guppy
+15 | def foo(s: MyStruct @ owned) -> None:
+16 |     [s.x for _ in bar(s)]
+   |      ^^^ Field `s.x` cannot be moved ...
+
+Note:
+   | 
+15 | def foo(s: MyStruct @ owned) -> None:
+16 |     [s.x for _ in bar(s)]
+   |                       - ... since variable `s` with non-copyable type `MyStruct` was
+   |                         already consumed here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comprehension_errors/mutable_struct6.py
+++ b/tests/error/comprehension_errors/mutable_struct6.py
@@ -1,0 +1,19 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy.declare
+def bar(s: MyStruct @ owned) -> list[int]: ...
+
+
+@guppy
+def foo(s: MyStruct @ owned) -> None:
+    [s.x for _ in bar(s)]
+
+
+foo.compile()

--- a/tests/error/inout_errors/field_already_used.err
+++ b/tests/error/inout_errors/field_already_used.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:26:8)
+   | 
+24 | def test(s: MyStruct1 @owned) -> None:
+25 |     use(s.x)
+26 |     foo(s.x)
+   |         ^^^ Field `s.x` cannot be borrowed ...
+
+Note:
+   | 
+24 | def test(s: MyStruct1 @owned) -> None:
+25 |     use(s.x)
+   |         --- ... since field `s.x` with non-copyable type `MyStruct2` was
+   |             already consumed here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/inout_errors/field_already_used.py
+++ b/tests/error/inout_errors/field_already_used.py
@@ -1,0 +1,29 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=True)
+class MyStruct1:
+    x: "MyStruct2"
+
+
+@guppy.struct(frozen=False)
+class MyStruct2:
+    y: int
+
+
+@guppy.declare
+def foo(s: MyStruct2) -> None: ...
+
+
+@guppy.declare
+def use(s: MyStruct2 @owned) -> None: ...
+
+
+@guppy
+def test(s: MyStruct1 @owned) -> None:
+    use(s.x)
+    foo(s.x)
+
+
+test.compile()

--- a/tests/error/inout_errors/field_borrow_twice.err
+++ b/tests/error/inout_errors/field_borrow_twice.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:21:13)
+   | 
+19 | @guppy
+20 | def test(s: MyStruct1 @owned) -> None:
+21 |     foo(s.x, s.x)
+   |              ^^^ Field `s.x` cannot be borrowed ...
+
+Note:
+   | 
+20 | def test(s: MyStruct1 @owned) -> None:
+21 |     foo(s.x, s.x)
+   |         --- ... since field `s.x` with non-copyable type `MyStruct2` was
+   |             already borrowed here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/inout_errors/field_borrow_twice.py
+++ b/tests/error/inout_errors/field_borrow_twice.py
@@ -1,0 +1,24 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=True)
+class MyStruct1:
+    x: "MyStruct2"
+
+
+@guppy.struct(frozen=False)
+class MyStruct2:
+    y: int
+
+
+@guppy.declare
+def foo(s: MyStruct2, t: MyStruct2) -> None: ...
+
+
+@guppy
+def test(s: MyStruct1 @owned) -> None:
+    foo(s.x, s.x)
+
+
+test.compile()

--- a/tests/error/linear_errors/affine_struct_array.err
+++ b/tests/error/linear_errors/affine_struct_array.err
@@ -1,0 +1,12 @@
+Error: Subscript returned (at $FILE:12:11)
+   | 
+10 | @guppy
+11 | def foo(xs: array[MyStruct, 20]) -> MyStruct:
+12 |     return xs[0]
+   |            ^^^^^ Cannot return a subscript of `xs` with non-copyable type
+   |                  `array[MyStruct, 20]`
+
+Note: Subscripts on non-copyable types are only allowed to be borrowed, not
+returned
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/affine_struct_array.py
+++ b/tests/error/linear_errors/affine_struct_array.py
@@ -1,0 +1,14 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import array
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(xs: array[MyStruct, 20]) -> MyStruct:
+    return xs[0]
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct1.err
+++ b/tests/error/linear_errors/mutable_affine_struct1.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:13:11)
+   | 
+11 | def foo(s: MyStruct @owned) -> MyStruct:
+12 |     t = s
+13 |     return s
+   |            ^ Variable `s` cannot be returned ...
+
+Note:
+   | 
+11 | def foo(s: MyStruct @owned) -> MyStruct:
+12 |     t = s
+   |         - ... since variable `s` with non-copyable type `MyStruct` was
+   |           already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct1.py
+++ b/tests/error/linear_errors/mutable_affine_struct1.py
@@ -1,0 +1,16 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned) -> MyStruct:
+    t = s
+    return s
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct2.err
+++ b/tests/error/linear_errors/mutable_affine_struct2.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:14:11)
+   | 
+12 |     if b:
+13 |         t = s
+14 |     return s
+   |            ^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+12 |     if b:
+13 |         t = s
+   |             - ... since variable `s` with non-copyable type `MyStruct` was
+   |               already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct2.err
+++ b/tests/error/linear_errors/mutable_affine_struct2.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:14:11)
 12 |     if b:
 13 |         t = s
 14 |     return s
-   |            ^ Field `s.x` cannot be returned ...
+   |            ^ Variable `s` cannot be returned ...
 
 Note:
    | 

--- a/tests/error/linear_errors/mutable_affine_struct2.py
+++ b/tests/error/linear_errors/mutable_affine_struct2.py
@@ -1,0 +1,17 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+    if b:
+        t = s
+    return s
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct3.err
+++ b/tests/error/linear_errors/mutable_affine_struct3.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:16:11)
+   | 
+14 |     else:
+15 |         t = s
+16 |     return s
+   |            ^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+14 |     else:
+15 |         t = s
+   |             - ... since variable `s` with non-copyable type `MyStruct` was
+   |               already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct3.err
+++ b/tests/error/linear_errors/mutable_affine_struct3.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:16:11)
 14 |     else:
 15 |         t = s
 16 |     return s
-   |            ^ Field `s.x` cannot be returned ...
+   |            ^ Variable `s` cannot be returned ...
 
 Note:
    | 

--- a/tests/error/linear_errors/mutable_affine_struct3.py
+++ b/tests/error/linear_errors/mutable_affine_struct3.py
@@ -1,0 +1,19 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+    if b:
+        pass
+    else:
+        t = s
+    return s
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct4.err
+++ b/tests/error/linear_errors/mutable_affine_struct4.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:14:15)
 12 |     t = s
 13 |     if b:
 14 |         return s
-   |                ^ Field `s.x` cannot be returned ...
+   |                ^ Variable `s` cannot be returned ...
 
 Note:
    | 

--- a/tests/error/linear_errors/mutable_affine_struct4.err
+++ b/tests/error/linear_errors/mutable_affine_struct4.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:14:15)
+   | 
+12 |     t = s
+13 |     if b:
+14 |         return s
+   |                ^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+11 | def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+12 |     t = s
+   |         - ... since variable `s` with non-copyable type `MyStruct` was
+   |           already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct4.py
+++ b/tests/error/linear_errors/mutable_affine_struct4.py
@@ -1,0 +1,18 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+    t = s
+    if b:
+        return s
+    return MyStruct(42)
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct5.err
+++ b/tests/error/linear_errors/mutable_affine_struct5.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:17:15)
 15 | def foo(s: MyStruct @owned, b: bool) -> MyStruct:
 16 |     if b or (t := s):
 17 |         return s
-   |                ^ Field `s.x` cannot be returned ...
+   |                ^ Variable `s` cannot be returned ...
 
 Note:
    | 

--- a/tests/error/linear_errors/mutable_affine_struct5.err
+++ b/tests/error/linear_errors/mutable_affine_struct5.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:17:15)
+   | 
+15 | def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+16 |     if b or (t := s):
+17 |         return s
+   |                ^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+15 | def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+16 |     if b or (t := s):
+   |                   - ... since variable `s` with non-copyable type `MyStruct` was
+   |                     already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct5.py
+++ b/tests/error/linear_errors/mutable_affine_struct5.py
@@ -1,0 +1,21 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+    @guppy
+    def __bool__(self) -> bool:
+        return self.x > 0
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+    if b or (t := s):
+        return s
+    return MyStruct(0)
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct6.err
+++ b/tests/error/linear_errors/mutable_affine_struct6.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:17:11)
+   | 
+15 |             break
+16 |         a = s.x  # Ok
+17 |     return s
+   |            ^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+13 |         if b:
+14 |             t = s
+   |                 - ... since variable `s` with non-copyable type `MyStruct` was
+   |                   already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct6.err
+++ b/tests/error/linear_errors/mutable_affine_struct6.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:17:11)
 15 |             break
 16 |         a = s.x  # Ok
 17 |     return s
-   |            ^ Field `s.x` cannot be returned ...
+   |            ^ Variable `s` cannot be returned ...
 
 Note:
    | 

--- a/tests/error/linear_errors/mutable_affine_struct6.py
+++ b/tests/error/linear_errors/mutable_affine_struct6.py
@@ -1,0 +1,20 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+    while b:
+        if b:
+            t = s
+            break
+        a = s.x  # Ok
+    return s
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_affine_struct7.err
+++ b/tests/error/linear_errors/mutable_affine_struct7.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:13:12)
+   | 
+11 | def foo(s: MyStruct @owned, b: bool) -> None:
+12 |     while b:
+13 |         t = s
+   |             ^ Field `s.x` cannot be moved ...
+
+Note:
+   | 
+12 |     while b:
+13 |         t = s
+   |             - ... since variable `s` with non-copyable type `MyStruct` was
+   |               already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_affine_struct7.err
+++ b/tests/error/linear_errors/mutable_affine_struct7.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:13:12)
 11 | def foo(s: MyStruct @owned, b: bool) -> None:
 12 |     while b:
 13 |         t = s
-   |             ^ Field `s.x` cannot be moved ...
+   |             ^ Variable `s` cannot be moved ...
 
 Note:
    | 

--- a/tests/error/linear_errors/mutable_affine_struct7.py
+++ b/tests/error/linear_errors/mutable_affine_struct7.py
@@ -1,0 +1,16 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> None:
+    while b:
+        t = s
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_empty_struct1.err
+++ b/tests/error/linear_errors/mutable_empty_struct1.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:13:11)
+   | 
+11 | def foo(s: MyStruct @owned) -> MyStruct:
+12 |     t = s  # Empty mutable structs are stiff affine
+13 |     return s
+   |            ^ Variable `s` with non-copyable type `MyStruct` cannot be
+   |              returned ...
+
+Note:
+   | 
+11 | def foo(s: MyStruct @owned) -> MyStruct:
+12 |     t = s  # Empty mutable structs are stiff affine
+   |         - Variable `s` already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_empty_struct1.py
+++ b/tests/error/linear_errors/mutable_empty_struct1.py
@@ -1,0 +1,16 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    pass
+
+
+@guppy
+def foo(s: MyStruct @owned) -> MyStruct:
+    t = s  # Empty mutable structs are stiff affine
+    return s
+
+
+foo.compile()

--- a/tests/error/linear_errors/mutable_empty_struct2.err
+++ b/tests/error/linear_errors/mutable_empty_struct2.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:14:11)
+   | 
+12 |     if b:
+13 |         t = s  # Empty mutable structs are stiff affine
+14 |     return s
+   |            ^ Variable `s` with non-copyable type `MyStruct` cannot be
+   |              returned ...
+
+Note:
+   | 
+12 |     if b:
+13 |         t = s  # Empty mutable structs are stiff affine
+   |             - Variable `s` already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/mutable_empty_struct2.py
+++ b/tests/error/linear_errors/mutable_empty_struct2.py
@@ -1,0 +1,17 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    pass
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> MyStruct:
+    if b:
+        t = s  # Empty mutable structs are stiff affine
+    return s
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved1.err
+++ b/tests/error/linear_errors/parent_moved1.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:13:11)
+   | 
+11 | def foo(s: MyStruct @owned) -> int:
+12 |     t = s
+13 |     return s.x
+   |            ^^^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+11 | def foo(s: MyStruct @owned) -> int:
+12 |     t = s
+   |         - ... since variable `s` with non-copyable type `MyStruct` was
+   |           already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved1.py
+++ b/tests/error/linear_errors/parent_moved1.py
@@ -1,0 +1,16 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned) -> int:
+    t = s
+    return s.x
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved2.err
+++ b/tests/error/linear_errors/parent_moved2.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:14:11)
+   | 
+12 |     if b:
+13 |         t = s
+14 |     return s.x
+   |            ^^^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+12 |     if b:
+13 |         t = s
+   |             - ... since variable `s` with non-copyable type `MyStruct` was
+   |               already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved2.py
+++ b/tests/error/linear_errors/parent_moved2.py
@@ -1,0 +1,17 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> int:
+    if b:
+        t = s
+    return s.x
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved3.err
+++ b/tests/error/linear_errors/parent_moved3.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:21:11)
+   | 
+19 |     else:
+20 |         t = s
+21 |     return s.x.y
+   |            ^^^^^ Field `s.x.y` cannot be returned ...
+
+Note:
+   | 
+19 |     else:
+20 |         t = s
+   |             - ... since field `s.x` with non-copyable type `MyStruct2` was
+   |               already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved3.py
+++ b/tests/error/linear_errors/parent_moved3.py
@@ -1,0 +1,24 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct1:
+    x: "MyStruct2"
+
+
+@guppy.struct(frozen=False)
+class MyStruct2:
+    y: int
+
+
+@guppy
+def foo(s: MyStruct1 @owned, b: bool) -> int:
+    if b:
+        s.x = MyStruct2(42)
+    else:
+        t = s
+    return s.x.y
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved4.err
+++ b/tests/error/linear_errors/parent_moved4.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:19:15)
+   | 
+17 |     t = s.x
+18 |     if b:
+19 |         return s.x.y
+   |                ^^^^^ Field `s.x.y` cannot be returned ...
+
+Note:
+   | 
+16 | def foo(s: MyStruct1 @owned, b: bool) -> int:
+17 |     t = s.x
+   |         --- ... since field `s.x` with non-copyable type `MyStruct2` was
+   |             already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved4.py
+++ b/tests/error/linear_errors/parent_moved4.py
@@ -1,0 +1,23 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=True)
+class MyStruct1:
+    x: "MyStruct2"
+
+
+@guppy.struct(frozen=False)
+class MyStruct2:
+    y: int
+
+
+@guppy
+def foo(s: MyStruct1 @owned, b: bool) -> int:
+    t = s.x
+    if b:
+        return s.x.y
+    return 0
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved5.err
+++ b/tests/error/linear_errors/parent_moved5.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:17:15)
+   | 
+15 | def foo(s: MyStruct @owned, b: bool) -> int:
+16 |     if b or (t := s):
+17 |         return s.x
+   |                ^^^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+15 | def foo(s: MyStruct @owned, b: bool) -> int:
+16 |     if b or (t := s):
+   |                   - ... since variable `s` with non-copyable type `MyStruct` was
+   |                     already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved5.py
+++ b/tests/error/linear_errors/parent_moved5.py
@@ -1,0 +1,21 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+    @guppy
+    def __bool__(self) -> bool:
+        return self.x > 0
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> int:
+    if b or (t := s):
+        return s.x
+    return 0
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved6.err
+++ b/tests/error/linear_errors/parent_moved6.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:17:11)
+   | 
+15 |             break
+16 |         a = s.x  # Ok
+17 |     return s.x
+   |            ^^^ Field `s.x` cannot be returned ...
+
+Note:
+   | 
+13 |         if b:
+14 |             t = s
+   |                 - ... since variable `s` with non-copyable type `MyStruct` was
+   |                   already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved6.py
+++ b/tests/error/linear_errors/parent_moved6.py
@@ -1,0 +1,20 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=False)
+class MyStruct:
+    x: int
+
+
+@guppy
+def foo(s: MyStruct @owned, b: bool) -> int:
+    while b:
+        if b:
+            t = s
+            break
+        a = s.x  # Ok
+    return s.x
+
+
+foo.compile()

--- a/tests/error/linear_errors/parent_moved7.err
+++ b/tests/error/linear_errors/parent_moved7.err
@@ -3,7 +3,7 @@ Error: Copy violation (at $FILE:18:12)
 16 | def foo(s: MyStruct1 @owned, b: bool) -> None:
 17 |     while b:
 18 |         a = s.x
-   |             ^^^ Field `s.x.y` cannot be moved ...
+   |             ^^^ Field `s.x` cannot be moved ...
 
 Note:
    | 

--- a/tests/error/linear_errors/parent_moved7.err
+++ b/tests/error/linear_errors/parent_moved7.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:18:12)
+   | 
+16 | def foo(s: MyStruct1 @owned, b: bool) -> None:
+17 |     while b:
+18 |         a = s.x
+   |             ^^^ Field `s.x.y` cannot be moved ...
+
+Note:
+   | 
+17 |     while b:
+18 |         a = s.x
+   |             --- ... since field `s.x` with non-copyable type `MyStruct2` was
+   |                 already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/linear_errors/parent_moved7.py
+++ b/tests/error/linear_errors/parent_moved7.py
@@ -1,0 +1,21 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import owned
+
+
+@guppy.struct(frozen=True)
+class MyStruct1:
+    x: "MyStruct2"
+
+
+@guppy.struct(frozen=False)
+class MyStruct2:
+    y: int
+
+
+@guppy
+def foo(s: MyStruct1 @owned, b: bool) -> None:
+    while b:
+        a = s.x
+
+
+foo.compile()

--- a/tests/error/struct_errors/mutate_classical.err
+++ b/tests/error/struct_errors/mutate_classical.err
@@ -1,8 +1,8 @@
-Error: Unsupported (at $FILE:14:6)
+Error: Immutable (at $FILE:14:4)
    | 
 12 | def foo(s: MyStruct) -> tuple[MyStruct, bool]:
 13 |     t = s
 14 |     t.x += 1
-   |       ^ Mutation of classical fields is not supported
+   |     ^^^ Struct `MyStruct` is immutable
 
 Guppy compilation failed due to 1 previous error

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -265,6 +265,23 @@ def test_struct_nested_subscript(validate):
     validate(main.compile_function())
 
 
+def test_mutate_struct_array(validate):
+    @guppy.struct(frozen=False)
+    class MyStruct:
+        x: int
+        xs: array[int, 42]
+
+    @guppy
+    def main(ss: array[MyStruct, 10]) -> int:
+        ss[0].x = 0
+        ss[1].xs[0] += ss[0].x + 2
+        if ss[1].x > ss[0].x:
+            ss[1].xs = ss[0].xs.copy()
+        return ss[0].x + ss[1].xs[0]
+
+    validate(main.compile_function())
+
+
 def test_generic_function(validate):
     T = guppy.type_var("T", copyable=False, droppable=False)
     n = guppy.nat_var("n")

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -81,6 +81,29 @@ def test_struct(validate):
     validate(test2.compile_function())
 
 
+def test_struct_mutate_classical(validate):
+    @guppy.struct(frozen=False)
+    class MyStruct:
+        x: int
+        y: float
+
+        @guppy
+        def add(self, z: int) -> None:
+            self.x += z
+            if z > 5:
+                self.y += 2 * z
+            else:
+                self.y = 0.0
+
+    @guppy
+    def main() -> float:
+        s = MyStruct(41, 1.5)
+        s.add(1)
+        return s.x + s.y
+
+    validate(main.compile_function())
+
+
 def test_control_flow(validate):
     @guppy.declare
     def foo(q: qubit) -> None: ...

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -243,6 +243,111 @@ def test_struct_reassign2(validate):
     validate(test.compile_function())
 
 
+def test_mutate_classical_field1(validate):
+    @guppy.struct(frozen=False)
+    class MyStruct:
+        x: int
+
+    @guppy
+    def main(s: MyStruct @ owned, b: bool) -> int:
+        x = s.x
+        s.x = 41
+        t = s
+        if b:
+            t.x += 1
+        return t.x + x
+
+    validate(main.compile_function())
+
+
+def test_mutate_classical_field2(validate):
+    @guppy.struct
+    class MyStruct1:
+        x: "MyStruct2"
+
+    @guppy.struct(frozen=False)
+    class MyStruct2:
+        y: int
+
+    @guppy
+    def test(s: MyStruct1 @ owned, b: bool) -> MyStruct2:
+        s.x.y += 1
+        if b:
+            s = MyStruct2(42)
+            return s
+        else:
+            s = MyStruct1(MyStruct2(s.x.y - 1))
+        s.x.y += 1
+        return s.x
+
+    validate(test.compile_function())
+
+
+def test_mutate_classical_field3(validate):
+    @guppy.struct(frozen=False)
+    class MyStruct:
+        x: int
+
+    @guppy
+    def main(s: MyStruct @ owned) -> int:
+        while True:
+            if s.x > 7:
+                t = s
+                break
+            s.x += 1
+        return t.x
+
+    validate(main.compile_function())
+
+
+def test_mutate_classical_field4(validate):
+    @guppy.struct(frozen=False)
+    class MyStruct:
+        x: int
+
+    @guppy
+    def main(s: MyStruct @ owned, t: MyStruct @ owned) -> tuple[int, int]:
+        while True:
+            if s.x > 7:
+                t.x += 1
+                s, t = t, s
+                continue
+            u = s
+            t.x += u.x
+            break
+        return u.x, t.x
+
+    validate(main.compile_function())
+
+
+def test_mutate_classical_field5(validate):
+    @guppy.struct(frozen=False)
+    class MyStruct1:
+        x: "MyStruct2"
+        y: "MyStruct2"
+
+    @guppy.struct(frozen=False)
+    class MyStruct2:
+        z: int
+
+    @guppy
+    def main(s: MyStruct1 @ owned) -> int:
+        while True:
+            if s.x.z > 5:
+                s.x = s.y
+                s.y = MyStruct2(42)
+            else:
+                s.x, s.y = s.y, s.x
+                continue
+            if s.y.z > 5:
+                s.x.z += 1
+            else:
+                break
+        return s.x.z + s.y.z
+
+    validate(main.compile_function())
+
+
 def test_measure(validate):
     @guppy
     def test(q: qubit @ owned, x: int) -> int:


### PR DESCRIPTION
Closes #1775

This PR adds the optional `frozen` kwarg to the `@guppy.struct` decorator. When set to `True`, the struct will support mutation of both classical and linear fields.

To make this change non-breaking, structs defaults to `frozen=True` and mutation of affine fields is allowed even if `frozen=True`. See #1776 for the issue for changing the default behaviour.

The main difficulty with this feature is linearity checking: If we use a projection of a mutable struct, we need to make sure that the struct value itself has not been moved. In particular, values can now be affine, even if all their projections are copyable individually. This clashes with the previous approach of linearity checking where struct values were tracked by just tracking all leaf projections.

Initially, I was planning to rewrite the entire linearity checker to stop decomposing places into their leaf projections. I still think this would be a good idea, however it felt too risky to get everything right in time for the 1.0 release. Instead, I found an alternative solution: Now, we track uses of values via all their projections, not only the leaf ones. This retains enough information to check if parents have been moved.

I recommend reviewing commit by commit.

Note that this PR is only breaking for `guppylang-internals`:

BREAKING CHANGE: `RawStructDef`, `ParsedStructDef`, and `CheckedStructDef` have a new required field `frozen`
BREAKING CHANGE: `linearity_checker.Scope.use` now requires a `Place` instead of a `PlaceId`

BEGIN_COMMIT_OVERRIDE
feat: Support mutable structs (#1793)
END_COMMIT_OVERRIDE