### PR TITLE
fix: Comptime attribute access in struct definitions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -274,6 +274,12 @@ def _parse_delayed_annotation(ast_str: str, node: ast.Constant) -> ast.expr:
 
 
 def annotation_nodes(node: ast.expr) -> Iterator[ast.expr]:
+    """Iterates over all the Guppy type annotations (recursively) contained in the given
+    expression. Parses delayed annotations, and does not recurse into comptime
+    expressions."""
+    if is_comptime_expression(node):
+        return
+
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         node = _parse_delayed_annotation(node.value, node)
 

--- a/tests/integration/test_struct.py
+++ b/tests/integration/test_struct.py
@@ -1,6 +1,9 @@
 from typing import Generic, TYPE_CHECKING
 
+from guppylang import comptime, qubit, array
 from guppylang.decorator import guppy
+from guppylang.std.quantum import discard_array
+
 from tests.integration.modules import struct_scope_defs
 
 
@@ -205,3 +208,28 @@ def test_redefine(validate):
         return MyStruct()
 
     validate(foo.compile_function())
+
+
+def test_comptime_attribute_access(validate):
+    """Tests that comptime expressions struct definitions can access attributes of local
+    variables. Regression test for https://github.com/Quantinuum/guppylang/issues/1816.
+    """
+
+    class Config:
+        x: int
+
+        def __init__(self, x: int):
+            self.x = x
+
+    config = Config(x=5)
+
+    @guppy.struct
+    class Struct:
+        qs: array[qubit, comptime(config.x)]
+
+    @guppy
+    def main() -> None:
+        s = Struct(array(qubit() for _ in range(comptime(config.x))))
+        discard_array(s.qs)
+
+    validate(main.compile_function())


### PR DESCRIPTION
The recursiveness checker introduced in #1809 also recursed into comptime calls that were nested inside type annotations in structs. In these, arbitrary Python expressions are allowed, which are not necessarily types.

Currently, I do not think that there is a way to have a Guppy type result from a comptime expression, so for now I just forbid the recursive type annotation search from recursing into comptime expressions.

Fixes #1816