### PR TITLE
refactor!: Make stdlib types state mutable with private fields

### DIFF
--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -262,18 +262,18 @@ class array(builtins.list[_T], Generic[_T, _n]):
 class ArrayIter(Generic[L, n]):
     """Iterator over arrays."""
 
-    xs: array[L, n]
-    i: int
+    _xs: array[L, n]
+    _i: int
 
     @guppy
     @no_type_check
     def __next__(
         self: ArrayIter[L, n] @ owned,
     ) -> Option[tuple[L, ArrayIter[L, n]]]:
-        if self.i < int(n):
-            elem = self.xs.take(self.i)
-            return some((elem, ArrayIter(self.xs, self.i + 1)))
-        self.xs.discard_all_taken()
+        if self._i < int(n):
+            elem = self._xs.take(self._i)
+            return some((elem, ArrayIter(self._xs, self._i + 1)))
+        self._xs.discard_all_taken()
         return nothing()
 
 
@@ -329,14 +329,14 @@ class frozenarray(Generic[T, n]):
 class FrozenarrayIter(Generic[T, n]):
     """Iterator for frozenarrays."""
 
-    xs: frozenarray[T, n]  # type: ignore[type-arg]
-    i: int
+    _xs: frozenarray[T, n]  # type: ignore[type-arg]
+    _i: int
 
     @guppy
     @no_type_check
     def __next__(
         self: FrozenarrayIter[T, n],
     ) -> Option[tuple[T, FrozenarrayIter[T, n]]]:
-        if self.i < int(n):
-            return some((self.xs[self.i], FrozenarrayIter(self.xs, self.i + 1)))
+        if self._i < int(n):
+            return some((self.xs[self._i], FrozenarrayIter(self.xs, self._i + 1)))
         return nothing()

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -258,7 +258,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         return [*args]
 
 
-@guppy.struct(frozen=True)
+@guppy.struct
 class ArrayIter(Generic[L, n]):
     """Iterator over arrays."""
 
@@ -268,11 +268,12 @@ class ArrayIter(Generic[L, n]):
     @guppy
     @no_type_check
     def __next__(
-        self: ArrayIter[L, n] @ owned,
-    ) -> Option[tuple[L, ArrayIter[L, n]]]:
+        self: Self @ owned,
+    ) -> Option[tuple[L, Self]]:
         if self._i < int(n):
             elem = self._xs.take(self._i)
-            return some((elem, ArrayIter(self._xs, self._i + 1)))
+            self._i += 1
+            return some((elem, self))
         self._xs.discard_all_taken()
         return nothing()
 
@@ -325,7 +326,7 @@ class frozenarray(Generic[T, n]):
         return array(x for x in self)
 
 
-@guppy.struct(frozen=True)
+@guppy.struct
 class FrozenarrayIter(Generic[T, n]):
     """Iterator for frozenarrays."""
 
@@ -335,8 +336,10 @@ class FrozenarrayIter(Generic[T, n]):
     @guppy
     @no_type_check
     def __next__(
-        self: FrozenarrayIter[T, n],
-    ) -> Option[tuple[T, FrozenarrayIter[T, n]]]:
+        self: Self @ owned,
+    ) -> Option[tuple[T, Self]]:
         if self._i < int(n):
-            return some((self._xs[self._i], FrozenarrayIter(self._xs, self._i + 1)))
+            elem = self._xs[self._i]
+            self._i += 1
+            return some((elem, self))
         return nothing()

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -338,5 +338,5 @@ class FrozenarrayIter(Generic[T, n]):
         self: FrozenarrayIter[T, n],
     ) -> Option[tuple[T, FrozenarrayIter[T, n]]]:
         if self._i < int(n):
-            return some((self.xs[self._i], FrozenarrayIter(self.xs, self._i + 1)))
+            return some((self._xs[self._i], FrozenarrayIter(self._xs, self._i + 1)))
         return nothing()

--- a/guppylang/src/guppylang/std/iter.py
+++ b/guppylang/src/guppylang/std/iter.py
@@ -47,19 +47,20 @@ class SizedIter:
         """Dummy implementation making sized iterators iterable themselves."""
 
 
-@guppy.struct(frozen=True)
+@guppy.struct
 class Range:
     _next: int
     _stop: int
     _step: int
 
     @guppy
-    def __iter__(self: Self) -> Self:
+    @no_type_check
+    def __iter__(self: Self @ owned) -> Self:
         return self
 
     @guppy
     @no_type_check
-    def __next__(self: Self) -> Option[tuple[int, Self]]:
+    def __next__(self: Self @ owned) -> Option[tuple[int, Self]]:
         end = (
             (self._next >= self._stop)
             if self._step >= 0
@@ -67,9 +68,9 @@ class Range:
         )
         if end:
             return nothing()
-        return some(
-            (self._next, Range(self._next + self._step, self._stop, self._step))
-        )
+        actual_next = self._next
+        self._next += self._step
+        return some((actual_next, self))
 
 
 @guppy

--- a/guppylang/src/guppylang/std/iter.py
+++ b/guppylang/src/guppylang/std/iter.py
@@ -49,9 +49,9 @@ class SizedIter:
 
 @guppy.struct(frozen=True)
 class Range:
-    next: int
-    stop: int
-    step: int
+    _next: int
+    _stop: int
+    _step: int
 
     @guppy
     def __iter__(self: Range) -> Range:
@@ -60,10 +60,16 @@ class Range:
     @guppy
     @no_type_check
     def __next__(self: Range) -> Option[tuple[int, Range]]:
-        end = (self.next >= self.stop) if self.step >= 0 else (self.next <= self.stop)
+        end = (
+            (self._next >= self._stop)
+            if self._step >= 0
+            else (self._next <= self._stop)
+        )
         if end:
             return nothing()
-        return some((self.next, Range(self.next + self.step, self.stop, self.step)))
+        return some(
+            (self._next, Range(self._next + self._step, self._stop, self._step))
+        )
 
 
 @guppy

--- a/guppylang/src/guppylang/std/iter.py
+++ b/guppylang/src/guppylang/std/iter.py
@@ -4,11 +4,12 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Self, no_type_check
+from typing import TYPE_CHECKING, Any, no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.definition.custom import NoopCompiler
 from guppylang_internals.tys.builtin import sized_iter_type_def
+from typing_extensions import Self
 
 from guppylang import guppy
 from guppylang.std.option import Option, nothing, some

--- a/guppylang/src/guppylang/std/iter.py
+++ b/guppylang/src/guppylang/std/iter.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, no_type_check
+from typing import TYPE_CHECKING, Any, Self, no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.definition.custom import NoopCompiler
@@ -54,12 +54,12 @@ class Range:
     _step: int
 
     @guppy
-    def __iter__(self: Range) -> Range:
+    def __iter__(self: Self) -> Self:
         return self
 
     @guppy
     @no_type_check
-    def __next__(self: Range) -> Option[tuple[int, Range]]:
+    def __next__(self: Self) -> Option[tuple[int, Self]]:
         end = (
             (self._next >= self._stop)
             if self._step >= 0

--- a/guppylang/src/guppylang/std/qsystem/random.py
+++ b/guppylang/src/guppylang/std/qsystem/random.py
@@ -109,7 +109,7 @@ class DiscreteDistribution(Generic[DISCRETE_N]):  # type: ignore[misc]
 
     # The `sums` array represents the cumulative probability distribution. That is,
     # sums[i] is the probability of drawing a value <= i from the distribution.
-    sums: array[float, DISCRETE_N]  # type: ignore[valid-type]
+    _sums: array[float, DISCRETE_N]  # type: ignore[valid-type]
 
     @guppy
     @no_type_check
@@ -123,7 +123,7 @@ class DiscreteDistribution(Generic[DISCRETE_N]):  # type: ignore[misc]
         i_max = DISCRETE_N - 1
         while i_min < i_max:
             i = (i_min + i_max) // 2
-            if self.sums[i] >= x:
+            if self._sums[i] >= x:
                 i_max = i
             else:
                 i_min = i + 1


### PR DESCRIPTION
closes #1822 

The following stdlib types now have private members:
* `ArrayIter`
* `FrozenarrayIter`
* `Range`
* `DiscreteDistribution`

Moreover, `ArrayIter`, `FrozenarrayIter`, and `Range` are now mutable avoiding in the `__next__` to redefine a new struct every time.


BREAKING CHANGE: (`guppylang.std.array`) `ArrayIter.xs` and `ArrayIter.i` made private (renamed to `_xs` and `_i`)
BREAKING CHANGE: (`guppylang.std.array`) `FrozenarrayIter.xs` and `FrozenarrayIter.i` made private (renamed to `_xs` and `_i`)
BREAKING CHANGE: (`guppylang.std.iter`) `Range.next` and `Range.stop` made private (renamed to `_next` and `_stop`)
BREAKING CHANGE: (`guppylang.std.qsystem.random`) `DiscreteDistribution.sums` made private (renamed to `_sums`)
