### PR TITLE
docs: Correct docstring formatting for std.quantum.reset

### DIFF
--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -369,7 +369,7 @@ def measure(q: qubit @ owned) -> bool:
 @hugr_op(quantum_op("Reset"))
 @no_type_check
 def reset(q: qubit) -> None:
-    """Reset a single qubit to the :math:`|0\rangle` state."""
+    """Reset a single qubit to the :math:`|0\\rangle` state."""
 
 
 N = guppy.nat_var("N")


### PR DESCRIPTION
Cherry-picks the change from #1810 so we can get the fix in the 0.21.* series