### PR TITLE
chore: Merge components into a single release PR

### DIFF
--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -1,10 +1,8 @@
 # A check that ensures that `guppylang` and `guppylang-internals` work correctly with the lowest and highest allowed
-# versions of their dependencies. Additionally, `guppylang` is tested to work with the latest released version of
-# `guppylang-internals`.
+# versions of their dependencies.
 #
-# If either checks fail, it is likely that the packages are not compatible with the respective versions of their
-# dependencies and the version ranges have to be adjusted. Additionally, this might fail if `guppylang` requires an
-# unreleased or unpublished version of `guppylang-internals`.
+# If checks fail, it is likely that the packages are not compatible with the respective versions of their dependencies
+# and the version ranges have to be adjusted.
 
 name: 🚚 Release checks
 
@@ -22,12 +20,8 @@ jobs:
   check-release-guppylang-internals:
     name: Check `guppylang-internals` release compatibility with ${{ matrix.target.resolution }} dependencies
     runs-on: ubuntu-latest
-    # Check if we are running on a release PR, targeting some branch (sits in the middle of the release branch name)
-    #
-    # release-please always uses this branch name.
-    if: |
-     github.event_name == 'workflow_dispatch' ||
-     (startsWith(github.head_ref, 'release-please--') && endsWith(github.head_ref, '--components--guppylang-internals'))
+    # Check if we are running on a release PR (release-please always uses this branch name)
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--')
     strategy:
       fail-fast: false
       matrix:
@@ -59,69 +53,16 @@ jobs:
           echo "\nDone! Installed dependencies:"
           uv pip list
       - name: Type check with mypy
-        run: uv run --no-sync mypy guppylang-internals
+        run: uv run --no-sync mypy guppylang guppylang-internals
       - name: Lint with ruff
-        run: uv run --no-sync ruff check guppylang-internals
+        run: uv run --no-sync ruff check guppylang guppylang-internals
       - name: Run tests
         run: UV_NO_SYNC=1 just test
-
-  check-release-guppylang:
-    name: Check `guppylang` release compatibility with ${{ matrix.target.resolution }} dependencies
-    runs-on: ubuntu-latest
-    # Check if we are running on a release PR, targeting some branch (sits in the middle of the release branch name)
-    #
-    # release-please always uses this branch name.
-    if: |
-     github.event_name == 'workflow_dispatch' ||
-     (startsWith(github.head_ref, 'release-please--') && endsWith(github.head_ref, '--components--guppylang'))
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - resolution: "highest"
-            python: "3.14"
-          - resolution: "lowest-direct"
-            python: "3.10"
-    steps:
-      - uses: actions/checkout@v6
-      - uses: mozilla-actions/sccache-action@v0.0.10
-      - name: Set up uv
-        uses: astral-sh/setup-uv@v7
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: true
-      - name: Set up Just
-        uses: extractions/setup-just@v4
-      - name: Install Python ${{ matrix.target.python }}
-        run: |
-          uv python install ${{ matrix.target.python }}
-          uv python pin ${{ matrix.target.python }}
-      - name: Setup `guppylang` with only pypi dependencies
-        env:
-          RES: ${{ matrix.target.resolution }}
-        run: |
-          UV_RESOLUTION="$RES" uv lock --prerelease=allow --no-sources -U
-          UV_RESOLUTION="$RES" uv sync --prerelease=allow --no-sources --no-install-workspace
-          # Install the latest published release of guppylang-internals.
-          uv pip install --no-sources --prerelease allow guppylang-internals
-          # Install the local version of guppylang.
-          uv pip install -e guppylang --no-deps
-          echo "\nDone! Installed dependencies:"
-          uv pip list
-      - name: Type check with mypy
-        run: uv run --no-sync mypy guppylang
-      - name: Lint with ruff
-        run: uv run --no-sync ruff check guppylang
-      - name: Run tests
-        run: UV_NO_SYNC=1 just test
-
 
   check-guppy-docs-build:
     name: Check the guppy-docs build for `guppylang` release 
     runs-on: ubuntu-latest
-    if: |
-     github.event_name == 'workflow_dispatch' ||
-     (startsWith(github.head_ref, 'release-please--') && endsWith(github.head_ref, '--components--guppylang'))
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.head_ref, 'release-please--')
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+      - mr/chore/merge-release-workflows
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/release-checks.yml
+++ b/.github/workflows/release-checks.yml
@@ -14,7 +14,7 @@ on:
 
 env:
   # Pinned version for the uv package manager
-  UV_VERSION: "0.9.5"
+  UV_VERSION: "0.11.21"
 
 jobs:
   check-release-guppylang-internals:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - mr/chore/merge-release-workflows
 
 permissions:
   contents: write
@@ -20,4 +21,5 @@ jobs:
         with:
             # Using a personal access token so releases created by this workflow can trigger the deployment workflow
             token: ${{ secrets.HUGRBOT_PAT }}
+            target-branch: 'mr/chore/merge-release-workflows'
             config-file: release-please-config.json

--- a/guppylang-internals/src/guppylang_internals/ast_util.py
+++ b/guppylang-internals/src/guppylang_internals/ast_util.py
@@ -31,7 +31,7 @@ class AstVisitor(Generic[T]):
     Note: This class is based on the implementation of `ast.NodeVisitor` but
     allows extra arguments to be passed to the `visit` functions.
 
-    Original documentation:
+    Original documentation woah:
 
     A node visitor base class that walks the abstract syntax tree and calls a
     visitor function for every node found.  This function may return a value

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "separate-pull-requests": true,
+  "separate-pull-requests": false,
+  "draft-pull-request": true,
   "pull-request-title-pattern": "chore: release${component} ${version}",
   "include-component-in-tag": true,
   "include-v-in-tag": true,
@@ -14,12 +15,11 @@
       "prerelease": true,
       "prerelease-type": "a",
       "versioning": "prerelease",
-      "draft-pull-request": true,
       "extra-files": [
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name.value=='guppylang')].version"
+          "jsonpath": "$.package[?(@.name=='guppylang')].version"
         }
       ]
     },
@@ -36,7 +36,7 @@
         {
           "type": "toml",
           "path": "uv.lock",
-          "jsonpath": "$.package[?(@.name.value=='guppylang-internals')].version"
+          "jsonpath": "$.package[?(@.name=='guppylang-internals')].version"
         }
       ]
     }


### PR DESCRIPTION
The upside comes down to a simpler release workflow and simpler actions definitions.

The downside is that we cannot check `guppylang` against the released `guppylang-internals` anymore, only against a locally built wheel at maximum (currently it is just the local dev version).

Also the generated release-pr does not include the version of the component in the title (as it contains multiple components).

Closes #1867