### PR TITLE
feat(std): add native PCG32 random number generator

### DIFF
--- a/guppylang/src/guppylang/std/random.py
+++ b/guppylang/src/guppylang/std/random.py
@@ -1,0 +1,87 @@
+"""Pure Guppy random number generation."""
+
+# mypy: disable-error-code="no-any-return, misc, call-arg, call-overload, assignment"
+from __future__ import annotations
+
+from typing import no_type_check
+
+from guppylang import guppy
+from guppylang.std.num import nat
+
+
+@guppy
+@no_type_check
+def _mask32(value: nat) -> nat:
+    uint32_mask: nat = 4294967295
+    return value & uint32_mask
+
+
+@guppy
+@no_type_check
+def _uint32_to_signed(value: nat) -> int:
+    """Convert a 32-bit unsigned value stored in a nat to a signed 32-bit int."""
+    uint32_sign_bit: nat = 2147483648
+    masked = _mask32(value)
+    if masked >= uint32_sign_bit:
+        return int(masked) - 4294967296
+    return int(masked)
+
+
+@guppy.struct
+class PCG32:
+    """A deterministic 32-bit random number generator using the PCG32 algorithm.
+
+    Unlike :py:class:`guppylang.std.qsystem.random.RNG`, PCG32 keeps its state in a
+    local Guppy value rather than in platform-global RNG state. Because Guppy structs
+    are immutable, each draw returns an updated generator together with the value:
+
+    .. code-block:: python
+
+        rng = seeded_pcg32(1)
+        rng, value = rng.next_int()
+        rng, another = rng.next_int()
+
+    Thread the returned ``rng`` through your program to keep random streams independent.
+    """
+
+    state: nat
+    inc: nat
+
+    @guppy
+    @no_type_check
+    def next_int(self: PCG32) -> tuple[PCG32, int]:
+        """Advance the generator and return the updated state with a random value.
+
+        Returns a signed 32-bit integer, matching the shape of
+        :py:meth:`guppylang.std.qsystem.random.RNG.random_int`.
+        """
+        pcg32_mult: nat = 6364136223846793005
+        old_state = self.state
+        new_state = nat(old_state * pcg32_mult + self.inc)
+        xorshifted = _mask32(((old_state >> nat(18)) ^ old_state) >> nat(27))
+        rot = _mask32(old_state >> nat(59))
+        rot_inv = _mask32((~rot + nat(1)) & nat(31))
+        output = _mask32((xorshifted >> rot) | (xorshifted << rot_inv))
+        return PCG32(new_state, self.inc), _uint32_to_signed(output)
+
+
+@guppy
+@no_type_check
+def seeded_pcg32(seed: int) -> PCG32:
+    """Create a new :py:class:`PCG32` generator from a seed value.
+
+    The seed selects one of ``2**63`` possible PCG32 sequences. The same seed always
+    produces the same stream of values. Different :py:class:`PCG32` values do not
+    share state, so using one generator does not affect another.
+
+    Args:
+        seed: Sequence identifier used to initialize the generator.
+    """
+    initstate = nat(42)
+    initseq = nat(seed)
+    inc = nat((initseq << nat(1)) | nat(1))
+    rng = PCG32(nat(0), inc)
+    rng, _ = rng.next_int()
+    rng = PCG32(rng.state + initstate, rng.inc)
+    rng, _ = rng.next_int()
+    return rng

--- a/guppylang/src/guppylang/std/random.py
+++ b/guppylang/src/guppylang/std/random.py
@@ -1,4 +1,8 @@
-"""Pure Guppy random number generation."""
+"""Pure Guppy random number generation.
+
+Implements the PCG32 (XSH-RR, 64/32) generator from the PCG family; see
+https://www.pcg-random.org/ and the reference C code in pcg-c-basic.
+"""
 
 # mypy: disable-error-code="no-any-return, misc, call-arg, call-overload, assignment"
 from __future__ import annotations
@@ -12,6 +16,7 @@ from guppylang.std.num import nat
 @guppy
 @no_type_check
 def _mask32(value: nat) -> nat:
+    # 2**32 - 1: keep only the low 32 bits (Guppy has no native uint32 type).
     uint32_mask: nat = 4294967295
     return value & uint32_mask
 
@@ -20,9 +25,11 @@ def _mask32(value: nat) -> nat:
 @no_type_check
 def _uint32_to_signed(value: nat) -> int:
     """Convert a 32-bit unsigned value stored in a nat to a signed 32-bit int."""
+    # 2**31: high bit of a 32-bit word; values at or above this map to negative ints.
     uint32_sign_bit: nat = 2147483648
     masked = _mask32(value)
     if masked >= uint32_sign_bit:
+        # 2**32: reinterpret unsigned 32-bit output as signed (two's complement).
         return int(masked) - 4294967296
     return int(masked)
 
@@ -55,9 +62,12 @@ class PCG32:
         Returns a signed 32-bit integer, matching the shape of
         :py:meth:`guppylang.std.qsystem.random.RNG.random_int`.
         """
+        # LCG multiplier N from the PCG paper / pcg32_random_r (64-bit state, 32-bit
+        # output).
         pcg32_mult: nat = 6364136223846793005
         old_state = self.state
         new_state = nat(old_state * pcg32_mult + self.inc)
+        # XSH-RR output permutation: xor-shift then random rotate (see pcg32_random_r).
         xorshifted = _mask32(((old_state >> nat(18)) ^ old_state) >> nat(27))
         rot = _mask32(old_state >> nat(59))
         rot_inv = _mask32((~rot + nat(1)) & nat(31))
@@ -77,9 +87,12 @@ def seeded_pcg32(seed: int) -> PCG32:
     Args:
         seed: Sequence identifier used to initialize the generator.
     """
+    # Default initstate from PCG reference examples (e.g. Rosetta Code PCG32 task).
     initstate = nat(42)
     initseq = nat(seed)
+    # PCG requires an odd increment; initseq is the stream/sequence selector.
     inc = nat((initseq << nat(1)) | nat(1))
+    # pcg32_srandom_r: advance twice after mixing initstate into state.
     rng = PCG32(nat(0), inc)
     rng, _ = rng.next_int()
     rng = PCG32(rng.state + initstate, rng.inc)

--- a/tests/integration/std/test_random.py
+++ b/tests/integration/std/test_random.py
@@ -1,0 +1,145 @@
+from guppylang import guppy
+from guppylang.std.builtins import owned, result
+from guppylang.std.quantum import h, measure, qubit, x
+from guppylang.std.random import seeded_pcg32
+
+
+def test_pcg32_compile(validate) -> None:
+    @guppy
+    def main() -> tuple[int, int]:
+        rng = seeded_pcg32(1)
+        rng, first = rng.next_int()
+        rng, second = rng.next_int()
+        return first, second
+
+    validate(main.compile_function())
+
+
+def test_pcg32_sequence_seed_1(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        rng = seeded_pcg32(1)
+        rng, first = rng.next_int()
+        rng, second = rng.next_int()
+        return first + second
+
+    run_int_fn(main, 1307692281 + -444364974)
+
+
+def test_pcg32_sequence_seed_2(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        rng = seeded_pcg32(2)
+        _, first = rng.next_int()
+        return first
+
+    run_int_fn(main, -8000311)
+
+
+def test_pcg32_deterministic_sequence(run_int_fn) -> None:
+    """First five outputs for initstate=42, initseq=54 match PCG32 reference."""
+
+    @guppy
+    def main() -> int:
+        rng = seeded_pcg32(54)
+        total = 0
+        for _ in range(5):
+            rng, value = rng.next_int()
+            total += value
+        return total
+
+    # Reference values from https://rosettacode.org/wiki/Pseudo-random_numbers/PCG32
+    expected = sum(
+        [
+            -1587805513,
+            2068313097,
+            -1172491472,
+            -2083327341,
+            -1079740341,
+        ]
+    )
+    run_int_fn(main, expected)
+
+
+def test_pcg32_motivating_example() -> None:
+    """Exact scenario from issue #1578: inner RNG must not affect outer."""
+
+    @guppy
+    def uses_inner_rng() -> int:
+        inner = seeded_pcg32(2)
+        _, value = inner.next_int()
+        return value
+
+    @guppy
+    def main() -> None:
+        outer = seeded_pcg32(1)
+        outer, first = outer.next_int()
+
+        _ = uses_inner_rng()
+
+        outer, second = outer.next_int()
+        result("first", first)
+        result("second", second)
+
+    results = dict(
+        main.emulator(0).coinflip_sim().with_seed(42).run().results[0].entries
+    )
+    assert results == {"first": 1307692281, "second": -444364974}
+
+
+def test_pcg32_independent_streams(validate, run_int_fn) -> None:
+    """Inner and outer RNG streams do not interfere with each other."""
+
+    @guppy
+    def uses_inner_rng() -> int:
+        inner = seeded_pcg32(2)
+        _, value = inner.next_int()
+        return value
+
+    @guppy
+    def main() -> int:
+        outer = seeded_pcg32(1)
+        outer, first = outer.next_int()
+        _ = uses_inner_rng()
+        outer, second = outer.next_int()
+        return first + second
+
+    validate(main.compile_function())
+    run_int_fn(main, 1307692281 + -444364974)
+
+
+def test_pcg32_no_interference_with_quantum() -> None:
+    """Outer RNG output is independent of conditional inner RNG use."""
+
+    @guppy
+    def some_outside_function(q: qubit @ owned) -> qubit:
+        p = qubit()
+        if measure(q):
+            rng_inner = seeded_pcg32(2)
+            _, value = rng_inner.next_int()
+            result("rng1_0", value)
+            x(p)
+        return p
+
+    @guppy
+    def main() -> None:
+        rng_outer = seeded_pcg32(1)
+        rng_outer, value = rng_outer.next_int()
+        result("rng0_0", value)
+
+        q = qubit()
+        h(q)
+        p = some_outside_function(q)
+        if measure(p):
+            _, value = rng_outer.next_int()
+            result("rng0_1", value)
+        else:
+            _, value = rng_outer.next_int()
+            result("rng0_1", value)
+
+    results = main.emulator(2).coinflip_sim().with_seed(42).run().results[0].entries
+    entries = dict(results)
+    assert entries["rng0_0"] == 1307692281
+    assert entries["rng0_1"] == -444364974
+    if "rng1_0" in entries:
+        assert entries["rng1_0"] == -8000311

--- a/tests/integration/std/test_random.py
+++ b/tests/integration/std/test_random.py
@@ -62,7 +62,10 @@ def test_pcg32_deterministic_sequence(run_int_fn) -> None:
 
 
 def test_pcg32_motivating_example() -> None:
-    """Exact scenario from issue #1578: inner RNG must not affect outer."""
+    """Exact scenario from https://github.com/Quantinuum/guppylang/issues/1578.
+
+    Inner RNG must not affect the outer stream.
+    """
 
     @guppy
     def uses_inner_rng() -> int:
@@ -109,7 +112,7 @@ def test_pcg32_independent_streams(validate, run_int_fn) -> None:
 
 
 def test_pcg32_no_interference_with_quantum() -> None:
-    """Outer RNG output is independent of conditional inner RNG use."""
+    """Outer RNG is stable across branches; see https://github.com/Quantinuum/guppylang/issues/1578."""
 
     @guppy
     def some_outside_function(q: qubit @ owned) -> qubit:


### PR DESCRIPTION
## Summary

Adds a pure-Guppy PCG32 RNG at `guppylang.std.random` so random state lives in a local value instead of the platform-global qsystem RNG.

- Introduces `PCG32` and `seeded_pcg32(seed: int)`
- `next_int()` returns `(new_rng, signed_32_bit_int)` for immutable state threading
- Uses explicit 32-bit masking and signed conversion on top of `nat`
- Leaves `guppylang.std.qsystem.random.RNG` unchanged

Fixes the interference problem from #1578: with `seeded_pcg32(1)`, the second draw is always `-444364974`, even if another function uses `seeded_pcg32(2)`.

Closes #1578

## Test plan

- [x] `uv run pytest tests/integration/std/test_random.py`
- [x] Deterministic PCG32 sequence checks (seeds 1, 2, 54 vs reference vectors)
- [x] Issue motivating example: inner RNG does not affect outer stream
- [x] Quantum control-flow test: `rng0_1` is stable across branches
- [x] `uv run pytest tests/integration/test_qsystem.py` — no qsystem RNG regression
- [x] Full suite: `pytest -n auto` (1513 passed)
- [x] `ruff check`, `ruff format --check`, `mypy guppylang guppylang-internals`

BEGIN_COMMIT_OVERRIDE
feat: Add native PCG32 random number generator to std lib (#1808)
END_COMMIT_OVERRIDE