### PR TITLE
feat!: Implicit loading of Python values

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/errors/comptime_errors.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/comptime_errors.py
@@ -7,9 +7,11 @@ from guppylang_internals.tys.ty import FunctionType
 
 
 @dataclass(frozen=True)
-class IllegalComptimeExpressionError(Error):
-    title: ClassVar[str] = "Unsupported Python expression"
-    span_label: ClassVar[str] = "Expression of type `{python_ty}` is not supported"
+class UnsupportedPythonValueError(Error):
+    title: ClassVar[str] = "Unsupported Python value"
+    span_label: ClassVar[str] = (
+        "Python value of type `{python_ty}` cannot be used in Guppy"
+    )
     python_ty: type
 
     @dataclass(frozen=True)

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -63,7 +63,7 @@ from guppylang_internals.checker.errors.comptime_errors import (
     ComptimeExprTypeVarError,
     ComptimeGuppyObjectError,
     ComptimeUnknownError,
-    IllegalComptimeExpressionError,
+    UnsupportedPythonValueError,
 )
 from guppylang_internals.checker.errors.generic import (
     ExpectedError,
@@ -394,7 +394,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             subst = {x: s for x, s in subst.items() if x in ty.unsolved_vars}
             return with_type(act, with_loc(node, ast.Constant(value=python_val))), subst
 
-        raise GuppyError(IllegalComptimeExpressionError(node.value, type(python_val)))
+        raise GuppyError(UnsupportedPythonValueError(node.value, type(python_val)))
 
     def generic_visit(self, node: ast.expr, ty: Type) -> tuple[ast.expr, Subst]:
         # Try to synthesize and then check if we can unify it with the given type
@@ -501,7 +501,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 case PythonObject(obj=val):
                     if ty := python_value_to_guppy_type(val, node):
                         return with_loc(node, ast.Constant(value=val)), ty
-                    raise GuppyError(IllegalComptimeExpressionError(node, type(val)))
+                    raise GuppyError(UnsupportedPythonValueError(node, type(val)))
 
         raise InternalGuppyError(
             f"Variable `{name_id}` is not defined in `TypeSynthesiser`."
@@ -989,7 +989,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         if ty := python_value_to_guppy_type(python_val, node):
             return with_loc(node, ast.Constant(value=python_val)), ty
 
-        raise GuppyError(IllegalComptimeExpressionError(node.value, type(python_val)))
+        raise GuppyError(UnsupportedPythonValueError(node.value, type(python_val)))
 
     def visit_NamedExpr(self, node: ast.NamedExpr) -> tuple[ast.expr, Type]:
         raise InternalGuppyError(
@@ -1648,9 +1648,9 @@ def python_value_to_guppy_type(
             for elt, hint in zip(elts, hints, strict=False):
                 ty = python_value_to_guppy_type(elt, node, hint)
                 if ty is None:
-                    err = IllegalComptimeExpressionError(node, type(elt))
+                    err = UnsupportedPythonValueError(node, type(elt))
                     err.add_sub_diagnostic(
-                        IllegalComptimeExpressionError.InContainer(None, tuple)
+                        UnsupportedPythonValueError.InContainer(None, tuple)
                     )
                     raise GuppyError(err)
                 tys.append(ty)
@@ -1696,16 +1696,14 @@ def _python_list_to_guppy_type(
     )
     el_ty = python_value_to_guppy_type(v, node, elt_hint)
     if el_ty is None:
-        err = IllegalComptimeExpressionError(node, type(v))
-        err.add_sub_diagnostic(IllegalComptimeExpressionError.InContainer(None, list))
+        err = UnsupportedPythonValueError(node, type(v))
+        err.add_sub_diagnostic(UnsupportedPythonValueError.InContainer(None, list))
         raise GuppyError(err)
     for v in rest:
         ty = python_value_to_guppy_type(v, node, elt_hint)
         if ty is None:
-            err = IllegalComptimeExpressionError(node, type(v))
-            err.add_sub_diagnostic(
-                IllegalComptimeExpressionError.InContainer(None, list)
-            )
+            err = UnsupportedPythonValueError(node, type(v))
+            err.add_sub_diagnostic(UnsupportedPythonValueError.InContainer(None, list))
             raise GuppyError(err)
         if (subst := unify(ty, el_ty, {})) is None:
             raise GuppyError(ComptimeExprIncoherentListError(node))

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -498,14 +498,10 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                             err.add_sub_diagnostic(ExpectedError.EnumHelp(None))
                             raise GuppyError(err)
                     return self._check_global(defn, name_id, node)
-                case PythonObject():
-                    from guppylang_internals.checker.cfg_checker import (
-                        VarNotDefinedError,
-                    )
-
-                    # TODO: Emit a hint that the variable could be accessed through a
-                    #  comptime expression
-                    raise GuppyError(VarNotDefinedError(node, node.id))
+                case PythonObject(obj=val):
+                    if ty := python_value_to_guppy_type(val, node):
+                        return with_loc(node, ast.Constant(value=val)), ty
+                    raise GuppyError(IllegalComptimeExpressionError(node, type(val)))
 
         raise InternalGuppyError(
             f"Variable `{name_id}` is not defined in `TypeSynthesiser`."

--- a/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
@@ -5,7 +5,7 @@ from hugr.build.dfg import DfBase
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.errors.comptime_errors import (
-    IllegalComptimeExpressionError,
+    UnsupportedPythonValueError,
 )
 from guppylang_internals.checker.expr_checker import python_value_to_guppy_type
 from guppylang_internals.compiler.core import CompilerContext, DFBuilder
@@ -142,7 +142,7 @@ def guppy_object_from_py(
         case v:
             ty = python_value_to_guppy_type(v, node)
             if ty is None:
-                raise GuppyError(IllegalComptimeExpressionError(node, type(v)))
+                raise GuppyError(UnsupportedPythonValueError(node, type(v)))
             hugr_val = python_value_to_hugr(v, ty, ctx)
             assert hugr_val is not None
             return GuppyObject(ty, builder.load(hugr_val))

--- a/guppylang-internals/src/guppylang_internals/tys/errors.py
+++ b/guppylang-internals/src/guppylang_internals/tys/errors.py
@@ -44,11 +44,9 @@ class InvalidTypeArgError(Error):
 
 
 @dataclass(frozen=True)
-class IllegalComptimeTypeArgError(Error):
+class IllegalPythonTypeArgError(Error):
     title: ClassVar[str] = "Invalid type argument"
-    span_label: ClassVar[str] = (
-        "Comptime expression evaluating to `{obj}` is not a valid type argument"
-    )
+    span_label: ClassVar[str] = "Python value `{obj}` is not a valid type argument"
     obj: object
 
 

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -33,7 +33,7 @@ from guppylang_internals.tys.errors import (
     FlagNotAllowedError,
     FreeTypeVarError,
     HigherKindedTypeVarError,
-    IllegalComptimeTypeArgError,
+    IllegalPythonTypeArgError,
     InvalidCallableTypeError,
     InvalidFlagError,
     InvalidTypeArgError,
@@ -171,7 +171,7 @@ def check_comptime_value(v: Any, node: AstNode) -> Argument:
         nat_ty = NumericType(NumericType.Kind.Nat)
         return ConstArg(ConstValue(nat_ty, v))
     else:
-        raise GuppyError(IllegalComptimeTypeArgError(node, v))
+        raise GuppyError(IllegalPythonTypeArgError(node, v))
 
 
 def try_parse_defn(node: AstNode, globals: Globals) -> Definition | None:

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -3,7 +3,7 @@ import sys
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field
 from types import ModuleType
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from guppylang_internals.ast_util import (
     AstNode,
@@ -105,6 +105,11 @@ def arg_from_ast(node: AstNode, ctx: TypeParsingCtx) -> Argument:
             return ctx.param_inst[node.id]
         if node.id in ctx.param_var_mapping:
             return ctx.param_var_mapping[node.id].to_bound()
+        if node.id in ctx.globals:
+            defn_or_python_obj = ctx.globals[node.id]
+            if isinstance(defn_or_python_obj, PythonObject):
+                return check_comptime_value(defn_or_python_obj.obj, node)
+
         raise GuppyError(VarNotDefinedError(node, node.id))
 
     # A parametrised type, e.g. `list[??]`
@@ -150,11 +155,7 @@ def arg_from_ast(node: AstNode, ctx: TypeParsingCtx) -> Argument:
         from guppylang_internals.checker.expr_checker import eval_comptime_expr
 
         v = eval_comptime_expr(comptime_expr, Context(ctx.globals, Locals({}), {}))
-        if isinstance(v, int):
-            nat_ty = NumericType(NumericType.Kind.Nat)
-            return ConstArg(ConstValue(nat_ty, v))
-        else:
-            raise GuppyError(IllegalComptimeTypeArgError(node, v))
+        return check_comptime_value(v, node)
 
     # Finally, we also support delayed annotations in strings
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
@@ -162,6 +163,15 @@ def arg_from_ast(node: AstNode, ctx: TypeParsingCtx) -> Argument:
         return arg_from_ast(node, ctx)
 
     raise GuppyError(InvalidTypeArgError(node))
+
+
+def check_comptime_value(v: Any, node: AstNode) -> Argument:
+    """Checks if a Python value is a valid type argument."""
+    if isinstance(v, int):
+        nat_ty = NumericType(NumericType.Kind.Nat)
+        return ConstArg(ConstValue(nat_ty, v))
+    else:
+        raise GuppyError(IllegalComptimeTypeArgError(node, v))
 
 
 def try_parse_defn(node: AstNode, globals: Globals) -> Definition | None:

--- a/tests/error/comptime_expr_errors/invalid_type_arg.err
+++ b/tests/error/comptime_expr_errors/invalid_type_arg.err
@@ -3,7 +3,6 @@ Error: Invalid type argument (at $FILE:7:23)
 5 | 
 6 | @compile_guppy
 7 | def foo(xs: array[int, comptime(1.0)]) -> None:
-  |                        ^^^^^^^^^^^^^ Comptime expression evaluating to `1.0` is not a valid type
-  |                                      argument
+  |                        ^^^^^^^^^^^^^ Python value `1.0` is not a valid type argument
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/invalid_type_arg_implicit.err
+++ b/tests/error/comptime_expr_errors/invalid_type_arg_implicit.err
@@ -1,0 +1,9 @@
+Error: Invalid type argument (at $FILE:8:23)
+  | 
+6 | 
+7 | @compile_guppy
+8 | def foo(xs: array[int, a]) -> None:
+  |                        ^ Comptime expression evaluating to `1.0` is not a valid type
+  |                          argument
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/invalid_type_arg_implicit.err
+++ b/tests/error/comptime_expr_errors/invalid_type_arg_implicit.err
@@ -3,7 +3,6 @@ Error: Invalid type argument (at $FILE:8:23)
 6 | 
 7 | @compile_guppy
 8 | def foo(xs: array[int, a]) -> None:
-  |                        ^ Comptime expression evaluating to `1.0` is not a valid type
-  |                          argument
+  |                        ^ Python value `1.0` is not a valid type argument
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/invalid_type_arg_implicit.py
+++ b/tests/error/comptime_expr_errors/invalid_type_arg_implicit.py
@@ -1,0 +1,9 @@
+from guppylang.std.builtins import array
+from tests.util import compile_guppy
+
+
+a = 1.0
+
+@compile_guppy
+def foo(xs: array[int, a]) -> None:
+    pass

--- a/tests/error/comptime_expr_errors/unsupported.err
+++ b/tests/error/comptime_expr_errors/unsupported.err
@@ -1,8 +1,8 @@
-Error: Unsupported Python expression (at $FILE:6:20)
+Error: Unsupported Python value (at $FILE:6:20)
   | 
 4 | @compile_guppy
 5 | def foo() -> int:
 6 |     return comptime({1, 2, 3})
-  |                     ^^^^^^^^^ Expression of type `<class 'set'>` is not supported
+  |                     ^^^^^^^^^ Python value of type `<class 'set'>` cannot be used in Guppy
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/unsupported_implicit.err
+++ b/tests/error/comptime_expr_errors/unsupported_implicit.err
@@ -1,0 +1,8 @@
+Error: Unsupported Python expression (at $FILE:9:11)
+  | 
+7 | @compile_guppy
+8 | def foo() -> int:
+9 |     return s
+  |            ^ Expression of type `<class 'set'>` is not supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/unsupported_implicit.err
+++ b/tests/error/comptime_expr_errors/unsupported_implicit.err
@@ -1,8 +1,8 @@
-Error: Unsupported Python expression (at $FILE:9:11)
+Error: Unsupported Python value (at $FILE:9:11)
   | 
 7 | @compile_guppy
 8 | def foo() -> int:
 9 |     return s
-  |            ^ Expression of type `<class 'set'>` is not supported
+  |            ^ Python value of type `<class 'set'>` cannot be used in Guppy
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/comptime_expr_errors/unsupported_implicit.py
+++ b/tests/error/comptime_expr_errors/unsupported_implicit.py
@@ -1,0 +1,9 @@
+from tests.util import compile_guppy
+
+
+s = {1, 2, 3}
+
+
+@compile_guppy
+def foo() -> int:
+    return s

--- a/tests/error/comptime_expr_errors/unsupported_in_list.err
+++ b/tests/error/comptime_expr_errors/unsupported_in_list.err
@@ -1,9 +1,10 @@
-Error: Unsupported Python expression (at $FILE:13:14)
+Error: Unsupported Python value (at $FILE:13:14)
    | 
 11 | def main() -> None:
 12 |     q = qubit()
 13 |     randval = comptime(randints)[get_current_shot()]
-   |               ^^^^^^^^^^^^^^^^^^ Expression of type `<class 'numpy.int64'>` is not supported
+   |               ^^^^^^^^^^^^^^^^^^ Python value of type `<class 'numpy.int64'>` cannot be used
+   |                                  in Guppy
 
 Note: Unsupported value was found inside a `list`
 

--- a/tests/error/tracing_errors/unsupported_type.err
+++ b/tests/error/tracing_errors/unsupported_type.err
@@ -3,4 +3,4 @@ Traceback (most recent call last):
     test.compile()
   File "$FILE", line 10, in test
     foo(set())
-guppylang_internals.error.GuppyComptimeError: Unsupported Python expression: Expression of type `<class 'set'>` is not supported
+guppylang_internals.error.GuppyComptimeError: Unsupported Python value: Python value of type `<class 'set'>` cannot be used in Guppy

--- a/tests/integration/test_comptime_expr.py
+++ b/tests/integration/test_comptime_expr.py
@@ -25,6 +25,16 @@ def test_py_alias(validate):
     validate(foo.compile_function())
 
 
+def test_implicit(validate):
+    x = 42
+
+    @guppy
+    def foo() -> int:
+        return x
+
+    validate(foo.compile_function())
+
+
 def test_builtin(validate):
     @compile_guppy
     def foo() -> int:
@@ -154,6 +164,30 @@ def test_func_type_arg(validate):
     @guppy.enum
     class Enum:
         VariantA = {"xs": array[int, comptime(n)]}
+
+    validate(foo.compile_function())
+    validate(bar.compile_function())
+    validate(Baz.compile())
+    validate(Enum.compile())
+
+
+def test_func_type_arg_implicit(validate):
+    n = 10
+
+    @guppy
+    def foo(xs: array[int, n] @ owned) -> array[int, n]:
+        return xs
+
+    @guppy.declare
+    def bar(xs: array[int, n]) -> array[int, n]: ...
+
+    @guppy.struct
+    class Baz:
+        xs: array[int, n]
+
+    @guppy.enum
+    class Enum:
+        VariantA = {"xs": array[int, n]}
 
     validate(foo.compile_function())
     validate(bar.compile_function())


### PR DESCRIPTION
Closes #1158 

BREAKING CHANGE: `guppylang_internals.checker.errors.comptime_errors.IllegalComptimeExpressionError` renamed to `UnsupportedPythonValueError`
BREAKING CHANGE: `guppylang_internals.tys.errors.IllegalComptimeTypeArgError` renamed to `IllegalPythonTypeArgError`