### PR TITLE
refactor!: Replace track_hugr_side_effects monkeypatch with hierarchy of builder classes

### DIFF
--- a/guppylang-internals/src/guppylang_internals/compiler/builder.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder.py
@@ -40,7 +40,7 @@ class DFBuilder(ABC, ToNode):
         """The underlying Hugr dataflow graph builder."""
 
     @contextmanager
-    def set_ast_context(self, ast_node: AstNode) -> Iterator[None]:
+    def set_ast_context(self, ast_node: AstNode | None) -> Iterator[None]:
         """Context manager to set the current AST node context for debug information
         attachment - within the context of this manager the given `ast_node` will be
         considered the most relevant AST node for any operation added, temporarily

--- a/guppylang-internals/src/guppylang_internals/compiler/builder.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder.py
@@ -27,7 +27,9 @@ class DFBuilder(ABC, ToNode):
     additional actions can be performed every time an operation is added to the graph.
 
     Manages attaching debug information, which requires keeping track of the most
-    relevant AST node for each operation being compiled with `current_ast_node`.
+    relevant AST node for each operation being compiled with `current_ast_node`,
+    and also manages adding Order edges for side-effecting operations, including
+    propagating side-effect-ness to parent builders (e.g. TailLoop, Conditional).
     """
 
     current_ast_node: AstNode | None = field(default=None, kw_only=True)

--- a/guppylang-internals/src/guppylang_internals/compiler/builder.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder.py
@@ -53,11 +53,13 @@ class DFBuilder(ABC, ToNode):
 
     def define_function(
         self, name: str, input_types: ht.TypeRow, output_types: ht.TypeRow
-    ) -> hf.Function:
-        return self._raw.module_root_builder().define_function(
-            name,
-            input_types,
-            output_types,
+    ) -> "FunctionBuilder":
+        return FunctionBuilder(
+            self._raw.module_root_builder().define_function(
+                name,
+                input_types,
+                output_types,
+            )
         )
 
     def to_node(self) -> Node:

--- a/guppylang-internals/src/guppylang_internals/compiler/builder.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder.py
@@ -1,0 +1,258 @@
+from abc import ABC, abstractmethod, abstractproperty
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass, field
+from types import TracebackType
+from typing import Generic, TypeVar
+
+from hugr import Node, Wire, ops, val
+from hugr import tys as ht
+from hugr.build import Block, Case, Cfg, Conditional, TailLoop
+from hugr.build import function as hf
+from hugr.hugr.node_port import ToNode
+from hugr.metadata import HugrDebugInfo
+from typing_extensions import Self, override
+
+from guppylang_internals.ast_util import AstNode
+from guppylang_internals.compiler.core import may_have_side_effect
+from guppylang_internals.metadata.debug_info_util import (
+    debug_conditions_fulfilled,
+    make_location_record,
+)
+
+
+@dataclass
+class DFBuilder(ABC, ToNode):
+    """A wrapper around a dataflow graph builder which ensures compiler-specific
+    additional actions can be performed every time an operation is added to the graph.
+
+    Manages attaching debug information, which requires keeping track of the most
+    relevant AST node for each operation being compiled with `current_ast_node`.
+    """
+
+    current_ast_node: AstNode | None = field(default=None, kw_only=True)
+    _last_side_effect: Node | None = field(default=None, init=False)
+
+    @abstractproperty
+    def _raw(self) -> hf.Function | Case | TailLoop | Block:
+        """The underlying Hugr dataflow graph builder."""
+
+    @contextmanager
+    def set_ast_context(self, ast_node: AstNode) -> Iterator[None]:
+        """Context manager to set the current AST node context for debug information
+        attachment - within the context of this manager the given `ast_node` will be
+        considered the most relevant AST node for any operation added, temporarily
+        overriding the previous `current_ast_node`.
+        """
+        prev_node = self.current_ast_node
+        self.current_ast_node = ast_node
+        try:
+            yield
+        finally:
+            self.current_ast_node = prev_node
+
+    def define_function(
+        self, name: str, input_types: ht.TypeRow, output_types: ht.TypeRow
+    ) -> hf.Function:
+        return self._raw.module_root_builder().define_function(
+            name,
+            input_types,
+            output_types,
+        )
+
+    def to_node(self) -> Node:
+        return self._raw.to_node()
+
+    @property
+    def input_node(self) -> Node:
+        return self._raw.input_node
+
+    def inputs(self) -> Sequence[Wire]:
+        return self._raw.inputs()
+
+    def set_outputs(self, *outputs: Wire) -> hf.Function | Case | TailLoop | Block:
+        self._raw.set_outputs(*outputs)
+        if self._last_side_effect is not None:
+            self._handle_side_effects(self._raw.output_node)
+        return self._raw
+
+    def add_op(
+        self,
+        op: ops.DataflowOp,
+        /,
+        *args: Wire,
+        set_debug_info: bool = True,
+    ) -> Node:
+        """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
+        avoid automatic debug information attachment.
+        """
+        op_node = self._raw.add_op(op, *args)
+        if may_have_side_effect(op):
+            self._handle_side_effects(op_node)
+
+        if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
+            assert self.current_ast_node is not None  # for type-checker
+            op_node.metadata[HugrDebugInfo] = make_location_record(
+                self.current_ast_node
+            )
+        return op_node
+
+    def _handle_side_effects(self, op_node: ToNode) -> None:
+        if self._last_side_effect is None:
+            self._propagate_side_effects()
+            self._last_side_effect = self.input_node
+        else:
+            assert not isinstance(self._raw.hugr[self._last_side_effect].op, ops.Output)
+        node = op_node.to_node()
+        if self._last_side_effect != node:  # avoid self-loops when propagating
+            self._raw.add_state_order(self._last_side_effect, node)
+            self._last_side_effect = node
+
+    @abstractmethod
+    def _propagate_side_effects(self) -> None:
+        """Subclasses must implement to mark the container node
+        as side-effecting within any parent/ancestor builder"""
+
+    def call(
+        self,
+        func: ToNode,
+        *args: Wire,
+        instantiation: ht.FunctionType | None = None,
+        type_args: Sequence[ht.TypeArg] | None = None,
+        set_debug_info: bool = True,
+    ) -> Node:
+        """Calls a static function in the graph. Set `set_debug_info=False` to
+        avoid automatic debug information attachment.
+        """
+        call = self._raw.call(
+            func, *args, instantiation=instantiation, type_args=type_args
+        )
+        self._handle_side_effects(call)
+        if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
+            assert self.current_ast_node is not None  # for type-checker
+            call.metadata[HugrDebugInfo] = make_location_record(self.current_ast_node)
+        return call
+
+    # Other frequently used operations for which we want to avoid having to use
+    # `_raw` every time for convenience, even though we aren't setting any debug
+    # information in them (yet).
+
+    def get_wire_type(self, wire: Wire) -> ht.Type | None:
+        return self._raw.hugr.port_type(wire.out_port())
+
+    def add_conditional(self, cond_wire: Wire, *args: Wire) -> "CondBuilder":
+        return CondBuilder(self._raw.add_conditional(cond_wire, *args), self)
+
+    def add_cfg(self, *args: Wire) -> Cfg:
+        return self._raw.add_cfg(*args)
+
+    def add_tail_loop(
+        self, just_inputs: Sequence[Wire], rest: Sequence[Wire]
+    ) -> "TailLoopBuilder":
+        return TailLoopBuilder(self._raw.add_tail_loop(just_inputs, rest), self)
+
+    def load(
+        self, const: ToNode | val.Value, const_parent: ToNode | None = None
+    ) -> Node:
+        return self._raw.load(const, const_parent)
+
+    def load_function(
+        self,
+        func: ToNode,
+        instantiation: ht.FunctionType | None = None,
+        type_args: Sequence[ht.TypeArg] | None = None,
+    ) -> Node:
+        return self._raw.load_function(func, instantiation, type_args)
+
+    def add_const(self, value: val.Value, parent: ToNode | None = None) -> Node:
+        return self._raw.add_const(value, parent)
+
+
+B = TypeVar("B", bound=hf.Function | Case | TailLoop | Block)
+
+
+@dataclass
+class _DFBuilderRaw(DFBuilder, Generic[B]):
+    _raw_builder: B
+
+    @property
+    def _raw(self) -> B:
+        return self._raw_builder
+
+
+@dataclass
+class TailLoopBuilder(_DFBuilderRaw[TailLoop]):
+    parent: DFBuilder
+
+    def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
+        self._raw.set_loop_outputs(predicate, *outputs)
+        if self._last_side_effect is not None:
+            self._handle_side_effects(self._raw.output_node)
+
+    def _propagate_side_effects(self) -> None:
+        self.parent._handle_side_effects(self._raw)
+
+
+@dataclass
+class FunctionBuilder(_DFBuilderRaw[hf.Function]):
+    def _propagate_side_effects(self) -> None:
+        pass  # No parent
+
+    @override
+    def set_outputs(self, *outputs: Wire) -> hf.Function:
+        super().set_outputs(*outputs)
+        return self._raw
+
+
+@dataclass
+class CaseBuilder(_DFBuilderRaw[Case]):
+    parent: Conditional
+    grandparent: DFBuilder
+
+    def _propagate_side_effects(self) -> None:
+        # No need to do anything in the Conditional,
+        # but the Conditional itself needs to be ordered inside its parent
+        self.grandparent._handle_side_effects(self.parent)
+
+
+@dataclass
+class CondBuilder(ToNode):
+    conditional: Conditional
+    parent: DFBuilder
+
+    def add_case(self, case_id: int) -> CaseBuilder:
+        return CaseBuilder(
+            self.conditional.add_case(case_id), self.conditional, self.parent
+        )
+
+    def to_node(self) -> Node:
+        return self.conditional.to_node()
+
+    def __enter__(self) -> Self:
+        c = self.conditional.__enter__()
+        assert c is self.conditional
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.conditional.__exit__(exc_type, exc_val, exc_tb)
+
+
+@dataclass
+class BlockBuilder(_DFBuilderRaw[Block]):
+    parent: Cfg
+    grandparent: DFBuilder
+
+    def _propagate_side_effects(self) -> None:
+        # No need to do anything in the CFG, but the CFG itself
+        # needs to be ordered inside its parent,
+        self.grandparent._handle_side_effects(self.parent)
+
+    def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
+        self._raw.set_outputs(branching, *other_outputs)
+        if self._last_side_effect is not None:
+            self._handle_side_effects(self._raw.output_node)

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -214,11 +214,9 @@ def choose_vars_for_tuple_sum(
     with dfg.builder.add_conditional(unit_sum, *all_vars_wires) as conditional:
         for i, var_row in enumerate(output_vars):
             with conditional.add_case(i) as case:
-                case_inputs = case.inputs()
-                outputs = [case_inputs[all_vars_idxs[v.id]] for v in var_row]
-                tag = CaseBuilder(case, conditional, dfg.builder).add_op(
-                    ops.Tag(i, sum_type), *outputs
-                )
+                case = CaseBuilder(case, conditional, dfg.builder)
+                outputs = [case.inputs()[all_vars_idxs[v.id]] for v in var_row]
+                tag = case.add_op(ops.Tag(i, sum_type), *outputs)
                 case.set_outputs(tag)
         return conditional
 

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -14,10 +14,9 @@ from guppylang_internals.checker.cfg_checker import (
     Signature,
 )
 from guppylang_internals.checker.core import Place, Variable
+from guppylang_internals.compiler.builder import BlockBuilder, DFBuilder
 from guppylang_internals.compiler.core import (
-    BlockBuilder,
     CompilerContext,
-    DFBuilder,
     DFContainer,
     is_return_var,
     return_var,

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -5,7 +5,6 @@ from typing import cast
 from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.build import cfg as hc
-from hugr.build.dfg import DP, DfBase
 from hugr.hugr.node_port import ToNode
 
 from guppylang_internals.checker.cfg_checker import (
@@ -16,7 +15,10 @@ from guppylang_internals.checker.cfg_checker import (
 )
 from guppylang_internals.checker.core import Place, Variable
 from guppylang_internals.compiler.core import (
+    BlockBuilder,
+    CaseBuilder,
     CompilerContext,
+    DFBuilder,
     DFContainer,
     is_return_var,
     return_var,
@@ -29,7 +31,7 @@ from guppylang_internals.tys.ty import type_to_row
 
 def compile_cfg(
     cfg: CheckedCFG[Place],
-    container: DfBase[DP],
+    container: DFBuilder,
     inputs: Sequence[Wire],
     ctx: CompilerContext,
 ) -> hc.Cfg:
@@ -46,7 +48,7 @@ def compile_cfg(
     ):
         insert_return_vars(cfg)
 
-    builder = container.add_cfg(*inputs)
+    builder: hc.Cfg = container.add_cfg(*inputs)
 
     # Explicitly annotate the output types since Hugr can't infer them if the exit is
     # unreachable
@@ -61,7 +63,7 @@ def compile_cfg(
 
     blocks: dict[CheckedBB[Place], ToNode] = {}
     for bb in cfg.bbs:
-        blocks[bb] = compile_bb(bb, builder, bb == cfg.entry_bb, ctx)
+        blocks[bb] = compile_bb(bb, builder, container, bb == cfg.entry_bb, ctx)
     for bb in cfg.bbs:
         for i, succ in enumerate(bb.successors):
             builder.branch(blocks[bb][i], blocks[succ])
@@ -72,6 +74,7 @@ def compile_cfg(
 def compile_bb(
     bb: CheckedBB[Place],
     builder: hc.Cfg,
+    outer: DFBuilder,
     is_entry: bool,
     ctx: CompilerContext,
 ) -> ToNode:
@@ -98,7 +101,7 @@ def compile_bb(
         block = builder.add_block(*(v.ty.to_hugr(ctx) for v in inputs))
 
     # Add input node and compile the statements
-    dfg = DFContainer(block, ctx)
+    dfg = DFContainer(BlockBuilder(block, builder, outer), ctx)
     for v, wire in zip(inputs, block.input_node, strict=True):
         dfg[v] = wire
     dfg = StmtCompiler(ctx).compile_stmts(bb.statements, dfg)
@@ -213,7 +216,9 @@ def choose_vars_for_tuple_sum(
             with conditional.add_case(i) as case:
                 case_inputs = case.inputs()
                 outputs = [case_inputs[all_vars_idxs[v.id]] for v in var_row]
-                tag = case.add_op(ops.Tag(i, sum_type), *outputs)
+                tag = CaseBuilder(case, conditional, dfg.builder).add_op(
+                    ops.Tag(i, sum_type), *outputs
+                )
                 case.set_outputs(tag)
         return conditional
 

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -91,17 +91,17 @@ def compile_bb(
     assert bb.reachable
 
     # Otherwise, we use a regular `Block` node
-    block: hc.Block
+    hugr_block: hc.Block
     inputs: Sequence[Place]
     if is_entry:
         inputs = bb.sig.input_row
-        block = builder.add_entry()
+        hugr_block = builder.add_entry()
     else:
         inputs = sort_vars(bb.sig.input_row)
-        block = builder.add_block(*(v.ty.to_hugr(ctx) for v in inputs))
-
+        hugr_block = builder.add_block(*(v.ty.to_hugr(ctx) for v in inputs))
+    block = BlockBuilder(hugr_block, builder, outer)
     # Add input node and compile the statements
-    dfg = DFContainer(BlockBuilder(block, builder, outer), ctx)
+    dfg = DFContainer(block, ctx)
     for v, wire in zip(inputs, block.input_node, strict=True):
         dfg[v] = wire
     dfg = StmtCompiler(ctx).compile_stmts(bb.statements, dfg)

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -16,7 +16,6 @@ from guppylang_internals.checker.cfg_checker import (
 from guppylang_internals.checker.core import Place, Variable
 from guppylang_internals.compiler.core import (
     BlockBuilder,
-    CaseBuilder,
     CompilerContext,
     DFBuilder,
     DFContainer,
@@ -213,11 +212,10 @@ def choose_vars_for_tuple_sum(
 
     with dfg.builder.add_conditional(unit_sum, *all_vars_wires) as conditional:
         for i, var_row in enumerate(output_vars):
-            with conditional.add_case(i) as case:
-                case = CaseBuilder(case, conditional, dfg.builder)
-                outputs = [case.inputs()[all_vars_idxs[v.id]] for v in var_row]
-                tag = case.add_op(ops.Tag(i, sum_type), *outputs)
-                case.set_outputs(tag)
+            case = conditional.add_case(i)
+            outputs = [case.inputs()[all_vars_idxs[v.id]] for v in var_row]
+            tag = case.add_op(ops.Tag(i, sum_type), *outputs)
+            case.set_outputs(tag)
         return conditional
 
 

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -340,7 +340,7 @@ class DFBuilder(ABC, ToNode):
                 self.raw_builder.hugr[self._last_stateful_op].op, ops.Output
             )
         node = op_node.to_node()
-        if self._last_stateful_op != node: # avoid self-loops when propagating
+        if self._last_stateful_op != node:  # avoid self-loops when propagating
             self.raw_builder.add_state_order(self._last_stateful_op, node)
             self._last_stateful_op = node
 
@@ -384,12 +384,7 @@ class DFBuilder(ABC, ToNode):
     def add_tail_loop(
         self, just_inputs: Sequence[Wire], rest: Sequence[Wire]
     ) -> "TailLoopBuilder":
-        # Can't state this in the return type without adding a second type parameter
-        # to DFBuilder, which is horrendous (at least until we can provide
-        # default values for type parameters, which arrives in PEP 0696 / python 3.13).
-        # So just get a static check here
-        raw: TailLoop = self.raw_builder.add_tail_loop(just_inputs, rest)
-        return TailLoopBuilder(raw, self)
+        return TailLoopBuilder(self.raw_builder.add_tail_loop(just_inputs, rest), self)
 
     def load(
         self, const: ToNode | val.Value, const_parent: ToNode | None = None
@@ -471,7 +466,6 @@ class BlockBuilder(DFBuilder):
 
     def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
         self.raw_builder.set_outputs(branching, *other_outputs)
-        self._outputs_set = True
         if self._last_stateful_op is not None:
             self._handle_side_effects(self.raw_builder.output_node)
 

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -271,15 +271,13 @@ class DFBuilder(ABC, ToNode):
 
     Manages attaching debug information, which requires keeping track of the most
     relevant AST node for each operation being compiled with `current_ast_node`.
-
-    The underlying builder can still be accessed through `raw_builder`.
     """
 
     current_ast_node: AstNode | None = field(default=None, kw_only=True)
     _last_stateful_op: Node | None = field(default=None, init=False)
 
     @abstractproperty
-    def raw_builder(self) -> hf.Function | Case | TailLoop | Block:
+    def _raw(self) -> hf.Function | Case | TailLoop | Block:
         """The underlying Hugr dataflow graph builder."""
 
     @contextmanager
@@ -299,27 +297,27 @@ class DFBuilder(ABC, ToNode):
     def define_function(
         self, name: str, input_types: ht.TypeRow, output_types: ht.TypeRow
     ) -> hf.Function:
-        return self.raw_builder.module_root_builder().define_function(
+        return self._raw.module_root_builder().define_function(
             name,
             input_types,
             output_types,
         )
 
     def to_node(self) -> Node:
-        return self.raw_builder.to_node()
+        return self._raw.to_node()
 
     @property
     def input_node(self) -> Node:
-        return self.raw_builder.input_node
+        return self._raw.input_node
 
     def inputs(self) -> Sequence[Wire]:
-        return self.raw_builder.inputs()
+        return self._raw.inputs()
 
     def set_outputs(self, *outputs: Wire) -> hf.Function | Case | TailLoop | Block:
-        self.raw_builder.set_outputs(*outputs)
+        self._raw.set_outputs(*outputs)
         if self._last_stateful_op is not None:
-            self._handle_side_effects(self.raw_builder.output_node)
-        return self.raw_builder
+            self._handle_side_effects(self._raw.output_node)
+        return self._raw
 
     def add_op(
         self,
@@ -331,7 +329,7 @@ class DFBuilder(ABC, ToNode):
         """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
         avoid automatic debug information attachment.
         """
-        op_node = self.raw_builder.add_op(op, *args)
+        op_node = self._raw.add_op(op, *args)
         if may_have_side_effect(op):
             self._handle_side_effects(op_node)
 
@@ -347,12 +345,10 @@ class DFBuilder(ABC, ToNode):
             self._propagate_side_effects()
             self._last_stateful_op = self.input_node
         else:
-            assert not isinstance(
-                self.raw_builder.hugr[self._last_stateful_op].op, ops.Output
-            )
+            assert not isinstance(self._raw.hugr[self._last_stateful_op].op, ops.Output)
         node = op_node.to_node()
         if self._last_stateful_op != node:  # avoid self-loops when propagating
-            self.raw_builder.add_state_order(self._last_stateful_op, node)
+            self._raw.add_state_order(self._last_stateful_op, node)
             self._last_stateful_op = node
 
     @abstractmethod
@@ -370,7 +366,7 @@ class DFBuilder(ABC, ToNode):
         """Calls a static function in the graph. Set `set_debug_info=False` to
         avoid automatic debug information attachment.
         """
-        call = self.raw_builder.call(
+        call = self._raw.call(
             func, *args, instantiation=instantiation, type_args=type_args
         )
         self._handle_side_effects(call)
@@ -380,27 +376,27 @@ class DFBuilder(ABC, ToNode):
         return call
 
     # Other frequently used operations for which we want to avoid having to use
-    # `raw_builder` every time for convenience, even though we aren't setting any debug
+    # `_raw` every time for convenience, even though we aren't setting any debug
     # information in them (yet).
 
     def get_wire_type(self, wire: Wire) -> ht.Type | None:
-        return self.raw_builder.hugr.port_type(wire.out_port())
+        return self._raw.hugr.port_type(wire.out_port())
 
     def add_conditional(self, cond_wire: Wire, *args: Wire) -> Conditional:
-        return self.raw_builder.add_conditional(cond_wire, *args)
+        return self._raw.add_conditional(cond_wire, *args)
 
     def add_cfg(self, *args: Wire) -> Cfg:
-        return self.raw_builder.add_cfg(*args)
+        return self._raw.add_cfg(*args)
 
     def add_tail_loop(
         self, just_inputs: Sequence[Wire], rest: Sequence[Wire]
     ) -> "TailLoopBuilder":
-        return TailLoopBuilder(self.raw_builder.add_tail_loop(just_inputs, rest), self)
+        return TailLoopBuilder(self._raw.add_tail_loop(just_inputs, rest), self)
 
     def load(
         self, const: ToNode | val.Value, const_parent: ToNode | None = None
     ) -> Node:
-        return self.raw_builder.load(const, const_parent)
+        return self._raw.load(const, const_parent)
 
     def load_function(
         self,
@@ -408,10 +404,10 @@ class DFBuilder(ABC, ToNode):
         instantiation: ht.FunctionType | None = None,
         type_args: Sequence[ht.TypeArg] | None = None,
     ) -> Node:
-        return self.raw_builder.load_function(func, instantiation, type_args)
+        return self._raw.load_function(func, instantiation, type_args)
 
     def add_const(self, value: val.Value, parent: ToNode | None = None) -> Node:
-        return self.raw_builder.add_const(value, parent)
+        return self._raw.add_const(value, parent)
 
 
 @dataclass
@@ -420,16 +416,16 @@ class TailLoopBuilder(DFBuilder):
     parent: DFBuilder
 
     @property
-    def raw_builder(self) -> TailLoop:
+    def _raw(self) -> TailLoop:
         return self._raw_builder
 
     def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
-        self.raw_builder.set_loop_outputs(predicate, *outputs)
+        self._raw.set_loop_outputs(predicate, *outputs)
         if self._last_stateful_op is not None:
-            self._handle_side_effects(self.raw_builder.output_node)
+            self._handle_side_effects(self._raw.output_node)
 
     def _propagate_side_effects(self) -> None:
-        self.parent._handle_side_effects(self.raw_builder)
+        self.parent._handle_side_effects(self._raw)
 
 
 @dataclass
@@ -437,7 +433,7 @@ class FunctionBuilder(DFBuilder):
     _raw_builder: hf.Function
 
     @property
-    def raw_builder(self) -> hf.Function:
+    def _raw(self) -> hf.Function:
         return self._raw_builder
 
     def _propagate_side_effects(self) -> None:
@@ -446,7 +442,7 @@ class FunctionBuilder(DFBuilder):
     @override
     def set_outputs(self, *outputs: Wire) -> hf.Function:
         super().set_outputs(*outputs)
-        return self.raw_builder
+        return self._raw
 
 
 @dataclass
@@ -456,7 +452,7 @@ class CaseBuilder(DFBuilder):
     grandparent: DFBuilder
 
     @property
-    def raw_builder(self) -> Case:
+    def _raw(self) -> Case:
         return self._raw_builder
 
     def _propagate_side_effects(self) -> None:
@@ -472,7 +468,7 @@ class BlockBuilder(DFBuilder):
     grandparent: DFBuilder
 
     @property
-    def raw_builder(self) -> Block:
+    def _raw(self) -> Block:
         return self._raw_builder
 
     def _propagate_side_effects(self) -> None:
@@ -481,9 +477,9 @@ class BlockBuilder(DFBuilder):
         self.grandparent._handle_side_effects(self.parent)
 
     def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
-        self.raw_builder.set_outputs(branching, *other_outputs)
+        self._raw.set_outputs(branching, *other_outputs)
         if self._last_stateful_op is not None:
-            self._handle_side_effects(self.raw_builder.output_node)
+            self._handle_side_effects(self._raw.output_node)
 
 
 class CompilerBase(ABC):

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -296,6 +296,15 @@ class DFBuilder(ABC, ToNode):
         finally:
             self.current_ast_node = prev_node
 
+    def define_function(
+        self, name: str, input_types: ht.TypeRow, output_types: ht.TypeRow
+    ) -> hf.Function:
+        return self.raw_builder.module_root_builder().define_function(
+            name,
+            input_types,
+            output_types,
+        )
+
     def to_node(self) -> Node:
         return self.raw_builder.to_node()
 

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -1,26 +1,18 @@
 import itertools
-from abc import ABC, abstractmethod, abstractproperty
-from collections.abc import Iterator, Sequence
-from contextlib import contextmanager
+from abc import ABC
 from dataclasses import dataclass, field
-from types import TracebackType
-from typing import Generic, TypeVar
+from typing import TYPE_CHECKING
 
 import tket_exts
-from hugr import Hugr, Node, Wire, ops, val
+from hugr import Hugr, Wire, ops
 from hugr import tys as ht
-from hugr.build import Block, Case, Cfg, Conditional, TailLoop
 from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder
 from hugr.hugr.base import OpVarCov
-from hugr.hugr.node_port import ToNode
-from hugr.metadata import HugrDebugInfo
 from hugr.std import PRELUDE
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
-from typing_extensions import Self, override
 
-from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import (
     FieldAccess,
     Place,
@@ -39,11 +31,7 @@ from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import CompiledCallableDef
 from guppylang_internals.engine import DEF_STORE, ENGINE, MonoDefId
 from guppylang_internals.error import InternalGuppyError
-from guppylang_internals.metadata.debug_info_util import (
-    StringTable,
-    debug_conditions_fulfilled,
-    make_location_record,
-)
+from guppylang_internals.metadata.debug_info_util import StringTable
 from guppylang_internals.std._internal.compiler.tket_exts import GUPPY_EXTENSION
 from guppylang_internals.tys.common import ToHugrContext
 from guppylang_internals.tys.subst import Inst
@@ -52,6 +40,9 @@ from guppylang_internals.tys.ty import (
     TupleType,
     Type,
 )
+
+if TYPE_CHECKING:
+    from guppylang_internals.compiler.builder import DFBuilder
 
 CompiledLocals = dict[PlaceId, Wire]
 
@@ -264,243 +255,6 @@ class DFContainer:
         # Make a copy of the var map so that mutating the copy doesn't
         # mutate our variable mapping
         return DFContainer(self.builder, self.ctx, self.locals.copy())
-
-
-@dataclass
-class DFBuilder(ABC, ToNode):
-    """A wrapper around a dataflow graph builder which ensures compiler-specific
-    additional actions can be performed every time an operation is added to the graph.
-
-    Manages attaching debug information, which requires keeping track of the most
-    relevant AST node for each operation being compiled with `current_ast_node`.
-    """
-
-    current_ast_node: AstNode | None = field(default=None, kw_only=True)
-    _last_side_effect: Node | None = field(default=None, init=False)
-
-    @abstractproperty
-    def _raw(self) -> hf.Function | Case | TailLoop | Block:
-        """The underlying Hugr dataflow graph builder."""
-
-    @contextmanager
-    def set_ast_context(self, ast_node: AstNode) -> Iterator[None]:
-        """Context manager to set the current AST node context for debug information
-        attachment - within the context of this manager the given `ast_node` will be
-        considered the most relevant AST node for any operation added, temporarily
-        overriding the previous `current_ast_node`.
-        """
-        prev_node = self.current_ast_node
-        self.current_ast_node = ast_node
-        try:
-            yield
-        finally:
-            self.current_ast_node = prev_node
-
-    def define_function(
-        self, name: str, input_types: ht.TypeRow, output_types: ht.TypeRow
-    ) -> hf.Function:
-        return self._raw.module_root_builder().define_function(
-            name,
-            input_types,
-            output_types,
-        )
-
-    def to_node(self) -> Node:
-        return self._raw.to_node()
-
-    @property
-    def input_node(self) -> Node:
-        return self._raw.input_node
-
-    def inputs(self) -> Sequence[Wire]:
-        return self._raw.inputs()
-
-    def set_outputs(self, *outputs: Wire) -> hf.Function | Case | TailLoop | Block:
-        self._raw.set_outputs(*outputs)
-        if self._last_side_effect is not None:
-            self._handle_side_effects(self._raw.output_node)
-        return self._raw
-
-    def add_op(
-        self,
-        op: ops.DataflowOp,
-        /,
-        *args: Wire,
-        set_debug_info: bool = True,
-    ) -> Node:
-        """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
-        avoid automatic debug information attachment.
-        """
-        op_node = self._raw.add_op(op, *args)
-        if may_have_side_effect(op):
-            self._handle_side_effects(op_node)
-
-        if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
-            assert self.current_ast_node is not None  # for type-checker
-            op_node.metadata[HugrDebugInfo] = make_location_record(
-                self.current_ast_node
-            )
-        return op_node
-
-    def _handle_side_effects(self, op_node: ToNode) -> None:
-        if self._last_side_effect is None:
-            self._propagate_side_effects()
-            self._last_side_effect = self.input_node
-        else:
-            assert not isinstance(self._raw.hugr[self._last_side_effect].op, ops.Output)
-        node = op_node.to_node()
-        if self._last_side_effect != node:  # avoid self-loops when propagating
-            self._raw.add_state_order(self._last_side_effect, node)
-            self._last_side_effect = node
-
-    @abstractmethod
-    def _propagate_side_effects(self) -> None:
-        """Subclasses must implement to mark the container node
-        as side-effecting within any parent/ancestor builder"""
-
-    def call(
-        self,
-        func: ToNode,
-        *args: Wire,
-        instantiation: ht.FunctionType | None = None,
-        type_args: Sequence[ht.TypeArg] | None = None,
-        set_debug_info: bool = True,
-    ) -> Node:
-        """Calls a static function in the graph. Set `set_debug_info=False` to
-        avoid automatic debug information attachment.
-        """
-        call = self._raw.call(
-            func, *args, instantiation=instantiation, type_args=type_args
-        )
-        self._handle_side_effects(call)
-        if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
-            assert self.current_ast_node is not None  # for type-checker
-            call.metadata[HugrDebugInfo] = make_location_record(self.current_ast_node)
-        return call
-
-    # Other frequently used operations for which we want to avoid having to use
-    # `_raw` every time for convenience, even though we aren't setting any debug
-    # information in them (yet).
-
-    def get_wire_type(self, wire: Wire) -> ht.Type | None:
-        return self._raw.hugr.port_type(wire.out_port())
-
-    def add_conditional(self, cond_wire: Wire, *args: Wire) -> "CondBuilder":
-        return CondBuilder(self._raw.add_conditional(cond_wire, *args), self)
-
-    def add_cfg(self, *args: Wire) -> Cfg:
-        return self._raw.add_cfg(*args)
-
-    def add_tail_loop(
-        self, just_inputs: Sequence[Wire], rest: Sequence[Wire]
-    ) -> "TailLoopBuilder":
-        return TailLoopBuilder(self._raw.add_tail_loop(just_inputs, rest), self)
-
-    def load(
-        self, const: ToNode | val.Value, const_parent: ToNode | None = None
-    ) -> Node:
-        return self._raw.load(const, const_parent)
-
-    def load_function(
-        self,
-        func: ToNode,
-        instantiation: ht.FunctionType | None = None,
-        type_args: Sequence[ht.TypeArg] | None = None,
-    ) -> Node:
-        return self._raw.load_function(func, instantiation, type_args)
-
-    def add_const(self, value: val.Value, parent: ToNode | None = None) -> Node:
-        return self._raw.add_const(value, parent)
-
-
-B = TypeVar("B", bound=hf.Function | Case | TailLoop | Block)
-
-
-@dataclass
-class _DFBuilderRaw(DFBuilder, Generic[B]):
-    _raw_builder: B
-
-    @property
-    def _raw(self) -> B:
-        return self._raw_builder
-
-
-@dataclass
-class TailLoopBuilder(_DFBuilderRaw[TailLoop]):
-    parent: DFBuilder
-
-    def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
-        self._raw.set_loop_outputs(predicate, *outputs)
-        if self._last_side_effect is not None:
-            self._handle_side_effects(self._raw.output_node)
-
-    def _propagate_side_effects(self) -> None:
-        self.parent._handle_side_effects(self._raw)
-
-
-@dataclass
-class FunctionBuilder(_DFBuilderRaw[hf.Function]):
-    def _propagate_side_effects(self) -> None:
-        pass  # No parent
-
-    @override
-    def set_outputs(self, *outputs: Wire) -> hf.Function:
-        super().set_outputs(*outputs)
-        return self._raw
-
-
-@dataclass
-class CaseBuilder(_DFBuilderRaw[Case]):
-    parent: Conditional
-    grandparent: DFBuilder
-
-    def _propagate_side_effects(self) -> None:
-        # No need to do anything in the Conditional,
-        # but the Conditional itself needs to be ordered inside its parent
-        self.grandparent._handle_side_effects(self.parent)
-
-
-@dataclass
-class CondBuilder(ToNode):
-    conditional: Conditional
-    parent: DFBuilder
-
-    def add_case(self, case_id: int) -> CaseBuilder:
-        return CaseBuilder(
-            self.conditional.add_case(case_id), self.conditional, self.parent
-        )
-
-    def to_node(self) -> Node:
-        return self.conditional.to_node()
-
-    def __enter__(self) -> Self:
-        c = self.conditional.__enter__()
-        assert c is self.conditional
-        return self
-
-    def __exit__(
-        self,
-        exc_type: type[BaseException] | None,
-        exc_val: BaseException | None,
-        exc_tb: TracebackType | None,
-    ) -> None:
-        self.conditional.__exit__(exc_type, exc_val, exc_tb)
-
-
-@dataclass
-class BlockBuilder(_DFBuilderRaw[Block]):
-    parent: Cfg
-    grandparent: DFBuilder
-
-    def _propagate_side_effects(self) -> None:
-        # No need to do anything in the CFG, but the CFG itself
-        # needs to be ordered inside its parent,
-        self.grandparent._handle_side_effects(self.parent)
-
-    def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
-        self._raw.set_outputs(branching, *other_outputs)
-        if self._last_side_effect is not None:
-            self._handle_side_effects(self._raw.output_node)
 
 
 class CompilerBase(ABC):

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Generic, TypeVar, override
+from typing import Generic, TypeVar
 
 import tket_exts
 from hugr import Hugr, Node, Wire, ops, val
@@ -17,6 +17,7 @@ from hugr.metadata import HugrDebugInfo
 from hugr.std import PRELUDE
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
+from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import (

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -1,16 +1,16 @@
 import itertools
-from abc import ABC
+from abc import ABC, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any, Generic, cast
+from typing import Any
 
 import tket_exts
 from hugr import Hugr, Node, Wire, ops, val
 from hugr import tys as ht
-from hugr.build import Conditional, TailLoop
+from hugr.build import Block, Case, Cfg, Conditional, TailLoop
 from hugr.build import function as hf
-from hugr.build.dfg import DP, DefinitionBuilder, DfBase
+from hugr.build.dfg import DefinitionBuilder
 from hugr.hugr.base import OpVarCov
 from hugr.hugr.node_port import ToNode
 from hugr.metadata import HugrDebugInfo, NodeMetadata
@@ -197,22 +197,9 @@ class DFContainer:
     current compilation state.
     """
 
-    builder: "DFBuilder[ops.DfParentOp]"
+    builder: "DFBuilder"
     ctx: CompilerContext
     locals: CompiledLocals = field(default_factory=dict)
-
-    def __init__(
-        self,
-        builder: DfBase[DP],
-        ctx: CompilerContext,
-        locals: CompiledLocals | None = None,
-    ) -> None:
-        generic_builder = cast("DfBase[ops.DfParentOp]", builder)
-        if locals is None:
-            locals = {}
-        self.builder = DFBuilder(generic_builder)
-        self.ctx = ctx
-        self.locals = locals
 
     def __getitem__(self, place: Place) -> Wire:
         """Constructs a wire for a local place in this DFG.
@@ -275,11 +262,11 @@ class DFContainer:
     def __copy__(self) -> "DFContainer":
         # Make a copy of the var map so that mutating the copy doesn't
         # mutate our variable mapping
-        return DFContainer(self.builder.raw_builder, self.ctx, self.locals.copy())
+        return DFContainer(self.builder, self.ctx, self.locals.copy())
 
 
 @dataclass
-class DFBuilder(Generic[DP]):
+class DFBuilder(ABC):
     """A wrapper around a dataflow graph builder which ensures compiler-specific
     additional actions can be performed every time an operation is added to the graph.
 
@@ -289,8 +276,11 @@ class DFBuilder(Generic[DP]):
     The underlying builder can still be accessed through `raw_builder`.
     """
 
-    raw_builder: DfBase[DP]
-    current_ast_node: AstNode | None = None
+    current_ast_node: AstNode | None = field(default=None, kw_only=True)
+
+    @abstractproperty
+    def raw_builder(self) -> hf.Function | Case | TailLoop | Block:
+        """The underlying Hugr dataflow graph builder."""
 
     @contextmanager
     def set_ast_context(self, ast_node: AstNode) -> Iterator[None]:
@@ -353,10 +343,18 @@ class DFBuilder(Generic[DP]):
     def add_conditional(self, cond_wire: Wire, *args: Wire) -> Conditional:
         return self.raw_builder.add_conditional(cond_wire, *args)
 
+    def add_cfg(self, *args: Wire) -> Cfg:
+        return self.raw_builder.add_cfg(*args)
+
     def add_tail_loop(
         self, just_inputs: Sequence[Wire], rest: Sequence[Wire]
-    ) -> TailLoop:
-        return self.raw_builder.add_tail_loop(just_inputs, rest)
+    ) -> "TailLoopBuilder":
+        # Can't state this in the return type without adding a second type parameter
+        # to DFBuilder, which is horrendous (at least until we can provide
+        # default values for type parameters, which arrives in PEP 0696 / python 3.13).
+        # So just get a static check here
+        raw: TailLoop = self.raw_builder.add_tail_loop(just_inputs, rest)
+        return TailLoopBuilder(raw, self)
 
     def load(
         self, const: ToNode | val.Value, const_parent: ToNode | None = None
@@ -373,6 +371,50 @@ class DFBuilder(Generic[DP]):
 
     def add_const(self, value: val.Value, parent: ToNode | None = None) -> Node:
         return self.raw_builder.add_const(value, parent)
+
+
+@dataclass
+class TailLoopBuilder(DFBuilder):
+    _raw_builder: TailLoop
+    parent: DFBuilder
+
+    @property
+    def raw_builder(self) -> TailLoop:
+        return self._raw_builder
+
+    def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
+        self.raw_builder.set_loop_outputs(predicate, *outputs)
+
+
+@dataclass
+class FunctionBuilder(DFBuilder):
+    _raw_builder: hf.Function
+
+    @property
+    def raw_builder(self) -> hf.Function:
+        return self._raw_builder
+
+
+@dataclass
+class CaseBuilder(DFBuilder):
+    _raw_builder: Case
+    parent: Conditional
+    grandparent: DFBuilder
+
+    @property
+    def raw_builder(self) -> Case:
+        return self._raw_builder
+
+
+@dataclass
+class BlockBuilder(DFBuilder):
+    _raw_builder: Block
+    parent: Cfg
+    grandparent: DFBuilder
+
+    @property
+    def raw_builder(self) -> Block:
+        return self._raw_builder
 
 
 class CompilerBase(ABC):

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -1,5 +1,5 @@
 import itertools
-from abc import ABC, abstractproperty
+from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -277,6 +277,7 @@ class DFBuilder(ABC, ToNode):
     """
 
     current_ast_node: AstNode | None = field(default=None, kw_only=True)
+    _last_stateful_op: Node | None = field(default=None, init=False)
 
     @abstractproperty
     def raw_builder(self) -> hf.Function | Case | TailLoop | Block:
@@ -308,6 +309,8 @@ class DFBuilder(ABC, ToNode):
 
     def set_outputs(self, *outputs: Wire) -> None:
         self.raw_builder.set_outputs(*outputs)
+        if self._last_stateful_op is not None:
+            self._handle_side_effects(self.raw_builder.output_node)
 
     def add_op(
         self,
@@ -320,12 +323,31 @@ class DFBuilder(ABC, ToNode):
         avoid automatic debug information attachment.
         """
         op_node = self.raw_builder.add_op(op, *args)
+        if may_have_side_effect(op):
+            self._handle_side_effects(op_node)
+
         if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
             assert self.current_ast_node is not None  # for type-checker
             op_node.metadata[HugrDebugInfo] = make_location_record(
                 self.current_ast_node
             )
         return op_node
+
+    def _handle_side_effects(self, op_node: ToNode) -> None:
+        if self._last_stateful_op is None:
+            self._propagate_side_effects()
+            self._last_stateful_op = self.input_node
+        else:
+            assert not isinstance(
+                self.raw_builder.hugr[self._last_stateful_op].op, ops.Output
+            )
+        node = op_node.to_node()
+        # self.raw_builder.add_state_order(self._last_stateful_op, node)
+        self._last_stateful_op = node
+
+    @abstractmethod
+    def _propagate_side_effects(self) -> None:
+        """Subclasses must implement"""
 
     def call(
         self,
@@ -341,6 +363,7 @@ class DFBuilder(ABC, ToNode):
         call = self.raw_builder.call(
             func, *args, instantiation=instantiation, type_args=type_args
         )
+        self._handle_side_effects(call)
         if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
             assert self.current_ast_node is not None  # for type-checker
             call.metadata[HugrDebugInfo] = make_location_record(self.current_ast_node)
@@ -397,6 +420,11 @@ class TailLoopBuilder(DFBuilder):
 
     def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
         self.raw_builder.set_loop_outputs(predicate, *outputs)
+        if self._last_stateful_op is not None:
+            self._handle_side_effects(self.raw_builder.output_node)
+
+    def _propagate_side_effects(self) -> None:
+        self.parent._handle_side_effects(self.raw_builder)
 
 
 @dataclass
@@ -406,6 +434,9 @@ class FunctionBuilder(DFBuilder):
     @property
     def raw_builder(self) -> hf.Function:
         return self._raw_builder
+
+    def _propagate_side_effects(self) -> None:
+        pass  # No parent
 
 
 @dataclass
@@ -418,6 +449,11 @@ class CaseBuilder(DFBuilder):
     def raw_builder(self) -> Case:
         return self._raw_builder
 
+    def _propagate_side_effects(self) -> None:
+        # No need to do anything in the Conditional,
+        # but the Conditional itself needs to be ordered inside its parent
+        self.grandparent._handle_side_effects(self.parent)
+
 
 @dataclass
 class BlockBuilder(DFBuilder):
@@ -429,9 +465,16 @@ class BlockBuilder(DFBuilder):
     def raw_builder(self) -> Block:
         return self._raw_builder
 
+    def _propagate_side_effects(self) -> None:
+        # No need to do anything in the CFG, but the CFG itself
+        # needs to be ordered inside its parent,
+        self.grandparent._handle_side_effects(self.parent)
+
     def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
         self.raw_builder.set_outputs(branching, *other_outputs)
         self._outputs_set = True
+        if self._last_stateful_op is not None:
+            self._handle_side_effects(self.raw_builder.output_node)
 
 
 class CompilerBase(ABC):

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from typing import override
 
 import tket_exts
 from hugr import Hugr, Node, Wire, ops, val
@@ -305,10 +306,11 @@ class DFBuilder(ABC, ToNode):
     def inputs(self) -> Sequence[Wire]:
         return self.raw_builder.inputs()
 
-    def set_outputs(self, *outputs: Wire) -> None:
+    def set_outputs(self, *outputs: Wire) -> hf.Function | Case | TailLoop | Block:
         self.raw_builder.set_outputs(*outputs)
         if self._last_stateful_op is not None:
             self._handle_side_effects(self.raw_builder.output_node)
+        return self.raw_builder
 
     def add_op(
         self,
@@ -431,6 +433,11 @@ class FunctionBuilder(DFBuilder):
 
     def _propagate_side_effects(self) -> None:
         pass  # No parent
+
+    @override
+    def set_outputs(self, *outputs: Wire) -> hf.Function:
+        super().set_outputs(*outputs)
+        return self.raw_builder
 
 
 @dataclass

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -170,14 +170,14 @@ class CompilerContext(ToHugrContext):
         const_id: GlobalConstId,
         func_ty: ht.PolyFuncType,
         type_args: Inst | None = None,
-    ) -> "hf.Function | FunctionBuilder":
+    ) -> tuple[hf.Function, bool]:
         """
-        Creates a FunctionBuilder for a global function if it doesn't already exist,
-        else returns the existing Function.
+        Creates a function builder for a global function if it doesn't already exist,
+        else returns the existing one.
         """
         mono_args = type_args or ()
         if (const_id, mono_args) in self.global_funcs:
-            return self.global_funcs[const_id, mono_args]
+            return self.global_funcs[const_id, mono_args], True
         func = self.module.module_root_builder().define_function(
             name=const_id.name,
             input_types=func_ty.body.input,
@@ -185,7 +185,7 @@ class CompilerContext(ToHugrContext):
             type_params=func_ty.params,
         )
         self.global_funcs[const_id, mono_args] = func
-        return FunctionBuilder(func)
+        return func, False
 
 
 @dataclass

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -3,6 +3,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
+from types import TracebackType
 from typing import Generic, TypeVar
 
 import tket_exts
@@ -17,7 +18,7 @@ from hugr.metadata import HugrDebugInfo
 from hugr.std import PRELUDE
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
-from typing_extensions import override
+from typing_extensions import Self, override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import (
@@ -383,8 +384,8 @@ class DFBuilder(ABC, ToNode):
     def get_wire_type(self, wire: Wire) -> ht.Type | None:
         return self._raw.hugr.port_type(wire.out_port())
 
-    def add_conditional(self, cond_wire: Wire, *args: Wire) -> Conditional:
-        return self._raw.add_conditional(cond_wire, *args)
+    def add_conditional(self, cond_wire: Wire, *args: Wire) -> "CondBuilder":
+        return CondBuilder(self._raw.add_conditional(cond_wire, *args), self)
 
     def add_cfg(self, *args: Wire) -> Cfg:
         return self._raw.add_cfg(*args)
@@ -456,6 +457,33 @@ class CaseBuilder(_DFBuilderRaw[Case]):
         # No need to do anything in the Conditional,
         # but the Conditional itself needs to be ordered inside its parent
         self.grandparent._handle_side_effects(self.parent)
+
+
+@dataclass
+class CondBuilder(ToNode):
+    conditional: Conditional
+    parent: DFBuilder
+
+    def add_case(self, case_id: int) -> CaseBuilder:
+        return CaseBuilder(
+            self.conditional.add_case(case_id), self.conditional, self.parent
+        )
+
+    def to_node(self) -> Node:
+        return self.conditional.to_node()
+
+    def __enter__(self) -> Self:
+        c = self.conditional.__enter__()
+        assert c is self.conditional
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        self.conditional.__exit__(exc_type, exc_val, exc_tb)
 
 
 @dataclass

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -276,7 +276,7 @@ class DFBuilder(ABC, ToNode):
     """
 
     current_ast_node: AstNode | None = field(default=None, kw_only=True)
-    _last_stateful_op: Node | None = field(default=None, init=False)
+    _last_side_effect: Node | None = field(default=None, init=False)
 
     @abstractproperty
     def _raw(self) -> hf.Function | Case | TailLoop | Block:
@@ -317,7 +317,7 @@ class DFBuilder(ABC, ToNode):
 
     def set_outputs(self, *outputs: Wire) -> hf.Function | Case | TailLoop | Block:
         self._raw.set_outputs(*outputs)
-        if self._last_stateful_op is not None:
+        if self._last_side_effect is not None:
             self._handle_side_effects(self._raw.output_node)
         return self._raw
 
@@ -343,15 +343,15 @@ class DFBuilder(ABC, ToNode):
         return op_node
 
     def _handle_side_effects(self, op_node: ToNode) -> None:
-        if self._last_stateful_op is None:
+        if self._last_side_effect is None:
             self._propagate_side_effects()
-            self._last_stateful_op = self.input_node
+            self._last_side_effect = self.input_node
         else:
-            assert not isinstance(self._raw.hugr[self._last_stateful_op].op, ops.Output)
+            assert not isinstance(self._raw.hugr[self._last_side_effect].op, ops.Output)
         node = op_node.to_node()
-        if self._last_stateful_op != node:  # avoid self-loops when propagating
-            self._raw.add_state_order(self._last_stateful_op, node)
-            self._last_stateful_op = node
+        if self._last_side_effect != node:  # avoid self-loops when propagating
+            self._raw.add_state_order(self._last_side_effect, node)
+            self._last_side_effect = node
 
     @abstractmethod
     def _propagate_side_effects(self) -> None:
@@ -431,7 +431,7 @@ class TailLoopBuilder(_DFBuilderRaw[TailLoop]):
 
     def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
         self._raw.set_loop_outputs(predicate, *outputs)
-        if self._last_stateful_op is not None:
+        if self._last_side_effect is not None:
             self._handle_side_effects(self._raw.output_node)
 
     def _propagate_side_effects(self) -> None:
@@ -499,7 +499,7 @@ class BlockBuilder(_DFBuilderRaw[Block]):
 
     def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
         self._raw.set_outputs(branching, *other_outputs)
-        if self._last_stateful_op is not None:
+        if self._last_side_effect is not None:
             self._handle_side_effects(self._raw.output_node)
 
 

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -3,7 +3,6 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import Any
 
 import tket_exts
 from hugr import Hugr, Node, Wire, ops, val
@@ -13,7 +12,7 @@ from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder
 from hugr.hugr.base import OpVarCov
 from hugr.hugr.node_port import ToNode
-from hugr.metadata import HugrDebugInfo, NodeMetadata
+from hugr.metadata import HugrDebugInfo
 from hugr.std import PRELUDE
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
@@ -135,8 +134,7 @@ class CompilerContext(ToHugrContext):
         while self.worklist:
             next_id, next_mono_args = self.worklist.popitem()[0]
             next_def = self.compiled[next_id, next_mono_args]
-            with track_hugr_side_effects():
-                next_def.compile_inner(self)
+            next_def.compile_inner(self)
 
         # Insert explicit drops for affine types
         # TODO: This is a quick workaround until we can properly insert these drops
@@ -342,8 +340,9 @@ class DFBuilder(ABC, ToNode):
                 self.raw_builder.hugr[self._last_stateful_op].op, ops.Output
             )
         node = op_node.to_node()
-        # self.raw_builder.add_state_order(self._last_stateful_op, node)
-        self._last_stateful_op = node
+        if self._last_stateful_op != node: # avoid self-loops when propagating
+            self.raw_builder.add_state_order(self._last_stateful_op, node)
+            self._last_stateful_op = node
 
     @abstractmethod
     def _propagate_side_effects(self) -> None:
@@ -551,75 +550,6 @@ def may_have_side_effect(op: ops.Op) -> bool:
             # TailLoops are only generated for array comprehensions which must have
             # statically-guaranteed (finite) size. TODO revisit this for lists.
             return False
-
-
-@contextmanager
-def track_hugr_side_effects() -> Iterator[None]:
-    """Initialises the tracking of nodes with side-effects during Hugr building.
-
-    Ensures that state-order edges are implicitly inserted between side-effectful nodes
-    to ensure they are executed in the order they are added.
-    """
-    # Remember original `Hugr.add_node` method that is monkey-patched below.
-    hugr_add_node = Hugr.add_node
-    # Last node with potential side effects for each dataflow parent
-    prev_node_with_side_effect: dict[Node, tuple[Node, Hugr[Any]]] = {}
-
-    def hugr_add_node_with_order(
-        self: Hugr[OpVarCov],
-        op: ops.Op,
-        parent: ToNode | None = None,
-        num_outs: int | None = None,
-        metadata: dict[str, Any] | NodeMetadata | None = None,
-    ) -> Node:
-        """Monkey-patched version of `Hugr.add_node` that takes care of implicitly
-        inserting state order edges between operations that could have side-effects.
-        """
-        new_node = hugr_add_node(self, op, parent, num_outs, metadata)
-        if may_have_side_effect(op):
-            handle_side_effect(new_node, self)
-        return new_node
-
-    def handle_side_effect(node: Node, hugr: Hugr[OpVarCov]) -> None:
-        """Performs the actual order-edge insertion, assuming that `node` has a side-
-        effect."""
-        parent = hugr[node].parent
-        assert parent is not None
-
-        if prev := prev_node_with_side_effect.get(parent):
-            prev_node = prev[0]
-        else:
-            # This is the first side-effectful op in this DFG. Recurse on the parent
-            # since the parent is also considered side-effectful now. We shouldn't walk
-            # up through function definitions (only the Module is above)
-            if not isinstance(hugr[parent].op, ops.FuncDefn):
-                handle_side_effect(parent, hugr)
-                # For DataflowBlocks and Cases, recurse to mark their containing CFG
-                # or Conditional as side-effectful as well, but there is nothing to do
-                # locally: we cannot add order edges, but Conditional/CFG semantics
-                # ensure execution if appropriate.
-                if isinstance(hugr[parent].op, ops.Conditional | ops.CFG):
-                    return
-            prev_node = hugr.children(parent)[0]
-            assert isinstance(hugr[prev_node].op, ops.Input)
-
-        # Add edge, but avoid self-loops for containers when recursing up the hierarchy.
-        if prev_node != node:
-            hugr.add_order_link(prev_node, node)
-            prev_node_with_side_effect[parent] = (node, hugr)
-
-    # Monkey-patch the `add_node` method
-    Hugr.add_node = hugr_add_node_with_order  # type: ignore[method-assign]
-    try:
-        yield
-        for parent, (last, hugr) in prev_node_with_side_effect.items():
-            # Connect the last side-effecting node to Output
-            outp = hugr.children(parent)[1]
-            assert isinstance(hugr[outp].op, ops.Output)
-            assert last != outp
-            hugr.add_order_link(last, outp)
-    finally:
-        Hugr.add_node = hugr_add_node  # type: ignore[method-assign]
 
 
 #: List of linear extension types that correspond to affine Guppy types and thus require

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod, abstractproperty
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import override
+from typing import Generic, TypeVar, override
 
 import tket_exts
 from hugr import Hugr, Node, Wire, ops, val
@@ -410,14 +410,21 @@ class DFBuilder(ABC, ToNode):
         return self._raw.add_const(value, parent)
 
 
+B = TypeVar("B", bound=hf.Function | Case | TailLoop | Block)
+
+
 @dataclass
-class TailLoopBuilder(DFBuilder):
-    _raw_builder: TailLoop
-    parent: DFBuilder
+class _DFBuilderRaw(DFBuilder, Generic[B]):
+    _raw_builder: B
 
     @property
-    def _raw(self) -> TailLoop:
+    def _raw(self) -> B:
         return self._raw_builder
+
+
+@dataclass
+class TailLoopBuilder(_DFBuilderRaw[TailLoop]):
+    parent: DFBuilder
 
     def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
         self._raw.set_loop_outputs(predicate, *outputs)
@@ -429,13 +436,7 @@ class TailLoopBuilder(DFBuilder):
 
 
 @dataclass
-class FunctionBuilder(DFBuilder):
-    _raw_builder: hf.Function
-
-    @property
-    def _raw(self) -> hf.Function:
-        return self._raw_builder
-
+class FunctionBuilder(_DFBuilderRaw[hf.Function]):
     def _propagate_side_effects(self) -> None:
         pass  # No parent
 
@@ -446,14 +447,9 @@ class FunctionBuilder(DFBuilder):
 
 
 @dataclass
-class CaseBuilder(DFBuilder):
-    _raw_builder: Case
+class CaseBuilder(_DFBuilderRaw[Case]):
     parent: Conditional
     grandparent: DFBuilder
-
-    @property
-    def _raw(self) -> Case:
-        return self._raw_builder
 
     def _propagate_side_effects(self) -> None:
         # No need to do anything in the Conditional,
@@ -462,14 +458,9 @@ class CaseBuilder(DFBuilder):
 
 
 @dataclass
-class BlockBuilder(DFBuilder):
-    _raw_builder: Block
+class BlockBuilder(_DFBuilderRaw[Block]):
     parent: Cfg
     grandparent: DFBuilder
-
-    @property
-    def _raw(self) -> Block:
-        return self._raw_builder
 
     def _propagate_side_effects(self) -> None:
         # No need to do anything in the CFG, but the CFG itself

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -429,6 +429,10 @@ class BlockBuilder(DFBuilder):
     def raw_builder(self) -> Block:
         return self._raw_builder
 
+    def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
+        self.raw_builder.set_outputs(branching, *other_outputs)
+        self._outputs_set = True
+
 
 class CompilerBase(ABC):
     """Base class for the Guppy compiler."""

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -170,14 +170,14 @@ class CompilerContext(ToHugrContext):
         const_id: GlobalConstId,
         func_ty: ht.PolyFuncType,
         type_args: Inst | None = None,
-    ) -> tuple[hf.Function, bool]:
+    ) -> "hf.Function | FunctionBuilder":
         """
-        Creates a function builder for a global function if it doesn't already exist,
-        else returns the existing one.
+        Creates a FunctionBuilder for a global function if it doesn't already exist,
+        else returns the existing Function.
         """
         mono_args = type_args or ()
         if (const_id, mono_args) in self.global_funcs:
-            return self.global_funcs[const_id, mono_args], True
+            return self.global_funcs[const_id, mono_args]
         func = self.module.module_root_builder().define_function(
             name=const_id.name,
             input_types=func_ty.body.input,
@@ -185,7 +185,7 @@ class CompilerContext(ToHugrContext):
             type_params=func_ty.params,
         )
         self.global_funcs[const_id, mono_args] = func
-        return func, False
+        return FunctionBuilder(func)
 
 
 @dataclass

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -266,7 +266,7 @@ class DFContainer:
 
 
 @dataclass
-class DFBuilder(ABC):
+class DFBuilder(ABC, ToNode):
     """A wrapper around a dataflow graph builder which ensures compiler-specific
     additional actions can be performed every time an operation is added to the graph.
 
@@ -295,6 +295,19 @@ class DFBuilder(ABC):
             yield
         finally:
             self.current_ast_node = prev_node
+
+    def to_node(self) -> Node:
+        return self.raw_builder.to_node()
+
+    @property
+    def input_node(self) -> Node:
+        return self.raw_builder.input_node
+
+    def inputs(self) -> Sequence[Wire]:
+        return self.raw_builder.inputs()
+
+    def set_outputs(self, *outputs: Wire) -> None:
+        self.raw_builder.set_outputs(*outputs)
 
     def add_op(
         self,

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -355,7 +355,8 @@ class DFBuilder(ABC, ToNode):
 
     @abstractmethod
     def _propagate_side_effects(self) -> None:
-        """Subclasses must implement"""
+        """Subclasses must implement to mark the container node
+        as side-effecting within any parent/ancestor builder"""
 
     def call(
         self,

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -26,6 +26,7 @@ from guppylang_internals.compiler.core import (
     CompilerContext,
     DFBuilder,
     DFContainer,
+    FunctionBuilder,
     GlobalConstId,
 )
 from guppylang_internals.compiler.hugr_extension import PartialOp
@@ -154,7 +155,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             "Inputs are not unique"
         )
         self.dfg = DFContainer(builder, self.ctx, self.dfg.locals.copy())
-        hugr_input = builder.raw_builder.input_node
+        hugr_input = builder.input_node
         for input_node, wire in zip(inputs, hugr_input, strict=True):
             self.dfg[input_node.place] = wire
 
@@ -185,7 +186,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             do_break = self.visit(break_predicate)
             loop.set_loop_outputs(do_break, *(self.visit(name) for name in loop_vars))
         # Update the DFG with the outputs from the loop
-        for node, wire in zip(loop_vars, loop.raw_builder, strict=True):
+        for node, wire in zip(loop_vars, loop, strict=True):
             self.dfg[node.place] = wire
 
     @contextmanager
@@ -823,7 +824,8 @@ def array_read_bool(ctx: CompilerContext) -> hf.Function:
     )
     func, already_defined = ctx.declare_global_func(ARRAY_READ_BOOL, sig)
     if not already_defined:
-        func.set_outputs(func.add_op(read_bool(), func.inputs()[0]))
+        fb = FunctionBuilder(func)
+        fb.set_outputs(fb.add_op(read_bool(), fb.inputs()[0]))
     return func
 
 
@@ -836,7 +838,8 @@ def array_make_opaque_bool(ctx: CompilerContext) -> hf.Function:
     )
     func, already_defined = ctx.declare_global_func(ARRAY_MAKE_OPAQUE_BOOL, sig)
     if not already_defined:
-        func.set_outputs(func.add_op(make_opaque(), func.inputs()[0]))
+        fb = FunctionBuilder(func)
+        fb.set_outputs(fb.add_op(make_opaque(), fb.inputs()[0]))
     return func
 
 

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -818,8 +818,9 @@ def array_read_bool(ctx: CompilerContext) -> hf.Function:
         params=[],
         body=ht.FunctionType([OpaqueBool], [ht.Bool]),
     )
-    func = ctx.declare_global_func(ARRAY_READ_BOOL, sig)
-    if isinstance(func, FunctionBuilder):
+    func, already_defined = ctx.declare_global_func(ARRAY_READ_BOOL, sig)
+    if not already_defined:
+        func = FunctionBuilder(func)
         func = func.set_outputs(func.add_op(read_bool(), func.inputs()[0]))
     return func
 
@@ -831,8 +832,9 @@ def array_make_opaque_bool(ctx: CompilerContext) -> hf.Function:
         params=[],
         body=ht.FunctionType([ht.Bool], [OpaqueBool]),
     )
-    func = ctx.declare_global_func(ARRAY_MAKE_OPAQUE_BOOL, sig)
-    if isinstance(func, FunctionBuilder):
+    func, already_defined = ctx.declare_global_func(ARRAY_MAKE_OPAQUE_BOOL, sig)
+    if not already_defined:
+        func = FunctionBuilder(func)
         func = func.set_outputs(func.add_op(make_opaque(), func.inputs()[0]))
     return func
 

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -14,7 +14,6 @@ from hugr import tys as ht
 from hugr import val as hv
 from hugr.build import function as hf
 from hugr.build.cond_loop import Conditional
-from hugr.build.dfg import DP, DfBase
 
 from guppylang_internals.ast_util import AstNode, AstVisitor, get_type
 from guppylang_internals.cfg.builder import tmp_vars
@@ -22,6 +21,7 @@ from guppylang_internals.checker.core import Variable, contains_subscript
 from guppylang_internals.checker.errors.generic import UnsupportedError
 from guppylang_internals.compiler.core import (
     DEBUG_EXTENSION,
+    CaseBuilder,
     CompilerBase,
     CompilerContext,
     DFBuilder,
@@ -136,13 +136,13 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         return [self.compile(e, dfg) for e in expr_to_row(expr)]
 
     @property
-    def builder(self) -> DFBuilder[ops.DfParentOp]:
+    def builder(self) -> DFBuilder:
         """The current Hugr dataflow graph builder."""
         return self.dfg.builder
 
     @contextmanager
     def _new_dfcontainer(
-        self, inputs: list[PlaceNode], builder: DfBase[DP]
+        self, inputs: list[PlaceNode], builder: DFBuilder
     ) -> Iterator[None]:
         """Context manager to build a graph inside a new `DFContainer`.
 
@@ -154,7 +154,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             "Inputs are not unique"
         )
         self.dfg = DFContainer(builder, self.ctx, self.dfg.locals.copy())
-        hugr_input = builder.input_node
+        hugr_input = builder.raw_builder.input_node
         for input_node, wire in zip(inputs, hugr_input, strict=True):
             self.dfg[input_node.place] = wire
 
@@ -185,7 +185,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             do_break = self.visit(break_predicate)
             loop.set_loop_outputs(do_break, *(self.visit(name) for name in loop_vars))
         # Update the DFG with the outputs from the loop
-        for node, wire in zip(loop_vars, loop, strict=True):
+        for node, wire in zip(loop_vars, loop.raw_builder, strict=True):
             self.dfg[node.place] = wire
 
     @contextmanager
@@ -202,7 +202,9 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         """
         # TODO: `Case` is `_DfgBase`, but not `Dfg`?
         case = conditional.add_case(case_id)
-        with self._new_dfcontainer(inputs, case):
+        with self._new_dfcontainer(
+            inputs, CaseBuilder(case, conditional, self.builder)
+        ):
             yield
             case.set_outputs(*(self.visit(name) for name in outputs))
 
@@ -732,7 +734,7 @@ def expr_to_row(expr: ast.expr) -> list[ast.expr]:
 def pack_returns(
     returns: Sequence[Wire],
     return_ty: Type,
-    builder: DFBuilder[ops.DfParentOp],
+    builder: DFBuilder,
     ctx: CompilerContext,
 ) -> Wire:
     """Groups function return values into a tuple"""
@@ -750,7 +752,7 @@ def pack_returns(
 def unpack_wire(
     wire: Wire,
     return_ty: Type,
-    builder: DFBuilder[ops.DfParentOp],
+    builder: DFBuilder,
     ctx: CompilerContext,
     ast_node: AstNode | None = None,
 ) -> list[Wire]:
@@ -848,7 +850,7 @@ def doesnt_contain_none(xs: list[T | None]) -> TypeGuard[list[T]]:
 
 def apply_array_op_with_conversions(
     ctx: CompilerContext,
-    builder: DFBuilder[ops.DfParentOp],
+    builder: DFBuilder,
     op: ops.DataflowOp,
     elem_ty: ht.Type,
     size_arg: ht.TypeArg,

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -13,7 +13,6 @@ from hugr import Wire, ops
 from hugr import tys as ht
 from hugr import val as hv
 from hugr.build import function as hf
-from hugr.build.cond_loop import Conditional
 
 from guppylang_internals.ast_util import AstNode, AstVisitor, get_type
 from guppylang_internals.cfg.builder import tmp_vars
@@ -21,9 +20,9 @@ from guppylang_internals.checker.core import Variable, contains_subscript
 from guppylang_internals.checker.errors.generic import UnsupportedError
 from guppylang_internals.compiler.core import (
     DEBUG_EXTENSION,
-    CaseBuilder,
     CompilerBase,
     CompilerContext,
+    CondBuilder,
     DFBuilder,
     DFContainer,
     FunctionBuilder,
@@ -194,15 +193,14 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         self,
         inputs: list[PlaceNode],
         outputs: list[PlaceNode],
-        conditional: Conditional,
+        conditional: CondBuilder,
         case_id: int,
     ) -> Iterator[None]:
         """Context manager to build a graph inside a new `Case` node.
 
         Automatically adds the `Output` node once the context manager exits.
         """
-        # TODO: `Case` is `_DfgBase`, but not `Dfg`?
-        case = CaseBuilder(conditional.add_case(case_id), conditional, self.builder)
+        case = conditional.add_case(case_id)
         with self._new_dfcontainer(inputs, case):
             yield
             case.set_outputs(*(self.visit(name) for name in outputs))

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -818,9 +818,8 @@ def array_read_bool(ctx: CompilerContext) -> hf.Function:
         params=[],
         body=ht.FunctionType([OpaqueBool], [ht.Bool]),
     )
-    func, already_defined = ctx.declare_global_func(ARRAY_READ_BOOL, sig)
-    if not already_defined:
-        func = FunctionBuilder(func)
+    func = ctx.declare_global_func(ARRAY_READ_BOOL, sig)
+    if isinstance(func, FunctionBuilder):
         func = func.set_outputs(func.add_op(read_bool(), func.inputs()[0]))
     return func
 
@@ -832,9 +831,8 @@ def array_make_opaque_bool(ctx: CompilerContext) -> hf.Function:
         params=[],
         body=ht.FunctionType([ht.Bool], [OpaqueBool]),
     )
-    func, already_defined = ctx.declare_global_func(ARRAY_MAKE_OPAQUE_BOOL, sig)
-    if not already_defined:
-        func = FunctionBuilder(func)
+    func = ctx.declare_global_func(ARRAY_MAKE_OPAQUE_BOOL, sig)
+    if isinstance(func, FunctionBuilder):
         func = func.set_outputs(func.add_op(make_opaque(), func.inputs()[0]))
     return func
 

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -202,10 +202,8 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         Automatically adds the `Output` node once the context manager exits.
         """
         # TODO: `Case` is `_DfgBase`, but not `Dfg`?
-        case = conditional.add_case(case_id)
-        with self._new_dfcontainer(
-            inputs, CaseBuilder(case, conditional, self.builder)
-        ):
+        case = CaseBuilder(conditional.add_case(case_id), conditional, self.builder)
+        with self._new_dfcontainer(inputs, case):
             yield
             case.set_outputs(*(self.visit(name) for name in outputs))
 

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -18,14 +18,12 @@ from guppylang_internals.ast_util import AstNode, AstVisitor, get_type
 from guppylang_internals.cfg.builder import tmp_vars
 from guppylang_internals.checker.core import Variable, contains_subscript
 from guppylang_internals.checker.errors.generic import UnsupportedError
+from guppylang_internals.compiler.builder import CondBuilder, DFBuilder, FunctionBuilder
 from guppylang_internals.compiler.core import (
     DEBUG_EXTENSION,
     CompilerBase,
     CompilerContext,
-    CondBuilder,
-    DFBuilder,
     DFContainer,
-    FunctionBuilder,
     GlobalConstId,
 )
 from guppylang_internals.compiler.hugr_extension import PartialOp

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -822,8 +822,8 @@ def array_read_bool(ctx: CompilerContext) -> hf.Function:
     )
     func, already_defined = ctx.declare_global_func(ARRAY_READ_BOOL, sig)
     if not already_defined:
-        fb = FunctionBuilder(func)
-        fb.set_outputs(fb.add_op(read_bool(), fb.inputs()[0]))
+        func = FunctionBuilder(func)
+        func = func.set_outputs(func.add_op(read_bool(), func.inputs()[0]))
     return func
 
 
@@ -836,8 +836,8 @@ def array_make_opaque_bool(ctx: CompilerContext) -> hf.Function:
     )
     func, already_defined = ctx.declare_global_func(ARRAY_MAKE_OPAQUE_BOOL, sig)
     if not already_defined:
-        fb = FunctionBuilder(func)
-        fb.set_outputs(fb.add_op(make_opaque(), fb.inputs()[0]))
+        func = FunctionBuilder(func)
+        func = func.set_outputs(func.add_op(make_opaque(), func.inputs()[0]))
     return func
 
 

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -24,7 +24,8 @@ def compile_global_func_def(
     ctx: CompilerContext,
 ) -> None:
     """Compiles a top-level function definition to Hugr."""
-    cfg = compile_cfg(func.cfg, FunctionBuilder(builder), builder.inputs(), ctx)
+    builder = FunctionBuilder(builder)
+    cfg = compile_cfg(func.cfg, builder, builder.inputs(), ctx)
     builder.set_outputs(*cfg)
 
 
@@ -49,8 +50,10 @@ def compile_local_func_def(
     # Prepend captured variables to the function arguments
     func_ty = func.ty.to_hugr(ctx)
     closure_ty = ht.FunctionType([*captured_types, *func_ty.input], func_ty.output)
-    func_builder = dfg.builder.raw_builder.module_root_builder().define_function(
-        func.name, closure_ty.input, closure_ty.output
+    func_builder = FunctionBuilder(
+        dfg.builder.raw_builder.module_root_builder().define_function(
+            func.name, closure_ty.input, closure_ty.output
+        )
     )
 
     # Nested functions are not generic, so no need to worry about monomorphization
@@ -73,7 +76,7 @@ def compile_local_func_def(
         func.cfg.input_tys.append(func.ty)
 
         # Compile the CFG
-        cfg = compile_cfg(func.cfg, FunctionBuilder(func_builder), call_args, ctx)
+        cfg = compile_cfg(func.cfg, func_builder, call_args, ctx)
         func_builder.set_outputs(*cfg)
     else:
         # Otherwise, we treat the function like a normal global variable
@@ -89,7 +92,7 @@ def compile_local_func_def(
             # so the hugr name does not really matter.
             func.name,
             func.cfg,
-            func_builder,
+            func_builder.raw_builder,
         )
         ctx.worklist[func.def_id, mono_args] = None  # will compile the CFG later
 

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -50,10 +50,8 @@ def compile_local_func_def(
     # Prepend captured variables to the function arguments
     func_ty = func.ty.to_hugr(ctx)
     closure_ty = ht.FunctionType([*captured_types, *func_ty.input], func_ty.output)
-    func_builder = FunctionBuilder(
-        dfg.builder.raw_builder.module_root_builder().define_function(
-            func.name, closure_ty.input, closure_ty.output
-        )
+    func_builder = dfg.builder.raw_builder.module_root_builder().define_function(
+        func.name, closure_ty.input, closure_ty.output
     )
 
     # Nested functions are not generic, so no need to worry about monomorphization
@@ -62,8 +60,9 @@ def compile_local_func_def(
     # If we have captured variables and the body contains a recursive occurrence of
     # the function itself, then we provide the partially applied function as a local
     # variable
-    call_args: list[Wire] = list(func_builder.inputs())
     if len(captured) > 0 and recursive:
+        func_builder = FunctionBuilder(func_builder)
+        call_args: list[Wire] = list(func_builder.inputs())
         check_partial_functions_enabled()
         loaded = func_builder.load_function(func_builder, closure_ty)
         partial = func_builder.add_op(
@@ -92,7 +91,7 @@ def compile_local_func_def(
             # so the hugr name does not really matter.
             func.name,
             func.cfg,
-            func_builder.raw_builder,
+            func_builder,
         )
         ctx.worklist[func.def_id, mono_args] = None  # will compile the CFG later
 

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -2,7 +2,6 @@ from typing import TYPE_CHECKING
 
 from hugr import Wire
 from hugr import tys as ht
-from hugr.build.function import Function
 
 from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
@@ -17,11 +16,10 @@ if TYPE_CHECKING:
 
 def compile_global_func_def(
     func: "CheckedFunctionDef",
-    builder: Function,
+    builder: FunctionBuilder,
     ctx: CompilerContext,
 ) -> None:
     """Compiles a top-level function definition to Hugr."""
-    builder = FunctionBuilder(builder)
     cfg = compile_cfg(func.cfg, builder, builder.inputs(), ctx)
     builder.set_outputs(*cfg)
 
@@ -58,7 +56,6 @@ def compile_local_func_def(
     # the function itself, then we provide the partially applied function as a local
     # variable
     if len(captured) > 0 and recursive:
-        func_builder = FunctionBuilder(func_builder)
         call_args: list[Wire] = list(func_builder.inputs())
         check_partial_functions_enabled()
         loaded = func_builder.load_function(func_builder, closure_ty)

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -5,7 +5,11 @@ from hugr import tys as ht
 from hugr.build.function import Function
 
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
-from guppylang_internals.compiler.core import CompilerContext, DFContainer
+from guppylang_internals.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    FunctionBuilder,
+)
 from guppylang_internals.compiler.hugr_extension import PartialOp
 from guppylang_internals.experimental import check_partial_functions_enabled
 from guppylang_internals.nodes import CheckedNestedFunctionDef
@@ -20,7 +24,7 @@ def compile_global_func_def(
     ctx: CompilerContext,
 ) -> None:
     """Compiles a top-level function definition to Hugr."""
-    cfg = compile_cfg(func.cfg, builder, builder.inputs(), ctx)
+    cfg = compile_cfg(func.cfg, FunctionBuilder(builder), builder.inputs(), ctx)
     builder.set_outputs(*cfg)
 
 
@@ -69,7 +73,7 @@ def compile_local_func_def(
         func.cfg.input_tys.append(func.ty)
 
         # Compile the CFG
-        cfg = compile_cfg(func.cfg, func_builder, call_args, ctx)
+        cfg = compile_cfg(func.cfg, FunctionBuilder(func_builder), call_args, ctx)
         func_builder.set_outputs(*cfg)
     else:
         # Otherwise, we treat the function like a normal global variable

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -1,11 +1,27 @@
+from typing import TYPE_CHECKING
+
 from hugr import Wire
 from hugr import tys as ht
 
+from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.hugr_extension import PartialOp
 from guppylang_internals.experimental import check_partial_functions_enabled
 from guppylang_internals.nodes import CheckedNestedFunctionDef
+
+if TYPE_CHECKING:
+    from guppylang_internals.definition.function import CheckedFunctionDef
+
+
+def compile_global_func_def(
+    func: "CheckedFunctionDef",
+    builder: FunctionBuilder,
+    ctx: CompilerContext,
+) -> None:
+    """Compiles a top-level function definition to Hugr."""
+    cfg = compile_cfg(func.cfg, builder, builder.inputs(), ctx)
+    builder.set_outputs(*cfg)
 
 
 def compile_local_func_def(

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -1,27 +1,11 @@
-from typing import TYPE_CHECKING
-
 from hugr import Wire
 from hugr import tys as ht
 
-from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.hugr_extension import PartialOp
 from guppylang_internals.experimental import check_partial_functions_enabled
 from guppylang_internals.nodes import CheckedNestedFunctionDef
-
-if TYPE_CHECKING:
-    from guppylang_internals.definition.function import CheckedFunctionDef
-
-
-def compile_global_func_def(
-    func: "CheckedFunctionDef",
-    builder: FunctionBuilder,
-    ctx: CompilerContext,
-) -> None:
-    """Compiles a top-level function definition to Hugr."""
-    cfg = compile_cfg(func.cfg, builder, builder.inputs(), ctx)
-    builder.set_outputs(*cfg)
 
 
 def compile_local_func_def(

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -50,7 +50,7 @@ def compile_local_func_def(
     # Prepend captured variables to the function arguments
     func_ty = func.ty.to_hugr(ctx)
     closure_ty = ht.FunctionType([*captured_types, *func_ty.input], func_ty.output)
-    func_builder = dfg.builder.raw_builder.module_root_builder().define_function(
+    func_builder = dfg.builder.define_function(
         func.name, closure_ty.input, closure_ty.output
     )
 

--- a/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/func_compiler.py
@@ -4,12 +4,9 @@ from hugr import Wire
 from hugr import tys as ht
 from hugr.build.function import Function
 
+from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
-from guppylang_internals.compiler.core import (
-    CompilerContext,
-    DFContainer,
-    FunctionBuilder,
-)
+from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.hugr_extension import PartialOp
 from guppylang_internals.experimental import check_partial_functions_enabled
 from guppylang_internals.nodes import CheckedNestedFunctionDef

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -7,7 +7,11 @@ from guppylang_internals.ast_util import get_type
 from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
 from guppylang_internals.checker.modifier_checker import non_copyable_front_others_back
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
-from guppylang_internals.compiler.core import CompilerContext, DFContainer
+from guppylang_internals.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    FunctionBuilder,
+)
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.metadata.common import add_metadata
 from guppylang_internals.nodes import CheckedModifiedBlock, PlaceNode
@@ -64,7 +68,9 @@ def compile_modified_block(
     )
 
     # compile body
-    cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
+    cfg = compile_cfg(
+        modified_block.cfg, FunctionBuilder(func_builder), func_builder.inputs(), ctx
+    )
     func_builder.set_outputs(*cfg)
 
     # Add the LoadFunc node

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -6,7 +6,6 @@ from hugr import tys as ht
 from guppylang_internals.ast_util import get_type
 from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
 from guppylang_internals.checker.modifier_checker import non_copyable_front_others_back
-from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
@@ -63,7 +62,6 @@ def compile_modified_block(
         func_builder,
         additional_metadata={"unitary": modified_block.ty.unitary_flags.value},
     )
-    func_builder = FunctionBuilder(func_builder)
     # compile body
     cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
     func_builder.set_outputs(*cfg)

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -66,11 +66,9 @@ def compile_modified_block(
         func_builder,
         additional_metadata={"unitary": modified_block.ty.unitary_flags.value},
     )
-
+    func_builder = FunctionBuilder(func_builder)
     # compile body
-    cfg = compile_cfg(
-        modified_block.cfg, FunctionBuilder(func_builder), func_builder.inputs(), ctx
-    )
+    cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
     func_builder.set_outputs(*cfg)
 
     # Add the LoadFunc node

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -59,7 +59,7 @@ def compile_modified_block(
     in_out_arg = ht.ListArg([t.type_arg() for t in in_out_ht])
     other_in_arg = ht.ListArg([t.type_arg() for t in other_in_ht])
 
-    func_builder = dfg.builder.raw_builder.module_root_builder().define_function(
+    func_builder = dfg.builder.define_function(
         str(modified_block), hugr_ty.input, hugr_ty.output
     )
     add_metadata(

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -6,12 +6,9 @@ from hugr import tys as ht
 from guppylang_internals.ast_util import get_type
 from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
 from guppylang_internals.checker.modifier_checker import non_copyable_front_others_back
+from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
-from guppylang_internals.compiler.core import (
-    CompilerContext,
-    DFContainer,
-    FunctionBuilder,
-)
+from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.metadata.common import add_metadata
 from guppylang_internals.nodes import CheckedModifiedBlock, PlaceNode

--- a/guppylang-internals/src/guppylang_internals/compiler/stmt_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/stmt_compiler.py
@@ -61,7 +61,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
         return self.dfg
 
     @property
-    def builder(self) -> DFBuilder[ops.DfParentOp]:
+    def builder(self) -> DFBuilder:
         """The Hugr dataflow graph builder."""
         return self.dfg.builder
 

--- a/guppylang-internals/src/guppylang_internals/compiler/stmt_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/stmt_compiler.py
@@ -6,10 +6,10 @@ from hugr import Wire, ops
 
 from guppylang_internals.ast_util import AstVisitor, get_type
 from guppylang_internals.checker.core import Variable, contains_subscript
+from guppylang_internals.compiler.builder import DFBuilder
 from guppylang_internals.compiler.core import (
     CompilerBase,
     CompilerContext,
-    DFBuilder,
     DFContainer,
     return_var,
 )

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -308,13 +308,12 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
 
         # We create a monomorphic `FunctionDef` that takes some inputs, contains the
         # results of compiling a call to the function, and returns those results
-        func, already_defined = ctx.declare_global_func(
+        func = ctx.declare_global_func(
             self.higher_order_func_id,
             self.ty.to_hugr_poly(ctx),
             self.type_args,
         )
-        if not already_defined:
-            func = FunctionBuilder(func)
+        if isinstance(func, FunctionBuilder):
             func_dfg = DFContainer(func, ctx, dfg.locals.copy())
             args: list[Wire] = list(func.inputs())
             returns = self.compile_call(args, func_dfg, ctx, node)

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -24,6 +24,7 @@ from guppylang_internals.compiler.core import (
     CompilerContext,
     DFBuilder,
     DFContainer,
+    FunctionBuilder,
     GlobalConstId,
 )
 from guppylang_internals.definition.common import CheckableGenericDef, ParsableDef
@@ -313,7 +314,7 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
             self.type_args,
         )
         if not already_defined:
-            func_dfg = DFContainer(func, ctx, dfg.locals.copy())
+            func_dfg = DFContainer(FunctionBuilder(func), ctx, dfg.locals.copy())
             args: list[Wire] = list(func.inputs())
             returns = self.compile_call(args, func_dfg, ctx, node)
             func.set_outputs(*returns.regular_returns, *returns.inout_returns)
@@ -469,7 +470,7 @@ class CustomInoutCallCompiler(ABC):
         """
 
     @property
-    def builder(self) -> DFBuilder[ops.DfParentOp]:
+    def builder(self) -> DFBuilder:
         """The hugr dataflow builder."""
         return self.dfg.builder
 

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -308,12 +308,13 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
 
         # We create a monomorphic `FunctionDef` that takes some inputs, contains the
         # results of compiling a call to the function, and returns those results
-        func = ctx.declare_global_func(
+        func, already_defined = ctx.declare_global_func(
             self.higher_order_func_id,
             self.ty.to_hugr_poly(ctx),
             self.type_args,
         )
-        if isinstance(func, FunctionBuilder):
+        if not already_defined:
+            func = FunctionBuilder(func)
             func_dfg = DFContainer(func, ctx, dfg.locals.copy())
             args: list[Wire] = list(func.inputs())
             returns = self.compile_call(args, func_dfg, ctx, node)

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -20,11 +20,10 @@ from guppylang_internals.ast_util import (
 from guppylang_internals.checker.core import Context, Globals
 from guppylang_internals.checker.expr_checker import check_call, synthesize_call
 from guppylang_internals.checker.func_checker import check_signature
+from guppylang_internals.compiler.builder import DFBuilder, FunctionBuilder
 from guppylang_internals.compiler.core import (
     CompilerContext,
-    DFBuilder,
     DFContainer,
-    FunctionBuilder,
     GlobalConstId,
 )
 from guppylang_internals.definition.common import CheckableGenericDef, ParsableDef

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -314,7 +314,8 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
             self.type_args,
         )
         if not already_defined:
-            func_dfg = DFContainer(FunctionBuilder(func), ctx, dfg.locals.copy())
+            func = FunctionBuilder(func)
+            func_dfg = DFContainer(func, ctx, dfg.locals.copy())
             args: list[Wire] = list(func.inputs())
             returns = self.compile_call(args, func_dfg, ctx, node)
             func.set_outputs(*returns.regular_returns, *returns.inout_returns)

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -290,20 +290,21 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
             other representations, regardless of whether the function is actually
             visible for linking)
         cfg: The type- and linearity-checked CFG for the function body.
-        func_def: The Hugr function definition.
+        _func_bldr: used to build the function body in `compile_inner`; clients
+                   should use `hugr_node`
     """
 
-    func_def: FunctionBuilder
+    _func_bldr: FunctionBuilder
 
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
-        return self.func_def.to_node()
+        return self._func_bldr.to_node()
 
     @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         """Loads the function as a value into a local Hugr dataflow graph."""
-        return load(dfg, self.func_def)
+        return load(dfg, self.hugr_node)
 
     @override
     def compile_call(
@@ -314,12 +315,12 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
         node: AstNode,
     ) -> CallReturnWires:
         """Compiles a call to the function."""
-        return compile_call(args, dfg, self.ty, self.func_def, node)
+        return compile_call(args, dfg, self.ty, self.hugr_node, node)
 
     @override
     def compile_inner(self, globals: CompilerContext) -> None:
         """Compiles the body of the function."""
-        compile_global_func_def(self, self.func_def, globals)
+        compile_global_func_def(self, self._func_bldr, globals)
 
 
 def load(dfg: DFContainer, func: ToNode) -> Wire:

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -1,7 +1,7 @@
 import ast
 import inspect
 from collections.abc import Callable, Sequence
-from dataclasses import InitVar, dataclass, field
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from hugr import Node, Wire
@@ -28,11 +28,11 @@ from guppylang_internals.checker.func_checker import (
     parse_function_with_docstring,
 )
 from guppylang_internals.compiler.builder import FunctionBuilder
-from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import (
     CompilerContext,
     DFContainer,
 )
+from guppylang_internals.compiler.func_compiler import compile_global_func_def
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
     CheckableGenericDef,
@@ -294,16 +294,12 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
                    should use `hugr_node`
     """
 
-    func_bldr: InitVar[FunctionBuilder] = field(default=None)
-    _bldr_node: FunctionBuilder | Node = field(init=False)
-
-    def __post_init__(self, func_bldr: FunctionBuilder) -> None:
-        object.__setattr__(self, "_bldr_node", func_bldr)
+    _func_bldr: FunctionBuilder
 
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
-        return self._bldr_node.to_node()
+        return self._func_bldr.to_node()
 
     @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
@@ -324,11 +320,7 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
     @override
     def compile_inner(self, globals: CompilerContext) -> None:
         """Compiles the body of the function."""
-        assert isinstance(self._bldr_node, FunctionBuilder)
-        cfg = compile_cfg(self.cfg, self._bldr_node, self._bldr_node.inputs(), globals)
-        object.__setattr__(
-            self, "_bldr_node", self._bldr_node.set_outputs(*cfg).to_node()
-        )
+        compile_global_func_def(self, self._func_bldr, globals)
 
 
 def load(dfg: DFContainer, func: ToNode) -> Wire:

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -1,7 +1,7 @@
 import ast
 import inspect
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from hugr import Node, Wire
@@ -28,11 +28,11 @@ from guppylang_internals.checker.func_checker import (
     parse_function_with_docstring,
 )
 from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import (
     CompilerContext,
     DFContainer,
 )
-from guppylang_internals.compiler.func_compiler import compile_global_func_def
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
     CheckableGenericDef,
@@ -294,12 +294,16 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
                    should use `hugr_node`
     """
 
-    _func_bldr: FunctionBuilder
+    func_bldr: InitVar[FunctionBuilder] = field(default=None)
+    _bldr_node: FunctionBuilder | Node = field(init=False)
+
+    def __post_init__(self, func_bldr: FunctionBuilder) -> None:
+        object.__setattr__(self, "_bldr_node", func_bldr)
 
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
-        return self._func_bldr.to_node()
+        return self._bldr_node.to_node()
 
     @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
@@ -320,7 +324,11 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
     @override
     def compile_inner(self, globals: CompilerContext) -> None:
         """Compiles the body of the function."""
-        compile_global_func_def(self, self._func_bldr, globals)
+        assert isinstance(self._bldr_node, FunctionBuilder)
+        cfg = compile_cfg(self.cfg, self._bldr_node, self._bldr_node.inputs(), globals)
+        object.__setattr__(
+            self, "_bldr_node", self._bldr_node.set_outputs(*cfg).to_node()
+        )
 
 
 def load(dfg: DFContainer, func: ToNode) -> Wire:

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -4,7 +4,6 @@ from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-import hugr.build.function as hf
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.debug_info import DISubprogram
@@ -28,6 +27,7 @@ from guppylang_internals.checker.func_checker import (
     check_signature,
     parse_function_with_docstring,
 )
+from guppylang_internals.compiler.builder import FunctionBuilder
 from guppylang_internals.compiler.core import (
     CompilerContext,
     DFContainer,
@@ -270,7 +270,7 @@ class CheckedFunctionDef(ParsedFunctionDef, CompilableDef):
             self.docstring,
             self.link_name,
             self.cfg,
-            func_def,
+            FunctionBuilder(func_def),
             metadata=self.metadata,
         )
 
@@ -293,12 +293,12 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
         func_def: The Hugr function definition.
     """
 
-    func_def: hf.Function
+    func_def: FunctionBuilder
 
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
-        return self.func_def.parent_node
+        return self.func_def.to_node()
 
     @override
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -275,7 +275,9 @@ class ParsedPytketDef(CallableDef, CompilableDef):
                 rotation = outer_func.add_op(from_halfturns_unchecked(), halfturns)
                 param_wires.append(rotation)
 
-        # Pass all arguments to call node.
+        # Pass all arguments to call node. Note that since we are using a
+        # FunctionBuilder, this will default to assuming that the target function
+        # is side-effecting, so may produce more order edges than necessary.
         call_node = outer_func.call(hugr_func, *(input_list + bool_wires + param_wires))
         # Add debug info metadata to the call node inside the outer function definition.
         if debug_mode_enabled():

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -20,11 +20,8 @@ from guppylang_internals.checker.expr_checker import check_call, synthesize_call
 from guppylang_internals.checker.func_checker import (
     check_signature,
 )
-from guppylang_internals.compiler.core import (
-    CompilerContext,
-    DFContainer,
-    FunctionBuilder,
-)
+from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
     CompilableDef,

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -20,7 +20,11 @@ from guppylang_internals.checker.expr_checker import check_call, synthesize_call
 from guppylang_internals.checker.func_checker import (
     check_signature,
 )
-from guppylang_internals.compiler.core import CompilerContext, DFContainer
+from guppylang_internals.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    FunctionBuilder,
+)
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
     CompilableDef,
@@ -215,7 +219,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
                     scope_line=None,
                 )
             outer_func.metadata[HugrDebugInfo] = func_metadata
-
+        outer_func = FunctionBuilder(outer_func)
         # Number of qubit inputs in the outer function.
         offset = (
             len(self.input_circuit.q_registers)
@@ -300,7 +304,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         # Convert hugr sum bools into the opaque bools that Guppy uses.
         wires = [
             outer_func.add_op(make_opaque(), wire)
-            if outer_func.hugr.port_type(wire.out_port()) == ht.Bool
+            if outer_func.get_wire_type(wire) == ht.Bool
             else wire
             for wire in wires
         ]
@@ -338,7 +342,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
             self.input_circuit,
             self.use_arrays,
             self.source_span,
-            outer_func,
+            outer_func.raw_builder,
         )
 
     @override

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -332,7 +332,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
                 wire_idx = wire_idx + q_reg.size
             wires = array_wires
 
-        outer_func.set_outputs(*wires)
+        outer_func = outer_func.set_outputs(*wires)
 
         return CompiledPytketDef(
             self.id,
@@ -342,7 +342,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
             self.input_circuit,
             self.use_arrays,
             self.source_span,
-            outer_func.raw_builder,
+            outer_func,
         )
 
     @override

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -20,7 +20,11 @@ from guppylang_internals.checker.expr_checker import (
 from guppylang_internals.checker.func_checker import (
     check_signature,
 )
-from guppylang_internals.compiler.core import CompilerContext, DFContainer
+from guppylang_internals.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    FunctionBuilder,
+)
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
     CompilableDef,
@@ -183,7 +187,7 @@ class CompiledTracedFunctionDef(
         trace_function(
             self.python_func,
             self.ty,
-            self.func_def,
+            FunctionBuilder(self.func_def),
             ctx,
             self.defined_at,
             self,

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -20,11 +20,8 @@ from guppylang_internals.checker.expr_checker import (
 from guppylang_internals.checker.func_checker import (
     check_signature,
 )
-from guppylang_internals.compiler.core import (
-    CompilerContext,
-    DFContainer,
-    FunctionBuilder,
-)
+from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
     CompilableDef,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -248,7 +248,7 @@ P = TypeVar("P", bound=ops.DfParentOp)
 
 
 def unpack_array(
-    builder: DFBuilder[P], array: Wire, ast_node: AstNode | None = None
+    builder: DFBuilder, array: Wire, ast_node: AstNode | None = None
 ) -> list[Wire]:
     """Unpacks a wire of type array into separate wires for each element."""
     array_ty = builder.get_wire_type(array)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -19,7 +19,7 @@ from guppylang_internals.tys.arg import ConstArg, TypeArg
 
 if TYPE_CHECKING:
     from guppylang_internals.ast_util import AstNode
-    from guppylang_internals.compiler.core import DFBuilder
+    from guppylang_internals.compiler.builder import DFBuilder
 
 
 # ------------------------------------------------------

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
@@ -4,6 +4,7 @@ from collections.abc import Sequence
 from hugr import Wire, ops
 from hugr import tys as ht
 
+from guppylang_internals.compiler.core import CaseBuilder
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -89,6 +90,7 @@ class EitherTestCompiler(EitherCompiler):
         for i in [0, 1]:
             with cond.add_case(i) as case:
                 val = OPAQUE_TRUE if i == self.tag else OPAQUE_FALSE
+                case = CaseBuilder(case, cond, self.builder)
                 either = case.add_op(ops.Tag(i, self.either_ty), *case.inputs())
                 case.set_outputs(case.load(val), either)
         [res, either] = cond.outputs()
@@ -107,6 +109,7 @@ class EitherToOptionCompiler(EitherCompiler, CustomCallCompiler):
         target_tys = self.left_tys if self.tag == 0 else self.right_tys
         for i in [0, 1]:
             with cond.add_case(i) as case:
+                case = CaseBuilder(case, cond, self.builder)
                 if i == self.tag:
                     out = case.add_op(
                         ops.Tag(1, ht.Option(*target_tys)), *case.inputs()

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
@@ -4,7 +4,6 @@ from collections.abc import Sequence
 from hugr import Wire, ops
 from hugr import tys as ht
 
-from guppylang_internals.compiler.core import CaseBuilder
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -88,11 +87,10 @@ class EitherTestCompiler(EitherCompiler):
         [either] = args
         cond = self.builder.add_conditional(either)
         for i in [0, 1]:
-            with cond.add_case(i) as case:
-                val = OPAQUE_TRUE if i == self.tag else OPAQUE_FALSE
-                case = CaseBuilder(case, cond, self.builder)
-                either = case.add_op(ops.Tag(i, self.either_ty), *case.inputs())
-                case.set_outputs(case.load(val), either)
+            case = cond.add_case(i)
+            val = OPAQUE_TRUE if i == self.tag else OPAQUE_FALSE
+            either = case.add_op(ops.Tag(i, self.either_ty), *case.inputs())
+            case.set_outputs(case.load(val), either)
         [res, either] = cond.outputs()
         return CallReturnWires(regular_returns=[res], inout_returns=[either])
 
@@ -108,15 +106,12 @@ class EitherToOptionCompiler(EitherCompiler, CustomCallCompiler):
         cond = self.builder.add_conditional(either)
         target_tys = self.left_tys if self.tag == 0 else self.right_tys
         for i in [0, 1]:
-            with cond.add_case(i) as case:
-                case = CaseBuilder(case, cond, self.builder)
-                if i == self.tag:
-                    out = case.add_op(
-                        ops.Tag(1, ht.Option(*target_tys)), *case.inputs()
-                    )
-                else:
-                    out = case.add_op(ops.Tag(0, ht.Option(*target_tys)))
-                case.set_outputs(out)
+            case = cond.add_case(i)
+            if i == self.tag:
+                out = case.add_op(ops.Tag(1, ht.Option(*target_tys)), *case.inputs())
+            else:
+                out = case.add_op(ops.Tag(0, ht.Option(*target_tys)))
+            case.set_outputs(out)
         return list(cond.outputs())
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -46,14 +46,14 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
             params=[ht.TypeTypeParam(ht.TypeBound.Copyable)],
             body=ht.FunctionType([StaticArray(var), INT_T], [var]),
         )
-        func = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
-        if isinstance(func, FunctionBuilder):
-            with func.set_ast_context(self.node):
-                [arr, idx] = func.inputs()
-                idx = func.add_op(convert_itousize(), idx)
-                elem_opt = func.add_op(static_array_get(var), arr, idx)
-                elem = build_unwrap(func, elem_opt, "Frozenarray index out of bounds")
-                func = func.set_outputs(elem)
+        func, already_exists = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
+        if not already_exists:
+            func = FunctionBuilder(func, current_ast_node=self.node)
+            [arr, idx] = func.inputs()
+            idx = func.add_op(convert_itousize(), idx)
+            elem_opt = func.add_op(static_array_get(var), arr, idx)
+            elem = build_unwrap(func, elem_opt, "Frozenarray index out of bounds")
+            func = func.set_outputs(elem)
         return func
 
     def compile(self, args: list[Wire]) -> list[Wire]:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -48,14 +48,12 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
         )
         func, already_exists = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
         if not already_exists:
-            func_builder = FunctionBuilder(func, current_ast_node=self.node)
+            func = FunctionBuilder(func, current_ast_node=self.node)
             [arr, idx] = func.inputs()
-            idx = func_builder.add_op(convert_itousize(), idx)
-            elem_opt = func_builder.add_op(static_array_get(var), arr, idx)
-            elem = build_unwrap(
-                func_builder, elem_opt, "Frozenarray index out of bounds"
-            )
-            func_builder.set_outputs(elem)
+            idx = func.add_op(convert_itousize(), idx)
+            elem_opt = func.add_op(static_array_get(var), arr, idx)
+            elem = build_unwrap(func, elem_opt, "Frozenarray index out of bounds")
+            func = func.set_outputs(elem)
         return func
 
     def compile(self, args: list[Wire]) -> list[Wire]:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -47,15 +47,15 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
             body=ht.FunctionType([StaticArray(var), INT_T], [var]),
         )
         func, already_exists = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
-        func_builder = FunctionBuilder(func, current_ast_node=self.node)
         if not already_exists:
+            func_builder = FunctionBuilder(func, current_ast_node=self.node)
             [arr, idx] = func.inputs()
             idx = func_builder.add_op(convert_itousize(), idx)
             elem_opt = func_builder.add_op(static_array_get(var), arr, idx)
             elem = build_unwrap(
                 func_builder, elem_opt, "Frozenarray index out of bounds"
             )
-            func.set_outputs(elem)
+            func_builder.set_outputs(elem)
         return func
 
     def compile(self, args: list[Wire]) -> list[Wire]:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -8,10 +8,7 @@ from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.collections.static_array import EXTENSION, StaticArray
 
-from guppylang_internals.compiler.core import (
-    DFBuilder,
-    GlobalConstId,
-)
+from guppylang_internals.compiler.core import FunctionBuilder, GlobalConstId
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import CustomCallCompiler
 from guppylang_internals.std._internal.compiler.arithmetic import (
@@ -50,7 +47,7 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
             body=ht.FunctionType([StaticArray(var), INT_T], [var]),
         )
         func, already_exists = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
-        func_builder = DFBuilder(func, self.node)
+        func_builder = FunctionBuilder(func, current_ast_node=self.node)
         if not already_exists:
             [arr, idx] = func.inputs()
             idx = func_builder.add_op(convert_itousize(), idx)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -8,7 +8,8 @@ from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.collections.static_array import EXTENSION, StaticArray
 
-from guppylang_internals.compiler.core import FunctionBuilder, GlobalConstId
+from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.core import GlobalConstId
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import CustomCallCompiler
 from guppylang_internals.std._internal.compiler.arithmetic import (

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -46,14 +46,14 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
             params=[ht.TypeTypeParam(ht.TypeBound.Copyable)],
             body=ht.FunctionType([StaticArray(var), INT_T], [var]),
         )
-        func, already_exists = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
-        if not already_exists:
-            func = FunctionBuilder(func, current_ast_node=self.node)
-            [arr, idx] = func.inputs()
-            idx = func.add_op(convert_itousize(), idx)
-            elem_opt = func.add_op(static_array_get(var), arr, idx)
-            elem = build_unwrap(func, elem_opt, "Frozenarray index out of bounds")
-            func = func.set_outputs(elem)
+        func = self.ctx.declare_global_func(FROZENARRAY_GETITEM, sig)
+        if isinstance(func, FunctionBuilder):
+            with func.set_ast_context(self.node):
+                [arr, idx] = func.inputs()
+                idx = func.add_op(convert_itousize(), idx)
+                elem_opt = func.add_op(static_array_get(var), arr, idx)
+                elem = build_unwrap(func, elem_opt, "Frozenarray index out of bounds")
+                func = func.set_outputs(elem)
         return func
 
     def compile(self, args: list[Wire]) -> list[Wire]:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
@@ -26,7 +26,7 @@ from guppylang_internals.std._internal.compiler.prelude import (
 from guppylang_internals.tys.arg import TypeArg
 
 if TYPE_CHECKING:
-    from guppylang_internals.compiler.core import DFBuilder
+    from guppylang_internals.compiler.builder import DFBuilder
 
 
 # ------------------------------------------------------

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
@@ -318,7 +318,7 @@ class ListLengthCompiler(CustomCallCompiler):
 P = TypeVar("P", bound=ops.DfParentOp)
 
 
-def list_new(builder: DFBuilder[P], elem_type: ht.Type, args: list[Wire]) -> Wire:
+def list_new(builder: DFBuilder, elem_type: ht.Type, args: list[Wire]) -> Wire:
     if elem_type.type_bound() == ht.TypeBound.Linear:
         return _list_new_linear(builder, elem_type, args)
     else:
@@ -326,7 +326,7 @@ def list_new(builder: DFBuilder[P], elem_type: ht.Type, args: list[Wire]) -> Wir
 
 
 def _list_new_classical(
-    builder: DFBuilder[P], elem_type: ht.Type, args: list[Wire]
+    builder: DFBuilder, elem_type: ht.Type, args: list[Wire]
 ) -> Wire:
     # This may be simplified in the future with a `new` or `with_capacity` list op
     # See https://github.com/quantinuum/hugr/issues/1508
@@ -337,9 +337,7 @@ def _list_new_classical(
     return lst
 
 
-def _list_new_linear(
-    builder: DFBuilder[P], elem_type: ht.Type, args: list[Wire]
-) -> Wire:
+def _list_new_linear(builder: DFBuilder, elem_type: ht.Type, args: list[Wire]) -> Wire:
     elem_opt_ty = ht.Option(elem_type)
     lst = builder.load(ListVal([], elem_ty=elem_opt_ty))
     push_op = list_push(elem_opt_ty)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/option.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/option.py
@@ -3,7 +3,6 @@ from abc import ABC
 from hugr import Wire, ops
 from hugr import tys as ht
 
-from guppylang_internals.compiler.core import CaseBuilder
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -54,11 +53,10 @@ class OptionTestCompiler(OptionCompiler):
         [opt] = args
         cond = self.builder.add_conditional(opt)
         for i in [0, 1]:
-            with cond.add_case(i) as case:
-                case = CaseBuilder(case, cond, self.builder)
-                val = OPAQUE_TRUE if i == self.tag else OPAQUE_FALSE
-                opt = case.add_op(ops.Tag(i, self.option_ty), *case.inputs())
-                case.set_outputs(case.load(val), opt)
+            case = cond.add_case(i)
+            val = OPAQUE_TRUE if i == self.tag else OPAQUE_FALSE
+            opt = case.add_op(ops.Tag(i, self.option_ty), *case.inputs())
+            case.set_outputs(case.load(val), opt)
         [res, opt] = cond.outputs()
         return CallReturnWires(regular_returns=[res], inout_returns=[opt])
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/option.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/option.py
@@ -3,6 +3,7 @@ from abc import ABC
 from hugr import Wire, ops
 from hugr import tys as ht
 
+from guppylang_internals.compiler.core import CaseBuilder
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -54,6 +55,7 @@ class OptionTestCompiler(OptionCompiler):
         cond = self.builder.add_conditional(opt)
         for i in [0, 1]:
             with cond.add_case(i) as case:
+                case = CaseBuilder(case, cond, self.builder)
                 val = OPAQUE_TRUE if i == self.tag else OPAQUE_FALSE
                 opt = case.add_op(ops.Tag(i, self.option_ty), *case.inputs())
                 case.set_outputs(case.load(val), opt)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -278,7 +278,7 @@ def unwrap_result(
     )
     type_args = [ht.TypeTypeArg(*result_tys)]
     func_call = builder.call(
-        func.parent_node,
+        func,
         either,
         instantiation=concrete_ty,
         type_args=type_args,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from contextlib import ExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, TypeVar
 
@@ -126,9 +125,7 @@ def build_unwrap_either(
 
     case = conditional.add_case(panic_case_num)
     error = build_static_error(case, error_signal, error_msg)
-    with ExitStack() as es:
-        if builder.current_ast_node is not None:
-            es.enter_context(case.set_ast_context(builder.current_ast_node))
+    with case.set_ast_context(builder.current_ast_node):
         case.set_outputs(
             *build_panic(
                 case,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -268,9 +268,9 @@ def unwrap_result(
         ),
     )
     # Build global unwrap result function if it doesn't already exist.
-    func, already_exists = ctx.declare_global_func(UNWRAP_RESULT, func_ty)
-    if not already_exists:
-        _build_unwrap_result(FunctionBuilder(func), ht.Variable(0, ht.TypeBound.Linear))
+    func = ctx.declare_global_func(UNWRAP_RESULT, func_ty)
+    if isinstance(func, FunctionBuilder):
+        _build_unwrap_result(func, ht.Variable(0, ht.TypeBound.Linear))
     # Call the global function.
     concrete_ty = ht.FunctionType(
         input=[ht.Either(error_tys, result_tys)], output=result_tys

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -13,8 +13,10 @@ from hugr import tys as ht
 from hugr import val as hv
 
 from guppylang_internals.compiler.core import (
+    CaseBuilder,
     CompilerContext,
     DFBuilder,
+    FunctionBuilder,
     GlobalConstId,
 )
 from guppylang_internals.definition.custom import (
@@ -28,7 +30,6 @@ from guppylang_internals.nodes import AbortKind
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from hugr.build import function as hf
     from hugr.build.dfg import DfBase
 
     from guppylang_internals.tys.common import ToHugrContext
@@ -91,7 +92,7 @@ P = TypeVar("P", bound=ops.DfParentOp)
 
 
 def build_panic(
-    builder: DFBuilder[P],
+    builder: DFBuilder,
     in_tys: ht.TypeRow,
     out_tys: ht.TypeRow,
     err: Wire,
@@ -109,7 +110,7 @@ def build_static_error(builder: DfBase[P], signal: int, msg: str) -> Wire:
 
 
 def build_unwrap_either(
-    builder: DFBuilder[P],
+    builder: DFBuilder,
     either: Wire,
     left: bool,
     error_msg: str,
@@ -131,7 +132,12 @@ def build_unwrap_either(
         error = build_static_error(case, error_signal, error_msg)
         case.set_outputs(
             *build_panic(
-                DFBuilder(case, builder.current_ast_node),
+                CaseBuilder(
+                    case,
+                    conditional,
+                    builder,
+                    current_ast_node=builder.current_ast_node,
+                ),
                 in_tys,
                 out_tys,
                 error,
@@ -142,7 +148,7 @@ def build_unwrap_either(
 
 
 def build_unwrap_left(
-    builder: DFBuilder[P], either: Wire, error_msg: str, error_signal: int = 1
+    builder: DFBuilder, either: Wire, error_msg: str, error_signal: int = 1
 ) -> Node:
     """Unwraps the left value from a `hugr.tys.Either` value, panicking with the given
     message if the result is right.
@@ -157,7 +163,7 @@ def build_unwrap_left(
 
 
 def build_unwrap_right(
-    builder: DFBuilder[P],
+    builder: DFBuilder,
     either: Wire,
     error_msg: str,
     error_signal: int = 1,
@@ -175,7 +181,7 @@ def build_unwrap_right(
 
 
 def build_unwrap(
-    builder: DFBuilder[P],
+    builder: DFBuilder,
     option: Wire,
     error_msg: str,
     error_signal: int = 1,
@@ -192,7 +198,7 @@ def build_unwrap(
 
 
 def build_expect_none(
-    builder: DFBuilder[P],
+    builder: DFBuilder,
     option: Wire,
     error_msg: str,
     error_signal: int = 1,
@@ -222,8 +228,8 @@ class MemSwapCompiler(CustomCallCompiler):
 UNWRAP_RESULT: Final[GlobalConstId] = GlobalConstId.fresh("unwrap_result")
 
 
-def _build_unwrap_result(func: hf.Function, result_type_var: ht.Variable) -> None:
-    either = func.inputs()[0]
+def _build_unwrap_result(func: DFBuilder, result_type_var: ht.Variable) -> None:
+    either = func.raw_builder.inputs()[0]
     conditional = func.add_conditional(either)
     with conditional.add_case(0) as case:
         [error] = list(case.inputs())
@@ -232,7 +238,7 @@ def _build_unwrap_result(func: hf.Function, result_type_var: ht.Variable) -> Non
                 # We don't want misleading debug info in global functions until
                 # https://github.com/Quantinuum/guppylang/issues/1609 is implemented,
                 # so `current_ast_node`is None here by default
-                DFBuilder(case),
+                CaseBuilder(case, conditional, func),
                 [error_type()],
                 [result_type_var],
                 error,
@@ -241,11 +247,11 @@ def _build_unwrap_result(func: hf.Function, result_type_var: ht.Variable) -> Non
         )
     with conditional.add_case(1) as case:
         case.set_outputs(*case.inputs())
-    func.set_outputs(*conditional.outputs())
+    func.raw_builder.set_outputs(*conditional.outputs())
 
 
 def unwrap_result(
-    builder: DFBuilder[P],
+    builder: DFBuilder,
     ctx: CompilerContext,
     either: Wire,
 ) -> Wire:
@@ -266,7 +272,7 @@ def unwrap_result(
     # Build global unwrap result function if it doesn't already exist.
     func, already_exists = ctx.declare_global_func(UNWRAP_RESULT, func_ty)
     if not already_exists:
-        _build_unwrap_result(func, ht.Variable(0, ht.TypeBound.Linear))
+        _build_unwrap_result(FunctionBuilder(func), ht.Variable(0, ht.TypeBound.Linear))
     # Call the global function.
     concrete_ty = ht.FunctionType(
         input=[ht.Either(error_tys, result_tys)], output=result_tys

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -268,9 +268,9 @@ def unwrap_result(
         ),
     )
     # Build global unwrap result function if it doesn't already exist.
-    func = ctx.declare_global_func(UNWRAP_RESULT, func_ty)
-    if isinstance(func, FunctionBuilder):
-        _build_unwrap_result(func, ht.Variable(0, ht.TypeBound.Linear))
+    func, already_exists = ctx.declare_global_func(UNWRAP_RESULT, func_ty)
+    if not already_exists:
+        _build_unwrap_result(FunctionBuilder(func), ht.Variable(0, ht.TypeBound.Linear))
     # Call the global function.
     concrete_ty = ht.FunctionType(
         input=[ht.Either(error_tys, result_tys)], output=result_tys

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, TypeVar
 
@@ -13,7 +14,6 @@ from hugr import tys as ht
 from hugr import val as hv
 
 from guppylang_internals.compiler.core import (
-    CaseBuilder,
     CompilerContext,
     DFBuilder,
     FunctionBuilder,
@@ -29,8 +29,6 @@ from guppylang_internals.nodes import AbortKind
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from hugr.build.dfg import DfBase
 
     from guppylang_internals.tys.common import ToHugrContext
     from guppylang_internals.tys.subst import Inst
@@ -103,7 +101,7 @@ def build_panic(
     return builder.add_op(op, err, *args)
 
 
-def build_static_error(builder: DfBase[P], signal: int, msg: str) -> Wire:
+def build_static_error(builder: DFBuilder, signal: int, msg: str) -> Wire:
     """Constructs and loads a static error value."""
     val = ErrorVal(signal, msg)
     return builder.load(builder.add_const(val))
@@ -126,13 +124,15 @@ def build_unwrap_either(
     [in_tys, out_tys] = [right_tys, left_tys] if left else [left_tys, right_tys]
     ok_case_num = 0 if left else 1
     panic_case_num = 1 - ok_case_num
-    with conditional.add_case(ok_case_num) as case:
-        case.set_outputs(*case.inputs())
-    with conditional.add_case(panic_case_num) as case:
-        error = build_static_error(case, error_signal, error_msg)
-        case = CaseBuilder(
-            case, conditional, builder, current_ast_node=builder.current_ast_node
-        )
+
+    case = conditional.add_case(ok_case_num)
+    case.set_outputs(*case.inputs())
+
+    case = conditional.add_case(panic_case_num)
+    error = build_static_error(case, error_signal, error_msg)
+    with ExitStack() as es:
+        if builder.current_ast_node is not None:
+            es.enter_context(case.set_ast_context(builder.current_ast_node))
         case.set_outputs(
             *build_panic(
                 case,
@@ -229,23 +229,22 @@ UNWRAP_RESULT: Final[GlobalConstId] = GlobalConstId.fresh("unwrap_result")
 def _build_unwrap_result(func: DFBuilder, result_type_var: ht.Variable) -> None:
     either = func.inputs()[0]
     conditional = func.add_conditional(either)
-    with conditional.add_case(0) as case:
-        case = CaseBuilder(case, conditional, func)
-        [error] = list(case.inputs())
-        case.set_outputs(
-            *build_panic(
-                # We don't want misleading debug info in global functions until
-                # https://github.com/Quantinuum/guppylang/issues/1609 is implemented,
-                # so `current_ast_node`is None here by default
-                case,
-                [error_type()],
-                [result_type_var],
-                error,
-                *case.inputs(),
-            )
+    case = conditional.add_case(0)
+    [error] = list(case.inputs())
+    case.set_outputs(
+        *build_panic(
+            # We don't want misleading debug info in global functions until
+            # https://github.com/Quantinuum/guppylang/issues/1609 is implemented,
+            # so `current_ast_node`is None here by default
+            case,
+            [error_type()],
+            [result_type_var],
+            error,
+            *case.inputs(),
         )
-    with conditional.add_case(1) as case:
-        case.set_outputs(*case.inputs())
+    )
+    case = conditional.add_case(1)
+    case.set_outputs(*case.inputs())
     func.set_outputs(*conditional.outputs())
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -130,14 +130,12 @@ def build_unwrap_either(
         case.set_outputs(*case.inputs())
     with conditional.add_case(panic_case_num) as case:
         error = build_static_error(case, error_signal, error_msg)
+        case = CaseBuilder(
+            case, conditional, builder, current_ast_node=builder.current_ast_node
+        )
         case.set_outputs(
             *build_panic(
-                CaseBuilder(
-                    case,
-                    conditional,
-                    builder,
-                    current_ast_node=builder.current_ast_node,
-                ),
+                case,
                 in_tys,
                 out_tys,
                 error,
@@ -229,16 +227,17 @@ UNWRAP_RESULT: Final[GlobalConstId] = GlobalConstId.fresh("unwrap_result")
 
 
 def _build_unwrap_result(func: DFBuilder, result_type_var: ht.Variable) -> None:
-    either = func.raw_builder.inputs()[0]
+    either = func.inputs()[0]
     conditional = func.add_conditional(either)
     with conditional.add_case(0) as case:
+        case = CaseBuilder(case, conditional, func)
         [error] = list(case.inputs())
         case.set_outputs(
             *build_panic(
                 # We don't want misleading debug info in global functions until
                 # https://github.com/Quantinuum/guppylang/issues/1609 is implemented,
                 # so `current_ast_node`is None here by default
-                CaseBuilder(case, conditional, func),
+                case,
                 [error_type()],
                 [result_type_var],
                 error,
@@ -247,7 +246,7 @@ def _build_unwrap_result(func: DFBuilder, result_type_var: ht.Variable) -> None:
         )
     with conditional.add_case(1) as case:
         case.set_outputs(*case.inputs())
-    func.raw_builder.set_outputs(*conditional.outputs())
+    func.set_outputs(*conditional.outputs())
 
 
 def unwrap_result(

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -13,12 +13,8 @@ from hugr import Node, Wire, ops
 from hugr import tys as ht
 from hugr import val as hv
 
-from guppylang_internals.compiler.core import (
-    CompilerContext,
-    DFBuilder,
-    FunctionBuilder,
-    GlobalConstId,
-)
+from guppylang_internals.compiler.builder import DFBuilder, FunctionBuilder
+from guppylang_internals.compiler.core import CompilerContext, GlobalConstId
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
     CustomInoutCallCompiler,

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -15,11 +15,8 @@ from guppylang_internals.checker.core import (
 )
 from guppylang_internals.checker.errors.type_errors import TypeMismatchError
 from guppylang_internals.checker.unitary_checker import BBUnitaryChecker
-from guppylang_internals.compiler.core import (
-    CompilerContext,
-    DFContainer,
-    FunctionBuilder,
-)
+from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.diagnostic import Error

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from hugr import ops
-from hugr.build.dfg import DfBase
+from hugr.build.function import Function
 
 from guppylang_internals.ast_util import AstNode, with_loc, with_type
 from guppylang_internals.cfg.builder import tmp_vars
@@ -31,7 +31,6 @@ from guppylang_internals.tracing.state import (
     set_tracing_state,
 )
 from guppylang_internals.tracing.unpacking import (
-    P,
     guppy_object_from_py,
     unpack_guppy_object,
     update_packed_value,
@@ -63,7 +62,7 @@ class TracingReturnError(Error):
 def trace_function(
     python_func: Callable[..., Any],
     ty: FunctionType,
-    builder: DfBase[P],
+    builder: Function,
     ctx: CompilerContext,
     node: AstNode,
     func_def: "CompiledTracedFunctionDef",

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from hugr import ops
-from hugr.build.function import Function
 
 from guppylang_internals.ast_util import AstNode, with_loc, with_type
 from guppylang_internals.cfg.builder import tmp_vars
@@ -16,7 +15,11 @@ from guppylang_internals.checker.core import (
 )
 from guppylang_internals.checker.errors.type_errors import TypeMismatchError
 from guppylang_internals.checker.unitary_checker import BBUnitaryChecker
-from guppylang_internals.compiler.core import CompilerContext, DFContainer
+from guppylang_internals.compiler.core import (
+    CompilerContext,
+    DFContainer,
+    FunctionBuilder,
+)
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.diagnostic import Error
@@ -62,7 +65,7 @@ class TracingReturnError(Error):
 def trace_function(
     python_func: Callable[..., Any],
     ty: FunctionType,
-    builder: Function,
+    builder: FunctionBuilder,
     ctx: CompilerContext,
     node: AstNode,
     func_def: "CompiledTracedFunctionDef",
@@ -83,7 +86,7 @@ def trace_function(
                 # thus breaking the semantics expected from Python.
                 frozen=InputFlags.Inout not in inp.flags,
             )
-            for wire, inp in zip(builder.inputs(), ty.inputs, strict=True)
+            for wire, inp in zip(builder.raw_builder.inputs(), ty.inputs, strict=True)
         ]
 
         with exception_hook(tracing_except_hook), mock_builtins(python_func):
@@ -148,7 +151,7 @@ def trace_function(
         msg = f"Value with non-droppable type `{unused._ty}` is leaked by this function"
         raise GuppyError(TracingReturnError(node, msg)) from None
 
-    builder.set_outputs(*regular_returns, *inout_returns)
+    builder.raw_builder.set_outputs(*regular_returns, *inout_returns)
 
 
 def trace_call(func: CallableDef, *args: Any) -> Any:
@@ -162,9 +165,7 @@ def trace_call(func: CallableDef, *args: Any) -> Any:
     with capture_guppy_errors():
         # Try to turn args into `GuppyObjects`
         args_objs = [
-            guppy_object_from_py(
-                arg, state.dfg.builder.raw_builder, state.node, state.ctx
-            )
+            guppy_object_from_py(arg, state.dfg.builder, state.node, state.ctx)
             for arg in args
         ]
 
@@ -205,7 +206,7 @@ def trace_call(func: CallableDef, *args: Any) -> Any:
                 ty = var.ty
                 inout_wire = state.dfg[var]
                 success = update_packed_value(
-                    arg, GuppyObject(ty, inout_wire), state.dfg.builder.raw_builder
+                    arg, GuppyObject(ty, inout_wire), state.dfg.builder
                 )
                 if not success:
                     # This means the user has passed an object that we cannot update,
@@ -216,4 +217,4 @@ def trace_call(func: CallableDef, *args: Any) -> Any:
                     )
 
     ret_obj = GuppyObject(ret_ty, ret_wire)
-    return unpack_guppy_object(ret_obj, state.dfg.builder.raw_builder)
+    return unpack_guppy_object(ret_obj, state.dfg.builder)

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -86,7 +86,7 @@ def trace_function(
                 # thus breaking the semantics expected from Python.
                 frozen=InputFlags.Inout not in inp.flags,
             )
-            for wire, inp in zip(builder.raw_builder.inputs(), ty.inputs, strict=True)
+            for wire, inp in zip(builder.inputs(), ty.inputs, strict=True)
         ]
 
         with exception_hook(tracing_except_hook), mock_builtins(python_func):
@@ -151,7 +151,7 @@ def trace_function(
         msg = f"Value with non-droppable type `{unused._ty}` is leaked by this function"
         raise GuppyError(TracingReturnError(node, msg)) from None
 
-    builder.raw_builder.set_outputs(*regular_returns, *inout_returns)
+    builder.set_outputs(*regular_returns, *inout_returns)
 
 
 def trace_call(func: CallableDef, *args: Any) -> Any:

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -65,9 +65,7 @@ def unary_operation(f: UnaryDunderMethod) -> UnaryDunderMethod:
         from guppylang_internals.tracing.unpacking import guppy_object_from_py
 
         state = get_tracing_state()
-        self = guppy_object_from_py(
-            self, state.dfg.builder.raw_builder, state.node, state.ctx
-        )
+        self = guppy_object_from_py(self, state.dfg.builder, state.node, state.ctx)
 
         with suppress(Exception):
             return f(self)
@@ -94,12 +92,8 @@ def binary_operation(f: BinaryDunderMethod) -> BinaryDunderMethod:
         from guppylang_internals.tracing.unpacking import guppy_object_from_py
 
         state = get_tracing_state()
-        self = guppy_object_from_py(
-            self, state.dfg.builder.raw_builder, state.node, state.ctx
-        )
-        other = guppy_object_from_py(
-            other, state.dfg.builder.raw_builder, state.node, state.ctx
-        )
+        self = guppy_object_from_py(self, state.dfg.builder, state.node, state.ctx)
+        other = guppy_object_from_py(other, state.dfg.builder, state.node, state.ctx)
 
         # First try the method on `self`
         with suppress(Exception):
@@ -135,9 +129,7 @@ class DunderMixin:
         from guppylang_internals.tracing.unpacking import guppy_object_from_py
 
         state = get_tracing_state()
-        self = guppy_object_from_py(
-            self, state.dfg.builder.raw_builder, state.node, state.ctx
-        )
+        self = guppy_object_from_py(self, state.dfg.builder, state.node, state.ctx)
         return self.__getattr__(name)
 
     def __abs__(self) -> Any:

--- a/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
@@ -7,7 +7,8 @@ from guppylang_internals.checker.errors.comptime_errors import (
     IllegalComptimeExpressionError,
 )
 from guppylang_internals.checker.expr_checker import python_value_to_guppy_type
-from guppylang_internals.compiler.core import CompilerContext, DFBuilder
+from guppylang_internals.compiler.builder import DFBuilder
+from guppylang_internals.compiler.core import CompilerContext
 from guppylang_internals.compiler.expr_compiler import python_value_to_hugr
 from guppylang_internals.error import GuppyComptimeError, GuppyError
 from guppylang_internals.std._internal.compiler.array import array_new, unpack_array

--- a/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
@@ -1,7 +1,6 @@
 from typing import Any, TypeVar
 
 from hugr import ops
-from hugr.build.dfg import DfBase
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.errors.comptime_errors import (
@@ -33,7 +32,7 @@ P = TypeVar("P", bound=ops.DfParentOp)
 
 
 def unpack_guppy_object(
-    obj: GuppyObject, builder: DfBase[P], frozen: bool = False
+    obj: GuppyObject, builder: DFBuilder, frozen: bool = False
 ) -> Any:
     """Tries to turn as much of the structure of a GuppyObject into Python objects.
 
@@ -72,7 +71,7 @@ def unpack_guppy_object(
                     # them as Guppy objects here
                     return obj
                 elem_ty = get_element_type(ty)
-                elems = unpack_array(DFBuilder(builder), obj._use_wire(None))
+                elems = unpack_array(builder, obj._use_wire(None))
                 obj_list = [
                     unpack_guppy_object(GuppyObject(elem_ty, wire), builder, frozen)
                     for wire in elems
@@ -86,7 +85,7 @@ def unpack_guppy_object(
 
 
 def guppy_object_from_py(
-    v: Any, builder: DfBase[P], node: AstNode, ctx: CompilerContext
+    v: Any, builder: DFBuilder, node: AstNode, ctx: CompilerContext
 ) -> GuppyObject:
     """Constructs a Guppy object from a Python value.
 
@@ -148,7 +147,7 @@ def guppy_object_from_py(
             return GuppyObject(ty, builder.load(hugr_val))
 
 
-def update_packed_value(v: Any, obj: "GuppyObject", builder: DfBase[P]) -> bool:
+def update_packed_value(v: Any, obj: "GuppyObject", builder: DFBuilder) -> bool:
     """Given a Python value `v` and a `GuppyObject` `obj` that was constructed from `v`
     using `guppy_object_from_py`, tries to update the wires of any `GuppyObjects`
     contained in `v` to the new wires specified by `obj`.
@@ -194,7 +193,7 @@ def update_packed_value(v: Any, obj: "GuppyObject", builder: DfBase[P]) -> bool:
         case list(vs) if len(vs) > 0:
             assert is_array_type(obj._ty)
             elem_ty = get_element_type(obj._ty)
-            wires = unpack_array(DFBuilder(builder), obj._use_wire(None))
+            wires = unpack_array(builder, obj._use_wire(None))
             for i, (v, wire) in enumerate(zip(vs, wires, strict=True)):
                 success = update_packed_value(v, GuppyObject(elem_ty, wire), builder)
                 if not success:


### PR DESCRIPTION
* Unparametrize `DFBuilder` (the parameter wasn't really used), and make into a subclass hierarchy, allowing subclasses to define a couple of type-specific methods (`set_loop_outputs` and `set_block_outputs`)
* Subclasses also know about parent hierarchy and how to propagate edges upwards
* Add a few more methods, thus allowing to hide `raw_builder`
* Use DFBuilder more, much more, including tracing, indeed hopefully everywhere that calls add_op

There are a couple of optional-extra commits that I'm willing to retract, designed to remove the possibility of accidentally forgetting to use the new Builder classes...thoughts welcome on benefits/removal of

* commit dcd1c788588885148881d08cc83a40e1c061127e changes `Context.declare_global_func` to return an `hf.Function | FunctionBuilder` rather than `hf.Function, bool`; a lot of `isinstance` :(

* commit abe78a480e2e661bd8fa80d9d5680a3aeb49339e adds a CondBuilder for conditionals (*not* a DFBuilder); duplicating yet more from the underlying hugr hierarchy, and needing contextmanager methods (hugr Conditional is a contextmanager which checks that all cases have been constructed - hugr Case is also a contextmanager but I've stopped us from using that as it doesn't do anything. I *could* add ctx-mgr methods to CaseBuilder too...).

This is a big step towards https://github.com/Quantinuum/guppylang/issues/1746 but doesn't intend to change any part of the Hugr. (Rather it opens the way to replacing `DFBuilder.add_op` with something that takes a list of effects.)

**Question** should I move these classes (`*Builder` - DFBuilder, CaseBuilder, CondBuilder, ...) into `compiler/builder.py`?

BREAKING CHANGE: (guppylang-internals) DFBuilder no longer parametrized, now an ABC - construct (Case/TailLoop/Function/Block)Builders with relevant (grand/)parents. This *must* be used for all add_ops to preserve (currently-total) ordering of side effects.