### PR TITLE
fix: do not use dummy decorator if running in Jupyter notebook

### DIFF
--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -72,8 +72,22 @@ def _dummy_custom_decorator(*args: Any, **kwargs: Any) -> Any:
     return lambda f: f
 
 
+def _notebook_kernel_running() -> bool:
+    """Checks if code is running inside a Jupyter kernel."""
+    try:
+        from IPython import get_ipython
+    except ImportError:
+        return False
+
+    shell = get_ipython()
+    return shell is not None and shell.__class__.__name__ == "ZMQInteractiveShell"
+
+
 def sphinx_running() -> bool:
-    """Checks if guppylang was imported during a sphinx build."""
+    """Checks if guppylang was imported during a Sphinx build."""
+    if _notebook_kernel_running():
+        return False
+
     # This is the most general solution available at the moment.
     # See: https://github.com/sphinx-doc/sphinx/issues/9805
     try:


### PR DESCRIPTION
In the process of updating some of the packages the documentation build uses, I started getting errors like the following:

```
13.31 ---------------------------------------------------------------------------
13.31 AttributeError                            Traceback (most recent call last)
13.31 Cell In[1], line 20
13.31      17         x(q2)
13.31      19     return q2
13.31 ---> 20 simple_circuit.check()
13.31
13.31 AttributeError: 'function' object has no attribute 'check'
```

It seems that Guppy checks whether it is running under Sphinx and replaces the Guppy directive with a dummy one that just produces a regular function, which doesn't work when the notebook tries to call Guppy's functions on it. I'm not sure exactly why this was working previously and started failing for me, I guess Sphinx or myst-nb changed something internally that means the heuristic used to detect Sphinx is now positive when myst-nb is running the notebooks.

This PR adds an additional check whether the code is running under a Jupyter notebook. If it is then the check returns `False` to ensure the dummy decorator is not used.