### PR TITLE
fix: correct docstring formatting for std.quantum.reset

### DIFF
--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -369,7 +369,7 @@ def measure(q: qubit @ owned) -> bool:
 @hugr_op(quantum_op("Reset"))
 @no_type_check
 def reset(q: qubit) -> None:
-    """Reset a single qubit to the :math:`|0\rangle` state."""
+    """Reset a single qubit to the :math:`|0\\rangle` state."""
 
 
 N = guppy.nat_var("N")


### PR DESCRIPTION
Currently appears like this

<img width="497" height="37" alt="Screenshot 2026-06-04 at 13 41 38" src="https://github.com/user-attachments/assets/b2810626-027b-4901-ae0b-f12e3bf83265" />

Adding the extra `\` means it will appear like this (already fixed for `qsystem.reset`)

<img width="544" height="105" alt="Screenshot 2026-06-04 at 13 43 10" src="https://github.com/user-attachments/assets/1758e5c5-f46c-4543-afc7-5403d0632863" />

BEGIN_COMMIT_OVERRIDE
docs: Correct docstring formatting for std.quantum.reset (#1810)
END_COMMIT_OVERRIDE