### PR TITLE
feat(stdlib): add yy_max utility to sol to match xx_max

### DIFF
--- a/guppylang/src/guppylang/std/qsystem/sol/__init__.py
+++ b/guppylang/src/guppylang/std/qsystem/sol/__init__.py
@@ -41,6 +41,7 @@ __all__ = [
     "reset",
     "rz",
     "xx_max",
+    "yy_max",
 ]
 
 
@@ -127,6 +128,19 @@ def xx_max(q1: qubit, q2: qubit) -> None:
     ``phased_xx_max`` with zero phase. This is the XX analogue of ``zz_max``.
     """
     phased_xx_max(q1, q2, angle(0.0))
+
+
+@guppy
+@no_type_check
+def yy_max(q1: qubit, q2: qubit) -> None:
+    r"""yy_max gate command. Maximally entangling YY gate.
+
+    Equivalent to :math:`e^{-i\frac{\pi}{4} Y \otimes Y}`, i.e.
+    ``phased_xx_max`` with phase :math:`\frac{\pi}{2}`.
+    """
+    # phased_xx_max(phase) is PhasedXX(pi / 2, phase). At phase pi / 2, the
+    # rotation axis is cos(pi / 2) X + sin(pi / 2) Y = Y.
+    phased_xx_max(q1, q2, pi / 2)
 
 
 @guppy

--- a/guppylang/src/guppylang/std/qsystem/sol/functional.py
+++ b/guppylang/src/guppylang/std/qsystem/sol/functional.py
@@ -57,6 +57,14 @@ def xx_max(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]:
 
 @guppy
 @no_type_check
+def yy_max(q1: qubit @ owned, q2: qubit @ owned) -> tuple[qubit, qubit]:
+    """Functional yy_max gate command. Maximally entangling YY gate."""
+    sol.yy_max(q1, q2)
+    return q1, q2
+
+
+@guppy
+@no_type_check
 def rz(q: qubit @ owned, angle: angle) -> qubit:
     """Functional Rz gate command."""
     sol.rz(q, angle)

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -125,6 +125,7 @@ def test_qsystem_sol(validate):  # type: ignore[no-untyped-def]
         phased_xx,
         phased_xx_max,
         xx_max,
+        yy_max,
         qfree,
         reset,
         rz,
@@ -136,6 +137,7 @@ def test_qsystem_sol(validate):  # type: ignore[no-untyped-def]
         phased_xx(q1, q2, a1, a1)
         phased_xx_max(q1, q2, a1)
         xx_max(q1, q2)
+        yy_max(q1, q2)
         rz(q1, a1)
         m1 = lazy_measure_and_reset(q1)
         m1.read()
@@ -187,6 +189,7 @@ def test_qsystem_sol_functional(validate):  # type: ignore[no-untyped-def]
         reset,
         rz,
         xx_max,
+        yy_max,
     )
 
     @guppy
@@ -195,6 +198,7 @@ def test_qsystem_sol_functional(validate):  # type: ignore[no-untyped-def]
         q1, q2 = phased_xx(q1, q2, a1, a1)
         q1, q2 = phased_xx_max(q1, q2, a1)
         q1, q2 = xx_max(q1, q2)
+        q1, q2 = yy_max(q1, q2)
         q1 = rz(q1, a1)
         q1 = reset(q1)
         q1, m1 = measure_and_reset(q1)


### PR DESCRIPTION
## Summary
- Add `yy_max` to the `qsystem.sol` API and export list.
- Provide the functional owned-qubit wrapper for `yy_max`.
- Extend integration coverage for both imperative and functional usage.

## Testing
- Added integration tests covering `yy_max` in the standard and functional qsystem suites.

BEGIN_COMMIT_OVERRIDE
feat: Add yy_max utility to sol standard library to match xx_max (#1857)
END_COMMIT_OVERRIDE