### PR TITLE
feat(effects)!: Improve error messages by passing callee into check_call/synthesize_call

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/errors/type_errors.py
+++ b/guppylang-internals/src/guppylang_internals/checker/errors/type_errors.py
@@ -74,7 +74,7 @@ class TooManyEffectsError(Error):
     title: ClassVar[str] = "Too many effects"
     span_label: ClassVar[str] = "{target} not allowed inside `{in_func}`"
     callee: str | FunctionType
-    effects: list[Effect]
+    surplus_effects: list[Effect]
     in_func: str
 
     @property
@@ -83,12 +83,14 @@ class TooManyEffectsError(Error):
             return f"Call to `{self.callee}`" + self.note_effects()
         msg = f"Callee of type `{self.callee}`"
         if self.callee.declared_effects is None:
-            # FunctionType that will not display any effects, so list separately
+            # FunctionType that will not display any effects, so list separately.
+            # (We could do this for all FunctionTypes, as this should only be those
+            # not allowed in the context, which may still be helpful?)
             msg += self.note_effects()
         return msg
 
     def note_effects(self) -> str:
-        return f" has effects `{Effect.format_list(self.effects)}`"
+        return f" has effects `{Effect.format_list(self.surplus_effects)}`"
 
     @dataclass(frozen=True)
     class MaxFromDecl(Note):

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1445,7 +1445,7 @@ def _check_effects(
 
 
 def synthesize_call(
-    target: FunctionType,
+    func_ty: FunctionType,
     args: list[ast.expr],
     node: AstNode,
     ctx: Context,
@@ -1456,15 +1456,15 @@ def synthesize_call(
     Returns an annotated argument list, the synthesized return type, and an
     instantiation for the quantifiers in the function type.
     """
-    assert not target.unsolved_vars
-    check_num_args(len(target.inputs), len(args), node, target)
+    assert not func_ty.unsolved_vars
+    check_num_args(len(func_ty.inputs), len(args), node, func_ty)
 
     # Replace quantified variables with free unification variables and try to infer an
     # instantiation by checking the arguments
-    unquantified, free_vars = target.unquantified()
+    unquantified, free_vars = func_ty.unquantified()
     var_mapping = {}
     inst_tele: list[Argument | None] = [None for _ in free_vars]
-    for ix, (var, param) in enumerate(zip(free_vars, target.params, strict=True)):
+    for ix, (var, param) in enumerate(zip(free_vars, func_ty.params, strict=True)):
         var_mapping[var] = param.instantiate_bounds(inst_tele)
         if isinstance(var, ExistentialTypeVar):
             inst_tele[ix] = TypeArg(var)
@@ -1475,18 +1475,18 @@ def synthesize_call(
 
     # Success implies that the substitution is closed
     assert all(not t.unsolved_vars for t in subst.values())
-    inst = check_all_solved(subst, free_vars, target, node)
+    inst = check_all_solved(subst, free_vars, func_ty, node)
 
     # Finally, check that the instantiation respects the linearity requirements
     # and the effects allowed in the context.
-    check_inst(target, inst, node)
-    _check_effects(target, callee, ctx, node)
+    check_inst(func_ty, inst, node)
+    _check_effects(func_ty, callee, ctx, node)
 
     return args, unquantified.output.substitute(subst), inst
 
 
 def check_call(
-    target: FunctionType,
+    func_ty: FunctionType,
     inputs: list[ast.expr],
     ty: Type,
     node: AstNode,
@@ -1499,8 +1499,8 @@ def check_call(
     Returns an annotated argument list, a substitution for the free variables in the
     expected type, and an instantiation for the quantifiers in the function type.
     """
-    assert not target.unsolved_vars
-    check_num_args(len(target.inputs), len(inputs), node, target)
+    assert not func_ty.unsolved_vars
+    check_num_args(len(func_ty.inputs), len(inputs), node, func_ty)
 
     # When checking, we can use the information from the expected return type to infer
     # some type arguments. However, this pushes errors inwards. For example, given a
@@ -1527,7 +1527,7 @@ def check_call(
     inputs_copy = copy.deepcopy(inputs)
 
     try:
-        inputs, synth, inst = synthesize_call(target, inputs, node, ctx, callee)
+        inputs, synth, inst = synthesize_call(func_ty, inputs, node, ctx, callee)
         subst = unify(ty, synth, {})
         if subst is None:
             raise GuppyTypeError(TypeMismatchError(node, ty, synth, kind))
@@ -1543,7 +1543,7 @@ def check_call(
 
     # If synthesis fails, we try again, this time also using information from the
     # expected return type
-    unquantified, free_vars = target.unquantified()
+    unquantified, free_vars = func_ty.unquantified()
     subst = unify(ty, unquantified.output, {})
     if subst is None:
         raise GuppyTypeError(TypeMismatchError(node, ty, unquantified.output, kind))
@@ -1552,7 +1552,7 @@ def check_call(
     # instantiation by checking the arguments
     var_mapping = {}
     inst_tele: list[Argument | None] = [None for _ in free_vars]
-    for ix, (var, param) in enumerate(zip(free_vars, target.params, strict=True)):
+    for ix, (var, param) in enumerate(zip(free_vars, func_ty.params, strict=True)):
         var_mapping[var] = param.instantiate_bounds(inst_tele)
         if isinstance(var, ExistentialTypeVar):
             inst_tele[ix] = TypeArg(var)
@@ -1565,7 +1565,7 @@ def check_call(
     # checking against
     if not set.issubset(ty.unsolved_vars, subst.keys()):
         unsolved = (subst.keys() - ty.unsolved_vars).pop()
-        err = TypeMismatchError(node, ty, target.output.substitute(subst))
+        err = TypeMismatchError(node, ty, func_ty.output.substitute(subst))
         err.add_sub_diagnostic(
             TypeMismatchError.CantInferParam(None, unsolved.display_name)
         )
@@ -1573,13 +1573,13 @@ def check_call(
 
     # Success implies that the substitution is closed
     assert all(not t.unsolved_vars for t in subst.values())
-    inst = check_all_solved(subst, free_vars, target, node)
+    inst = check_all_solved(subst, free_vars, func_ty, node)
     subst = {v: t for v, t in subst.items() if v in ty.unsolved_vars}
 
     # Finally, check that the instantiation respects the linearity requirements
     # and the effects allowed in the context.
-    check_inst(target, inst, node)
-    _check_effects(target, callee, ctx, node)
+    check_inst(func_ty, inst, node)
+    _check_effects(func_ty, callee, ctx, node)
 
     return inputs, subst, inst
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -340,13 +340,11 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(func_ty, FunctionType)
+                # Name here is not monomorphized, as we'll not come here when the caller
+                # is monomorphized.
+                func_name = f"Function {node.func.id} in protocol {node.func.def_id}"
                 args, subst, inst = check_call(
-                    func_ty,
-                    node.args,
-                    ty,
-                    node,
-                    self.ctx,
-                    (node.func.def_id, node.func.id),
+                    func_ty, node.args, ty, node, self.ctx, func_name
                 )
                 return with_loc(
                     node,
@@ -949,8 +947,9 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(ty, FunctionType)
+                func_name = f"Function {node.func.id} in protocol {node.func.def_id}"
                 args, return_ty, inst = synthesize_call(
-                    ty, node.args, node, self.ctx, (node.func.def_id, node.func.id)
+                    ty, node.args, node, self.ctx, func_name
                 )
                 return with_loc(
                     node,
@@ -1398,9 +1397,8 @@ def _identify_callee(node: ast.expr) -> str | None:
             return None
 
 
-# A function definition; a protocol definition and the name of the function within it;
-# or a string for error messages if there is no definition
-CalleeId: TypeAlias = DefId | tuple[DefId, str] | str
+# A function definition, or a string (for error messages) if there is no such
+CalleeId: TypeAlias = DefId | str
 
 
 def _check_effects(

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -343,7 +343,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
                 # ALAN just passing the name of the proto func here
                 # - should pass the protocol defn id too
                 args, subst, inst = check_call(
-                    (node.func.id, func_ty), node.args, ty, node, self.ctx
+                    func_ty, node.args, ty, node, self.ctx, node.func.id
                 )
                 return with_loc(
                     node,
@@ -366,7 +366,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         if isinstance(func_ty, FunctionType):
             tgt_name = _identify_callee(node.func)
             args, subst, inst = check_call(
-                (tgt_name, func_ty), node.args, ty, node, self.ctx
+                func_ty, node.args, ty, node, self.ctx, tgt_name
             )
             check_inst(func_ty, inst, node)
             node.func = instantiate_poly(node.func, func_ty, inst)
@@ -386,11 +386,12 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             processed_args, subst, inst = check_call(
                 # Doing better here would require major refactor to provide
                 # names/ids for each tensor element and identify the offender
-                ("<function tensor>", tensor_ty),
+                tensor_ty,
                 node.args,
                 ty,
                 node,
                 self.ctx,
+                "<function tensor>",
             )
             assert len(inst) == 0
             return with_loc(
@@ -948,7 +949,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                 # ALAN just passing the name of the proto func here
                 # - should pass the protocol defn id too
                 args, return_ty, inst = synthesize_call(
-                    (node.func.id, ty), node.args, node, self.ctx
+                    ty, node.args, node, self.ctx, node.func.id
                 )
                 return with_loc(
                     node,
@@ -970,7 +971,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         if isinstance(ty, FunctionType):
             tgt_name = _identify_callee(node.func)
             args, return_ty, inst = synthesize_call(
-                (tgt_name, ty), node.args, node, self.ctx
+                ty, node.args, node, self.ctx, tgt_name
             )
             node.func = instantiate_poly(node.func, ty, inst)
             return with_loc(node, LocalCall(func=node.func, args=args)), return_ty
@@ -987,10 +988,11 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             args, return_ty, inst = synthesize_call(
                 # Doing better here would require major refactor to provide
                 # names/ids for each tensor element and identify the offender
-                ("<function tensor>", tensor_ty),
+                tensor_ty,
                 node.args,
                 node,
                 self.ctx,
+                "<function tensor>",
             )
             assert len(inst) == 0
 
@@ -1396,22 +1398,24 @@ def _identify_callee(node: ast.expr) -> str | None:
 
 
 def _check_effects(
-    target: tuple[str | DefId | None, FunctionType], ctx: Context, node: AstNode
+    target: FunctionType,
+    callee_id: str | DefId | None,
+    ctx: Context,
+    node: AstNode,
 ) -> None:
     """Checks that a function call (AST provided) to a specified FunctionType
     respects the effect constraints in the context."""
     if (mf := ctx.max_effects_from) is None:
         return
-    tgt_id, func_ty = target
-    surplus_effects = [e for e in func_ty.effects if e not in mf.effects]
+    surplus_effects = [e for e in target.effects if e not in mf.effects]
     if surplus_effects:
         loc_node = node.func if isinstance(node, ast.Call) else node
         callee: str | FunctionType = (
-            func_ty
-            if tgt_id is None
-            else ctx.globals[tgt_id].name
-            if isinstance(tgt_id, DefId)
-            else tgt_id
+            target
+            if callee_id is None
+            else ctx.globals[callee_id].name
+            if isinstance(callee_id, DefId)
+            else callee_id
         )
         show_effects_allowed = mf.effects
         if isinstance(mf.decl, ast.expr):
@@ -1431,26 +1435,26 @@ def _check_effects(
 
 
 def synthesize_call(
-    target: tuple[str | DefId | None, FunctionType],
+    target: FunctionType,
     args: list[ast.expr],
     node: AstNode,
     ctx: Context,
+    callee: str | DefId | None,
 ) -> tuple[list[ast.expr], Type, Inst]:
-    _, func_ty = target
     """Synthesizes the return type of a function call.
 
     Returns an annotated argument list, the synthesized return type, and an
     instantiation for the quantifiers in the function type.
     """
-    assert not func_ty.unsolved_vars
-    check_num_args(len(func_ty.inputs), len(args), node, func_ty)
+    assert not target.unsolved_vars
+    check_num_args(len(target.inputs), len(args), node, target)
 
     # Replace quantified variables with free unification variables and try to infer an
     # instantiation by checking the arguments
-    unquantified, free_vars = func_ty.unquantified()
+    unquantified, free_vars = target.unquantified()
     var_mapping = {}
     inst_tele: list[Argument | None] = [None for _ in free_vars]
-    for ix, (var, param) in enumerate(zip(free_vars, func_ty.params, strict=True)):
+    for ix, (var, param) in enumerate(zip(free_vars, target.params, strict=True)):
         var_mapping[var] = param.instantiate_bounds(inst_tele)
         if isinstance(var, ExistentialTypeVar):
             inst_tele[ix] = TypeArg(var)
@@ -1461,22 +1465,23 @@ def synthesize_call(
 
     # Success implies that the substitution is closed
     assert all(not t.unsolved_vars for t in subst.values())
-    inst = check_all_solved(subst, free_vars, func_ty, node)
+    inst = check_all_solved(subst, free_vars, target, node)
 
     # Finally, check that the instantiation respects the linearity requirements
     # and the effects allowed in the context.
-    check_inst(func_ty, inst, node)
-    _check_effects(target, ctx, node)
+    check_inst(target, inst, node)
+    _check_effects(target, callee, ctx, node)
 
     return args, unquantified.output.substitute(subst), inst
 
 
 def check_call(
-    target: tuple[str | DefId | None, FunctionType],
+    target: FunctionType,
     inputs: list[ast.expr],
     ty: Type,
     node: AstNode,
     ctx: Context,
+    callee: str | DefId | None,
     kind: str = "expression",
 ) -> tuple[list[ast.expr], Subst, Inst]:
     """Checks the return type of a function call against a given type.
@@ -1484,9 +1489,8 @@ def check_call(
     Returns an annotated argument list, a substitution for the free variables in the
     expected type, and an instantiation for the quantifiers in the function type.
     """
-    _, func_ty = target
-    assert not func_ty.unsolved_vars
-    check_num_args(len(func_ty.inputs), len(inputs), node, func_ty)
+    assert not target.unsolved_vars
+    check_num_args(len(target.inputs), len(inputs), node, target)
 
     # When checking, we can use the information from the expected return type to infer
     # some type arguments. However, this pushes errors inwards. For example, given a
@@ -1513,7 +1517,7 @@ def check_call(
     inputs_copy = copy.deepcopy(inputs)
 
     try:
-        inputs, synth, inst = synthesize_call(target, inputs, node, ctx)
+        inputs, synth, inst = synthesize_call(target, inputs, node, ctx, callee)
         subst = unify(ty, synth, {})
         if subst is None:
             raise GuppyTypeError(TypeMismatchError(node, ty, synth, kind))
@@ -1529,7 +1533,7 @@ def check_call(
 
     # If synthesis fails, we try again, this time also using information from the
     # expected return type
-    unquantified, free_vars = func_ty.unquantified()
+    unquantified, free_vars = target.unquantified()
     subst = unify(ty, unquantified.output, {})
     if subst is None:
         raise GuppyTypeError(TypeMismatchError(node, ty, unquantified.output, kind))
@@ -1538,7 +1542,7 @@ def check_call(
     # instantiation by checking the arguments
     var_mapping = {}
     inst_tele: list[Argument | None] = [None for _ in free_vars]
-    for ix, (var, param) in enumerate(zip(free_vars, func_ty.params, strict=True)):
+    for ix, (var, param) in enumerate(zip(free_vars, target.params, strict=True)):
         var_mapping[var] = param.instantiate_bounds(inst_tele)
         if isinstance(var, ExistentialTypeVar):
             inst_tele[ix] = TypeArg(var)
@@ -1551,7 +1555,7 @@ def check_call(
     # checking against
     if not set.issubset(ty.unsolved_vars, subst.keys()):
         unsolved = (subst.keys() - ty.unsolved_vars).pop()
-        err = TypeMismatchError(node, ty, func_ty.output.substitute(subst))
+        err = TypeMismatchError(node, ty, target.output.substitute(subst))
         err.add_sub_diagnostic(
             TypeMismatchError.CantInferParam(None, unsolved.display_name)
         )
@@ -1559,13 +1563,13 @@ def check_call(
 
     # Success implies that the substitution is closed
     assert all(not t.unsolved_vars for t in subst.values())
-    inst = check_all_solved(subst, free_vars, func_ty, node)
+    inst = check_all_solved(subst, free_vars, target, node)
     subst = {v: t for v, t in subst.items() if v in ty.unsolved_vars}
 
     # Finally, check that the instantiation respects the linearity requirements
     # and the effects allowed in the context.
-    check_inst(func_ty, inst, node)
-    _check_effects(target, ctx, node)
+    check_inst(target, inst, node)
+    _check_effects(target, callee, ctx, node)
 
     return inputs, subst, inst
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -340,7 +340,11 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(func_ty, FunctionType)
-                args, subst, inst = check_call(func_ty, node.args, ty, node, self.ctx)
+                # ALAN just passing the name of the proto func here
+                # - should pass the protocol defn id too
+                args, subst, inst = check_call(
+                    (node.func.id, func_ty), node.args, ty, node, self.ctx
+                )
                 return with_loc(
                     node,
                     ProtocolCall(
@@ -941,7 +945,11 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(ty, FunctionType)
-                args, return_ty, inst = synthesize_call(ty, node.args, node, self.ctx)
+                # ALAN just passing the name of the proto func here
+                # - should pass the protocol defn id too
+                args, return_ty, inst = synthesize_call(
+                    (node.func.id, ty), node.args, node, self.ctx
+                )
                 return with_loc(
                     node,
                     ProtocolCall(

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1425,13 +1425,15 @@ def _check_effects(
             if isinstance(callee_id, tuple)
             else callee_id
         )
-        show_effects_allowed = mf.effects
-        if isinstance(mf.decl, ast.expr):
+        show_effects_allowed = (
             # We found the decorator that is the source of the effect constraint,
             # which will contain the allowed effects as an explicit argument
-            show_effects_allowed = None
-        # Otherwise, the error message points at all decorators, which may or may not
-        # list the allowed effects, so list them explicitly
+            None
+            if isinstance(mf.decl, ast.expr)
+            # Otherwise, the error message points at all decorators, which
+            # may or may not list the allowed effects, so list them explicitly
+            else mf.effects
+        )
 
         raise GuppyTypeError(
             TooManyEffectsError(

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -92,7 +92,7 @@ from guppylang_internals.checker.errors.type_errors import (
     UnitaryFlagMismatchError,
     WrongNumberOfArgsError,
 )
-from guppylang_internals.definition.common import Definition
+from guppylang_internals.definition.common import DefId, Definition
 from guppylang_internals.definition.parameter import ParamDef
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import CallableDef, ValueDef
@@ -360,7 +360,10 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         # Otherwise, it must be a function as a higher-order value - something
         # whose type is either a FunctionType or a Tuple of FunctionTypes
         if isinstance(func_ty, FunctionType):
-            args, subst, inst = check_call(func_ty, node.args, ty, node, self.ctx)
+            tgt_name = _identify_callee(node.func)
+            args, subst, inst = check_call(
+                (tgt_name, func_ty), node.args, ty, node, self.ctx
+            )
             check_inst(func_ty, inst, node)
             node.func = instantiate_poly(node.func, func_ty, inst)
             return with_loc(node, LocalCall(func=node.func, args=args)), subst
@@ -377,7 +380,13 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             tensor_ty = function_tensor_signature(function_elements)
 
             processed_args, subst, inst = check_call(
-                tensor_ty, node.args, ty, node, self.ctx
+                # Doing better here would require major refactor to provide
+                # names/ids for each tensor element and identify the offender
+                ("<function tensor>", tensor_ty),
+                node.args,
+                ty,
+                node,
+                self.ctx,
             )
             assert len(inst) == 0
             return with_loc(
@@ -951,7 +960,10 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
 
         # Otherwise, it must be a function as a higher-order value, or a tensor
         if isinstance(ty, FunctionType):
-            args, return_ty, inst = synthesize_call(ty, node.args, node, self.ctx)
+            tgt_name = _identify_callee(node.func)
+            args, return_ty, inst = synthesize_call(
+                (tgt_name, ty), node.args, node, self.ctx
+            )
             node.func = instantiate_poly(node.func, ty, inst)
             return with_loc(node, LocalCall(func=node.func, args=args)), return_ty
         elif isinstance(ty, TupleType) and (
@@ -965,7 +977,12 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
 
             tensor_ty = function_tensor_signature(function_elems)
             args, return_ty, inst = synthesize_call(
-                tensor_ty, node.args, node, self.ctx
+                # Doing better here would require major refactor to provide
+                # names/ids for each tensor element and identify the offender
+                ("<function tensor>", tensor_ty),
+                node.args,
+                node,
+                self.ctx,
             )
             assert len(inst) == 0
 
@@ -1362,14 +1379,32 @@ def check_comptime_arg(
     return subst
 
 
-def _check_effects(func_ty: FunctionType, ctx: Context, node: AstNode) -> None:
+def _identify_callee(node: ast.expr) -> str | None:
+    match node:
+        case PlaceNode(place=Variable(name=n)):
+            return n
+        case _:
+            return None
+
+
+def _check_effects(
+    target: tuple[str | DefId | None, FunctionType], ctx: Context, node: AstNode
+) -> None:
     """Checks that a function call (AST provided) to a specified FunctionType
     respects the effect constraints in the context."""
     if (mf := ctx.max_effects_from) is None:
         return
+    tgt_id, func_ty = target
     surplus_effects = [e for e in func_ty.effects if e not in mf.effects]
     if surplus_effects:
         loc_node = node.func if isinstance(node, ast.Call) else node
+        callee: str | FunctionType = (
+            func_ty
+            if tgt_id is None
+            else ctx.globals[tgt_id].name
+            if isinstance(tgt_id, DefId)
+            else tgt_id
+        )
         show_effects_allowed = mf.effects
         if isinstance(mf.decl, ast.expr):
             # We found the decorator that is the source of the effect constraint,
@@ -1378,7 +1413,6 @@ def _check_effects(func_ty: FunctionType, ctx: Context, node: AstNode) -> None:
         # Otherwise, the error message points at all decorators, which may or may not
         # list the allowed effects, so list them explicitly
 
-        callee = loc_node.id if isinstance(loc_node, ast.Name) else func_ty
         raise GuppyTypeError(
             TooManyEffectsError(
                 loc_node, callee, surplus_effects, mf.decl_name
@@ -1389,8 +1423,12 @@ def _check_effects(func_ty: FunctionType, ctx: Context, node: AstNode) -> None:
 
 
 def synthesize_call(
-    func_ty: FunctionType, args: list[ast.expr], node: AstNode, ctx: Context
+    target: tuple[str | DefId | None, FunctionType],
+    args: list[ast.expr],
+    node: AstNode,
+    ctx: Context,
 ) -> tuple[list[ast.expr], Type, Inst]:
+    _, func_ty = target
     """Synthesizes the return type of a function call.
 
     Returns an annotated argument list, the synthesized return type, and an
@@ -1420,13 +1458,13 @@ def synthesize_call(
     # Finally, check that the instantiation respects the linearity requirements
     # and the effects allowed in the context.
     check_inst(func_ty, inst, node)
-    _check_effects(func_ty, ctx, node)
+    _check_effects(target, ctx, node)
 
     return args, unquantified.output.substitute(subst), inst
 
 
 def check_call(
-    func_ty: FunctionType,
+    target: tuple[str | DefId | None, FunctionType],
     inputs: list[ast.expr],
     ty: Type,
     node: AstNode,
@@ -1438,6 +1476,7 @@ def check_call(
     Returns an annotated argument list, a substitution for the free variables in the
     expected type, and an instantiation for the quantifiers in the function type.
     """
+    _, func_ty = target
     assert not func_ty.unsolved_vars
     check_num_args(len(func_ty.inputs), len(inputs), node, func_ty)
 
@@ -1466,7 +1505,7 @@ def check_call(
     inputs_copy = copy.deepcopy(inputs)
 
     try:
-        inputs, synth, inst = synthesize_call(func_ty, inputs, node, ctx)
+        inputs, synth, inst = synthesize_call(target, inputs, node, ctx)
         subst = unify(ty, synth, {})
         if subst is None:
             raise GuppyTypeError(TypeMismatchError(node, ty, synth, kind))
@@ -1518,7 +1557,7 @@ def check_call(
     # Finally, check that the instantiation respects the linearity requirements
     # and the effects allowed in the context.
     check_inst(func_ty, inst, node)
-    _check_effects(func_ty, ctx, node)
+    _check_effects(target, ctx, node)
 
     return inputs, subst, inst
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -28,7 +28,7 @@ from collections.abc import Mapping, Sequence
 from contextlib import suppress
 from dataclasses import replace
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, NoReturn
+from typing import TYPE_CHECKING, Any, NoReturn, TypeAlias
 
 from guppylang_internals.ast_util import (
     AstNode,
@@ -340,10 +340,13 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(func_ty, FunctionType)
-                # ALAN just passing the name of the proto func here
-                # - should pass the protocol defn id too
                 args, subst, inst = check_call(
-                    func_ty, node.args, ty, node, self.ctx, node.func.id
+                    func_ty,
+                    node.args,
+                    ty,
+                    node,
+                    self.ctx,
+                    (node.func.def_id, node.func.id),
                 )
                 return with_loc(
                     node,
@@ -946,10 +949,8 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             # protocol definition itself first.
             if isinstance(defn, ParsedProtocolDef):
                 assert isinstance(ty, FunctionType)
-                # ALAN just passing the name of the proto func here
-                # - should pass the protocol defn id too
                 args, return_ty, inst = synthesize_call(
-                    ty, node.args, node, self.ctx, node.func.id
+                    ty, node.args, node, self.ctx, (node.func.def_id, node.func.id)
                 )
                 return with_loc(
                     node,
@@ -1397,9 +1398,14 @@ def _identify_callee(node: ast.expr) -> str | None:
             return None
 
 
+# A function definition; a protocol definition and the name of the function within it;
+# or a string for error messages if there is no definition
+CalleeId: TypeAlias = DefId | tuple[DefId, str] | str
+
+
 def _check_effects(
     target: FunctionType,
-    callee_id: str | DefId | None,
+    callee_id: CalleeId | None,
     ctx: Context,
     node: AstNode,
 ) -> None:
@@ -1415,6 +1421,8 @@ def _check_effects(
             if callee_id is None
             else ctx.globals[callee_id].name
             if isinstance(callee_id, DefId)
+            else f"Function {callee_id[1]} in protocol {ctx.globals[callee_id[0]].name}"
+            if isinstance(callee_id, tuple)
             else callee_id
         )
         show_effects_allowed = mf.effects
@@ -1439,7 +1447,7 @@ def synthesize_call(
     args: list[ast.expr],
     node: AstNode,
     ctx: Context,
-    callee: str | DefId | None,
+    callee: CalleeId | None,
 ) -> tuple[list[ast.expr], Type, Inst]:
     """Synthesizes the return type of a function call.
 
@@ -1481,7 +1489,7 @@ def check_call(
     ty: Type,
     node: AstNode,
     ctx: Context,
-    callee: str | DefId | None,
+    callee: CalleeId | None,
     kind: str = "expression",
 ) -> tuple[list[ast.expr], Subst, Inst]:
     """Checks the return type of a function call against a given type.

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -491,13 +491,17 @@ class DefaultCallChecker(CustomCallChecker):
     @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
+        args, subst, inst = check_call(
+            (self.func.name, self.func.ty), args, ty, self.node, self.ctx
+        )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
 
     @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
+        args, ty, inst = synthesize_call(
+            (self.func.name, self.func.ty), args, self.node, self.ctx
+        )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -492,7 +492,7 @@ class DefaultCallChecker(CustomCallChecker):
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(
-            (self.func.name, self.func.ty), args, ty, self.node, self.ctx
+            self.func.ty, args, ty, self.node, self.ctx, self.func.name
         )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
 
@@ -500,7 +500,7 @@ class DefaultCallChecker(CustomCallChecker):
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(
-            (self.func.name, self.func.ty), args, self.node, self.ctx
+            self.func.ty, args, self.node, self.ctx, self.func.name
         )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -492,7 +492,7 @@ class DefaultCallChecker(CustomCallChecker):
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(
-            self.func.ty, args, ty, self.node, self.ctx, self.func.name
+            self.func.ty, args, ty, self.node, self.ctx, self.func.id
         )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
 
@@ -500,7 +500,7 @@ class DefaultCallChecker(CustomCallChecker):
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(
-            self.func.ty, args, self.node, self.ctx, self.func.name
+            self.func.ty, args, self.node, self.ctx, self.func.id
         )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -167,7 +167,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return node, subst
@@ -178,7 +178,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     ) -> tuple[GlobalCall, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return with_type(ty, node), ty

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -167,7 +167,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return node, subst
@@ -178,7 +178,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     ) -> tuple[GlobalCall, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return with_type(ty, node), ty

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -167,7 +167,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx)
+        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return node, subst
@@ -178,7 +178,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
     ) -> tuple[GlobalCall, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx)
+        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return with_type(ty, node), ty

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -200,7 +200,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx)
+        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return node, subst
@@ -211,7 +211,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx)
+        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return with_type(ty, node), ty

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -200,7 +200,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return node, subst
@@ -211,7 +211,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return with_type(ty, node), ty

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -200,7 +200,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return node, subst
@@ -211,7 +211,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         ENGINE.register_generic_use(self, inst)
         return with_type(ty, node), ty

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -342,7 +342,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
@@ -352,7 +352,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -342,7 +342,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx)
+        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
@@ -352,7 +352,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx)
+        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -342,7 +342,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
@@ -352,7 +352,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -115,7 +115,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
@@ -125,7 +125,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.id)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -115,7 +115,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.ty, args, ty, node, ctx)
+        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
@@ -125,7 +125,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.ty, args, node, ctx)
+        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -115,7 +115,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
     ) -> tuple[ast.expr, Subst]:
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
-        args, subst, inst = check_call((self.name, self.ty), args, ty, node, ctx)
+        args, subst, inst = check_call(self.ty, args, ty, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, subst
 
@@ -125,7 +125,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
     ) -> tuple[ast.expr, Type]:
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call((self.name, self.ty), args, node, ctx)
+        args, ty, inst = synthesize_call(self.ty, args, node, ctx, self.name)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
         return node, ty
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -177,7 +177,7 @@ class ArrayCopyChecker(CustomCallChecker):
                     )
                     raise GuppyTypeError(err)
         [array_arg], _, inst = synthesize_call(
-            self.func.ty, args, self.node, self.ctx, self.func.name
+            self.func.ty, args, self.node, self.ctx, self.func.id
         )
         node = GlobalCall(def_id=self.func.id, args=[array_arg], type_args=inst)
         return with_loc(self.node, node), get_type(array_arg)
@@ -267,7 +267,7 @@ class ArrayIndexChecker(CustomCallChecker):
 
         # Run regular type checking for the arguments
         args, subs, type_args = check_call(
-            self.func.ty, args, ty, self.node, self.ctx, self.func.name
+            self.func.ty, args, ty, self.node, self.ctx, self.func.id
         )
 
         # Check the index bounds (first:index expression, second: length_arg)
@@ -283,7 +283,7 @@ class ArrayIndexChecker(CustomCallChecker):
         """Synthesize-mode: infer return type and perform bounds check."""
         # Run regular type synthesis for the arguments
         args, ty, type_args = synthesize_call(
-            self.func.ty, args, self.node, self.ctx, self.func.name
+            self.func.ty, args, self.node, self.ctx, self.func.id
         )
 
         # Check the index bounds (first:index expression, second: length_arg)
@@ -499,7 +499,7 @@ class BarrierChecker(CustomCallChecker):
             NoneType(),
         )
         args, ret_ty, inst = synthesize_call(
-            func_ty, args, self.node, self.ctx, self.func.name
+            func_ty, args, self.node, self.ctx, self.func.id
         )
         assert len(inst) == 0, "func_ty is not generic"
         node = BarrierExpr(args=args, func_ty=func_ty)
@@ -511,7 +511,7 @@ class WasmCallChecker(CustomCallChecker):
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(
-            self.func.ty, args, ty, self.node, self.ctx, self.func.name
+            self.func.ty, args, ty, self.node, self.ctx, self.func.id
         )
 
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
@@ -520,6 +520,6 @@ class WasmCallChecker(CustomCallChecker):
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(
-            self.func.ty, args, self.node, self.ctx, self.func.name
+            self.func.ty, args, self.node, self.ctx, self.func.id
         )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -176,7 +176,9 @@ class ArrayCopyChecker(CustomCallChecker):
                         ArrayCopyChecker.NonCopyableElementsError.Explanation(None)
                     )
                     raise GuppyTypeError(err)
-        [array_arg], _, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
+        [array_arg], _, inst = synthesize_call(
+            ("array.copy", self.func.ty), args, self.node, self.ctx
+        )
         node = GlobalCall(def_id=self.func.id, args=[array_arg], type_args=inst)
         return with_loc(self.node, node), get_type(array_arg)
 
@@ -264,7 +266,9 @@ class ArrayIndexChecker(CustomCallChecker):
         expected type and perform bounds check."""
 
         # Run regular type checking for the arguments
-        args, subs, type_args = check_call(self.func.ty, args, ty, self.node, self.ctx)
+        args, subs, type_args = check_call(
+            (self.func.name, self.func.ty), args, ty, self.node, self.ctx
+        )
 
         # Check the index bounds (first:index expression, second: length_arg)
         # Temporarily disabled: see https://github.com/Quantinuum/guppylang/issues/1669
@@ -278,7 +282,9 @@ class ArrayIndexChecker(CustomCallChecker):
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         """Synthesize-mode: infer return type and perform bounds check."""
         # Run regular type synthesis for the arguments
-        args, ty, type_args = synthesize_call(self.func.ty, args, self.node, self.ctx)
+        args, ty, type_args = synthesize_call(
+            (self.func.name, self.func.ty), args, self.node, self.ctx
+        )
 
         # Check the index bounds (first:index expression, second: length_arg)
         # Temporarily disabled: see https://github.com/Quantinuum/guppylang/issues/1669
@@ -492,7 +498,9 @@ class BarrierChecker(CustomCallChecker):
             [FuncInput(t, InputFlags.Inout) for t in tys],
             NoneType(),
         )
-        args, ret_ty, inst = synthesize_call(func_ty, args, self.node, self.ctx)
+        args, ret_ty, inst = synthesize_call(
+            (self.func.name, func_ty), args, self.node, self.ctx
+        )
         assert len(inst) == 0, "func_ty is not generic"
         node = BarrierExpr(args=args, func_ty=func_ty)
         return with_loc(self.node, node), ret_ty
@@ -502,12 +510,16 @@ class WasmCallChecker(CustomCallChecker):
     @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
-        args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
+        args, subst, inst = check_call(
+            (self.func.name, self.func.ty), args, ty, self.node, self.ctx
+        )
 
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
 
     @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
-        args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
+        args, ty, inst = synthesize_call(
+            (self.func.name, self.func.ty), args, self.node, self.ctx
+        )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -177,7 +177,7 @@ class ArrayCopyChecker(CustomCallChecker):
                     )
                     raise GuppyTypeError(err)
         [array_arg], _, inst = synthesize_call(
-            ("array.copy", self.func.ty), args, self.node, self.ctx
+            (self.func.name, self.func.ty), args, self.node, self.ctx
         )
         node = GlobalCall(def_id=self.func.id, args=[array_arg], type_args=inst)
         return with_loc(self.node, node), get_type(array_arg)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -177,7 +177,7 @@ class ArrayCopyChecker(CustomCallChecker):
                     )
                     raise GuppyTypeError(err)
         [array_arg], _, inst = synthesize_call(
-            (self.func.name, self.func.ty), args, self.node, self.ctx
+            self.func.ty, args, self.node, self.ctx, self.func.name
         )
         node = GlobalCall(def_id=self.func.id, args=[array_arg], type_args=inst)
         return with_loc(self.node, node), get_type(array_arg)
@@ -267,7 +267,7 @@ class ArrayIndexChecker(CustomCallChecker):
 
         # Run regular type checking for the arguments
         args, subs, type_args = check_call(
-            (self.func.name, self.func.ty), args, ty, self.node, self.ctx
+            self.func.ty, args, ty, self.node, self.ctx, self.func.name
         )
 
         # Check the index bounds (first:index expression, second: length_arg)
@@ -283,7 +283,7 @@ class ArrayIndexChecker(CustomCallChecker):
         """Synthesize-mode: infer return type and perform bounds check."""
         # Run regular type synthesis for the arguments
         args, ty, type_args = synthesize_call(
-            (self.func.name, self.func.ty), args, self.node, self.ctx
+            self.func.ty, args, self.node, self.ctx, self.func.name
         )
 
         # Check the index bounds (first:index expression, second: length_arg)
@@ -499,7 +499,7 @@ class BarrierChecker(CustomCallChecker):
             NoneType(),
         )
         args, ret_ty, inst = synthesize_call(
-            (self.func.name, func_ty), args, self.node, self.ctx
+            func_ty, args, self.node, self.ctx, self.func.name
         )
         assert len(inst) == 0, "func_ty is not generic"
         node = BarrierExpr(args=args, func_ty=func_ty)
@@ -511,7 +511,7 @@ class WasmCallChecker(CustomCallChecker):
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(
-            (self.func.name, self.func.ty), args, ty, self.node, self.ctx
+            self.func.ty, args, ty, self.node, self.ctx, self.func.name
         )
 
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
@@ -520,6 +520,6 @@ class WasmCallChecker(CustomCallChecker):
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(
-            (self.func.name, self.func.ty), args, self.node, self.ctx
+            self.func.ty, args, self.node, self.ctx, self.func.name
         )
         return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -98,7 +98,7 @@ class StateOutputChecker(CustomCallChecker):
                 NoneType(),
             )
         args, ret_ty, inst = synthesize_call(
-            ("`state_result`", func_ty), syn_args, self.node, self.ctx
+            func_ty, syn_args, self.node, self.ctx, "`state_result`"
         )
         assert len(inst) == 0, "func_ty is not generic"
         node = StateOutputExpr(

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -98,7 +98,7 @@ class StateOutputChecker(CustomCallChecker):
                 NoneType(),
             )
         args, ret_ty, inst = synthesize_call(
-            func_ty, syn_args, self.node, self.ctx, "`state_result`"
+            func_ty, syn_args, self.node, self.ctx, "state_result"
         )
         assert len(inst) == 0, "func_ty is not generic"
         node = StateOutputExpr(

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -97,7 +97,9 @@ class StateOutputChecker(CustomCallChecker):
                 + [FuncInput(qubit_ty, InputFlags.Inout)] * len(args[1:]),
                 NoneType(),
             )
-        args, ret_ty, inst = synthesize_call(func_ty, syn_args, self.node, self.ctx)
+        args, ret_ty, inst = synthesize_call(
+            ("`state_result`", func_ty), syn_args, self.node, self.ctx
+        )
         assert len(inst) == 0, "func_ty is not generic"
         node = StateOutputExpr(
             tag_value=tag_value,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -98,7 +98,7 @@ class StateOutputChecker(CustomCallChecker):
                 NoneType(),
             )
         args, ret_ty, inst = synthesize_call(
-            func_ty, syn_args, self.node, self.ctx, "state_result"
+            func_ty, syn_args, self.node, self.ctx, self.func.id
         )
         assert len(inst) == 0, "func_ty is not generic"
         node = StateOutputExpr(

--- a/tests/error/effects_errors/comptime_pure_calls_impure.err
+++ b/tests/error/effects_errors/comptime_pure_calls_impure.err
@@ -3,4 +3,4 @@ Traceback (most recent call last):
     main.compile()
   File "$FILE", line 9, in main
     return impure_func(5)
-guppylang_internals.error.GuppyComptimeError: Too many effects: Callee of type `int -> int` has effects `[ANY]` not allowed inside `main`
+guppylang_internals.error.GuppyComptimeError: Too many effects: Call to `impure_func` has effects `[ANY]` not allowed inside `main`

--- a/tests/error/effects_errors/pure_calls_explicit_callable.err
+++ b/tests/error/effects_errors/pure_calls_explicit_callable.err
@@ -3,7 +3,8 @@ Error: Too many effects (at $FILE:8:10)
 6 | @guppy(effects=[])
 7 | def main(impure_f: Callable[[int], int] @ effects(ANY)) -> int:
 8 |    return impure_f(5)
-  |           ^^^^^^^^ Callee of type `int -[ANY]-> int` not allowed inside `main`
+  |           ^^^^^^^^ Call to `impure_f` has effects `[ANY]` not allowed inside
+  |                    `main`
 
 Note:
   | 

--- a/tests/error/effects_errors/pure_calls_explicit_callable_comptime.err
+++ b/tests/error/effects_errors/pure_calls_explicit_callable_comptime.err
@@ -3,7 +3,8 @@ Error: Too many effects (at $FILE:8:10)
 6 | @guppy(effects=[])
 7 | def main(impure_f: Callable[[int], int] @ effects(ANY)) -> int:
 8 |    return impure_f(5)
-  |           ^^^^^^^^ Callee of type `int -[ANY]-> int` not allowed inside `main`
+  |           ^^^^^^^^ Call to `impure_f` has effects `[ANY]` not allowed inside
+  |                    `main`
 
 Note:
   | 

--- a/tests/error/effects_errors/pure_calls_impure_callable.err
+++ b/tests/error/effects_errors/pure_calls_impure_callable.err
@@ -3,8 +3,8 @@ Error: Too many effects (at $FILE:7:10)
 5 | @guppy(effects=[])
 6 | def main(impure_f: Callable[[int], int]) -> int:
 7 |    return impure_f(5)
-  |           ^^^^^^^^ Callee of type `int -> int` has effects `[ANY]` not allowed
-  |                    inside `main`
+  |           ^^^^^^^^ Call to `impure_f` has effects `[ANY]` not allowed inside
+  |                    `main`
 
 Note:
   | 

--- a/tests/error/effects_errors/pure_calls_impure_callable_comptime.err
+++ b/tests/error/effects_errors/pure_calls_impure_callable_comptime.err
@@ -3,8 +3,8 @@ Error: Too many effects (at $FILE:7:10)
 5 | @guppy(effects=[])
 6 | def main(impure_f: Callable[[int], int]) -> int:
 7 |    return impure_f(5)
-  |           ^^^^^^^^ Callee of type `int -> int` has effects `[ANY]` not allowed
-  |                    inside `main`
+  |           ^^^^^^^^ Call to `impure_f` has effects `[ANY]` not allowed inside
+  |                    `main`
 
 Note:
   | 

--- a/tests/error/effects_errors/pure_comptime_calls_impure_decl.err
+++ b/tests/error/effects_errors/pure_comptime_calls_impure_decl.err
@@ -3,4 +3,4 @@ Traceback (most recent call last):
     main.compile()
   File "$FILE", line 9, in main
     return impure_func(5)
-guppylang_internals.error.GuppyComptimeError: Too many effects: Callee of type `int -> int` has effects `[ANY]` not allowed inside `main`
+guppylang_internals.error.GuppyComptimeError: Too many effects: Call to `impure_func` has effects `[ANY]` not allowed inside `main`

--- a/tests/error/effects_errors/pure_comptime_calls_impure_def.err
+++ b/tests/error/effects_errors/pure_comptime_calls_impure_def.err
@@ -3,4 +3,4 @@ Traceback (most recent call last):
     main.compile()
   File "$FILE", line 9, in main
     return impure_func(5)
-guppylang_internals.error.GuppyComptimeError: Too many effects: Callee of type `int -> int` has effects `[ANY]` not allowed inside `main`
+guppylang_internals.error.GuppyComptimeError: Too many effects: Call to `impure_func` has effects `[ANY]` not allowed inside `main`


### PR DESCRIPTION
This significantly improves a lot of the error messages for effects violations, and perhaps might be applied to other errors too?

Note that tensor'd functions are gonna have terrible messages both before and after, I haven't got a test of these yet as they are marked experimental, note comment - we'd need significant refactoring to sort that.

BREAKING CHANGE: (guppylang-internals) top-level `check_call` and `synthesize_call` methods take a tuple of `str | DefId | None` to identify the callee