### PR TITLE
feat!: Use mutable state for PCG32 and encapsulate internals

### DIFF
--- a/guppylang/src/guppylang/std/random.py
+++ b/guppylang/src/guppylang/std/random.py
@@ -34,29 +34,26 @@ def _uint32_to_signed(value: nat) -> int:
     return int(masked)
 
 
-@guppy.struct
+@guppy.struct(frozen=False)
 class PCG32:
     """A deterministic 32-bit random number generator using the PCG32 algorithm.
 
     Unlike :py:class:`guppylang.std.qsystem.random.RNG`, PCG32 keeps its state in a
-    local Guppy value rather than in platform-global RNG state. Because Guppy structs
-    are immutable, each draw returns an updated generator together with the value:
+    local Guppy value rather than in platform-global RNG state.
 
     .. code-block:: python
 
         rng = seeded_pcg32(1)
-        rng, value = rng.next_int()
-        rng, another = rng.next_int()
-
-    Thread the returned ``rng`` through your program to keep random streams independent.
+        value = rng.next_int()
+        another = rng.next_int()
     """
 
-    state: nat
-    inc: nat
+    _state: nat
+    _inc: nat
 
     @guppy
     @no_type_check
-    def next_int(self: PCG32) -> tuple[PCG32, int]:
+    def next_int(self: PCG32) -> int:
         """Advance the generator and return the updated state with a random value.
 
         Returns a signed 32-bit integer, matching the shape of
@@ -65,14 +62,14 @@ class PCG32:
         # LCG multiplier N from the PCG paper / pcg32_random_r (64-bit state, 32-bit
         # output).
         pcg32_mult: nat = 6364136223846793005
-        old_state = self.state
-        new_state = nat(old_state * pcg32_mult + self.inc)
+        old_state = self._state
+        self._state = nat(old_state * pcg32_mult + self._inc)
         # XSH-RR output permutation: xor-shift then random rotate (see pcg32_random_r).
         xorshifted = _mask32(((old_state >> nat(18)) ^ old_state) >> nat(27))
         rot = _mask32(old_state >> nat(59))
         rot_inv = _mask32((~rot + nat(1)) & nat(31))
         output = _mask32((xorshifted >> rot) | (xorshifted << rot_inv))
-        return PCG32(new_state, self.inc), _uint32_to_signed(output)
+        return _uint32_to_signed(output)
 
 
 @guppy
@@ -94,7 +91,7 @@ def seeded_pcg32(seed: int) -> PCG32:
     inc = nat((initseq << nat(1)) | nat(1))
     # pcg32_srandom_r: advance twice after mixing initstate into state.
     rng = PCG32(nat(0), inc)
-    rng, _ = rng.next_int()
-    rng = PCG32(rng.state + initstate, rng.inc)
-    rng, _ = rng.next_int()
+    rng.next_int()
+    rng._state += initstate
+    rng.next_int()
     return rng

--- a/guppylang/src/guppylang/std/random.py
+++ b/guppylang/src/guppylang/std/random.py
@@ -34,7 +34,7 @@ def _uint32_to_signed(value: nat) -> int:
     return int(masked)
 
 
-@guppy.struct(frozen=False)
+@guppy.struct
 class PCG32:
     """A deterministic 32-bit random number generator using the PCG32 algorithm.
 

--- a/tests/integration/std/test_random.py
+++ b/tests/integration/std/test_random.py
@@ -8,8 +8,8 @@ def test_pcg32_compile(validate) -> None:
     @guppy
     def main() -> tuple[int, int]:
         rng = seeded_pcg32(1)
-        rng, first = rng.next_int()
-        rng, second = rng.next_int()
+        first = rng.next_int()
+        second = rng.next_int()
         return first, second
 
     validate(main.compile_function())
@@ -19,8 +19,8 @@ def test_pcg32_sequence_seed_1(run_int_fn) -> None:
     @guppy
     def main() -> int:
         rng = seeded_pcg32(1)
-        rng, first = rng.next_int()
-        rng, second = rng.next_int()
+        first = rng.next_int()
+        second = rng.next_int()
         return first + second
 
     run_int_fn(main, 1307692281 + -444364974)
@@ -30,7 +30,7 @@ def test_pcg32_sequence_seed_2(run_int_fn) -> None:
     @guppy
     def main() -> int:
         rng = seeded_pcg32(2)
-        _, first = rng.next_int()
+        first = rng.next_int()
         return first
 
     run_int_fn(main, -8000311)
@@ -44,7 +44,7 @@ def test_pcg32_deterministic_sequence(run_int_fn) -> None:
         rng = seeded_pcg32(54)
         total = 0
         for _ in range(5):
-            rng, value = rng.next_int()
+            value = rng.next_int()
             total += value
         return total
 
@@ -70,17 +70,17 @@ def test_pcg32_motivating_example() -> None:
     @guppy
     def uses_inner_rng() -> int:
         inner = seeded_pcg32(2)
-        _, value = inner.next_int()
+        value = inner.next_int()
         return value
 
     @guppy
     def main() -> None:
         outer = seeded_pcg32(1)
-        outer, first = outer.next_int()
+        first = outer.next_int()
 
         _ = uses_inner_rng()
 
-        outer, second = outer.next_int()
+        second = outer.next_int()
         result("first", first)
         result("second", second)
 
@@ -96,15 +96,15 @@ def test_pcg32_independent_streams(validate, run_int_fn) -> None:
     @guppy
     def uses_inner_rng() -> int:
         inner = seeded_pcg32(2)
-        _, value = inner.next_int()
+        value = inner.next_int()
         return value
 
     @guppy
     def main() -> int:
         outer = seeded_pcg32(1)
-        outer, first = outer.next_int()
+        first = outer.next_int()
         _ = uses_inner_rng()
-        outer, second = outer.next_int()
+        second = outer.next_int()
         return first + second
 
     validate(main.compile_function())
@@ -119,7 +119,7 @@ def test_pcg32_no_interference_with_quantum() -> None:
         p = qubit()
         if measure(q):
             rng_inner = seeded_pcg32(2)
-            _, value = rng_inner.next_int()
+            value = rng_inner.next_int()
             result("rng1_0", value)
             x(p)
         return p
@@ -127,17 +127,17 @@ def test_pcg32_no_interference_with_quantum() -> None:
     @guppy
     def main() -> None:
         rng_outer = seeded_pcg32(1)
-        rng_outer, value = rng_outer.next_int()
+        value = rng_outer.next_int()
         result("rng0_0", value)
 
         q = qubit()
         h(q)
         p = some_outside_function(q)
         if measure(p):
-            _, value = rng_outer.next_int()
+            value = rng_outer.next_int()
             result("rng0_1", value)
         else:
-            _, value = rng_outer.next_int()
+            value = rng_outer.next_int()
             result("rng0_1", value)
 
     results = main.emulator(2).coinflip_sim().with_seed(42).run().results[0].entries


### PR DESCRIPTION
Closes #1821

BREAKING CHANGE: `PCG32.next_int` now mutates the rng in place instead of returning a new state
BREAKING CHANGE: Members of `PCG32` are now private