### PR TITLE
refactor!: Remove vacuous pytket extra from distributions

### DIFF
--- a/guppylang-internals/pyproject.toml
+++ b/guppylang-internals/pyproject.toml
@@ -38,9 +38,6 @@ dependencies = [
     "tket[pytket]>=0.13.0",
 ]
 
-[project.optional-dependencies]
-pytket = []
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -39,9 +39,6 @@ dependencies = [
     "types-tqdm>=4.67.0.20250809",
 ]
 
-[project.optional-dependencies]
-pytket = []
-
 [project.urls]
 homepage = "https://github.com/quantinuum/guppylang"
 repository = "https://github.com/quantinuum/guppylang"

--- a/uv.lock
+++ b/uv.lock
@@ -1041,7 +1041,6 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
-provides-extras = ["pytket"]
 
 [[package]]
 name = "guppylang-internals"
@@ -1065,7 +1064,6 @@ requires-dist = [
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
     { name = "wasmtime", specifier = ">=38.0,<45.1" },
 ]
-provides-extras = ["pytket"]
 
 [[package]]
 name = "hugr"


### PR DESCRIPTION
Removes the `pytket` extra from both `guppylang` and `guppylang-internals`. It added no dependencies since we made tket and pytket a required dependency, and since we now track v1 breaking changes on main, we can remove this extra along the way.

BREAKING CHANGE: `guppylang` and `guppylang-internals` had their vacuous `pytket` extra removed. Use the packages without the extra.