### PR TITLE
refactor(stdlib)!: quantum.project_z returns Measurement 

### DIFF
--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -6,7 +6,6 @@ from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type, hugr_op
 from guppylang_internals.std._internal.compiler.quantum import (
-    InoutMeasureCompiler,
     RotationCompiler,
 )
 from guppylang_internals.std._internal.compiler.tket_exts import MEASUREMENT_EXTENSION
@@ -18,6 +17,7 @@ from guppylang import guppy
 from guppylang.std.angles import angle, pi
 from guppylang.std.array import array
 from guppylang.std.lang import owned
+from guppylang.std.mem import with_owned
 from guppylang.std.option import Option
 
 
@@ -34,7 +34,7 @@ class qubit:
 
     @guppy
     @no_type_check
-    def project_z(self: "qubit") -> bool:
+    def project_z(self: "qubit") -> "Measurement":
         return project_z(self)
 
     @guppy
@@ -371,10 +371,20 @@ def toffoli(control1: qubit, control2: qubit, target: qubit) -> None:
     """
 
 
-@custom_function(InoutMeasureCompiler())
+@guppy
 @no_type_check
-def project_z(q: qubit) -> bool:
+def project_z(q: qubit) -> Measurement:
     """Project a single qubit into the Z-basis (a non-destructive measurement)."""
+
+    # TODO revert to using "tket.quantum.Measure" op with InOutMeasureCompiler
+    # once bool -> Measurement is available https://github.com/Quantinuum/tket2/issues/1732
+    def helper(q: qubit @ owned) -> tuple[Measurement, qubit]:
+        return measure(q), qubit()
+
+    m = with_owned(q, helper)
+    if m:
+        x(q)
+    return m
 
 
 @hugr_op(quantum_op("QFree"))

--- a/guppylang/src/guppylang/std/quantum/functional.py
+++ b/guppylang/src/guppylang/std/quantum/functional.py
@@ -12,7 +12,7 @@ from guppylang.decorator import guppy
 # mypy: disable-error-code="empty-body, misc, valid-type"
 from guppylang.std.angles import angle
 from guppylang.std.lang import owned
-from guppylang.std.quantum import qubit
+from guppylang.std.quantum import Measurement, qubit
 
 
 @guppy
@@ -173,7 +173,7 @@ def reset(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def project_z(q: qubit @ owned) -> tuple[qubit, bool]:
+def project_z(q: qubit @ owned) -> tuple[qubit, Measurement]:
     """Functional project_z command."""
     b = quantum.project_z(q)
     return q, b

--- a/guppylang/src/guppylang/std/quantum_functional.py
+++ b/guppylang/src/guppylang/std/quantum_functional.py
@@ -1,5 +1,5 @@
 # TODO remove once https://github.com/Quantinuum/guppylang/issues/1019 has been resolved
 #  for a while
 raise ImportError(
-    "`guppylang.std.quantum_functional` has been removed. Import from `guppylang.std.quantum_functional` instead."  # noqa: E501
+    "`guppylang.std.quantum_functional` has been removed. Import from `guppylang.std.quantum.functional` instead."  # noqa: E501
 )

--- a/tests/integration/test_emulator.py
+++ b/tests/integration/test_emulator.py
@@ -186,7 +186,7 @@ def test_zeros():
     def main() -> array[qubit, comptime(N)]:
         q = array(qubit(), qubit())
         for i in range(comptime(N)):
-            output("c", project_z(q[i]))
+            output("c", project_z(q[i]).read())
         return q
 
     res = _build_run(main, n_qubits=N).results[0].entries
@@ -278,7 +278,7 @@ def test_alloc_free():
         qfree(q1)
         b2 = project_z(q0)
         output("c0", b1.read())
-        output("c1", b2)
+        output("c1", b2.read())
         output("c2", measure(q0).read())
 
     res = _build_run(main, n_qubits=2, n_shots=1, seed=12).results[0].entries

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -343,7 +343,7 @@ def test_self_qubit(validate):
         result = q0.project_z()
         q0.measure()
         qubit().discard()
-        return result
+        return result.read()
 
     validate(test.compile_function())
 

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -1,7 +1,7 @@
 from guppylang.decorator import guppy
 from guppylang.std.builtins import owned
 from guppylang.std.option import Option
-from guppylang.std.quantum import qubit, measure
+from guppylang.std.quantum import qubit, measure, Measurement
 
 from guppylang.std.quantum.functional import cx, t, h, project_z
 from guppylang_internals.decorator import custom_type
@@ -30,7 +30,7 @@ def test_linear_return_order(validate):
     # See https://github.com/quantinuum/guppy/issues/35
 
     @guppy
-    def test(q: qubit @ owned) -> tuple[qubit, bool]:
+    def test(q: qubit @ owned) -> tuple[qubit, Measurement]:
         return project_z(q)
 
     validate(test.compile_function())

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -99,7 +99,7 @@ def test_measure_ops(validate):
     """Compile various measurement-related operations."""
 
     @guppy
-    def test(q1: qubit @ owned, q2: qubit @ owned) -> tuple[bool, Measurement]:
+    def test(q1: qubit @ owned, q2: qubit @ owned) -> tuple[Measurement, Measurement]:
         q1, b1 = project_z(q1)
         q1 = discard(q1)
         q2 = reset(q2)

--- a/tests/test_removed.py
+++ b/tests/test_removed.py
@@ -4,7 +4,7 @@ import pytest
 def test_removed_quantum_functional():
     with pytest.raises(
         ImportError,
-        match=r"`guppylang.std.quantum_functional` has been removed. Import from `guppylang.std.quantum_functional` instead.",  # noqa: E501
+        match=r"`guppylang.std.quantum_functional` has been removed. Import from `guppylang.std.quantum.functional` instead.",  # noqa: E501
     ):
         import guppylang.std.quantum_functional  # noqa: F401
 


### PR DESCRIPTION
Closes #1894

Includes drive-by docs fix

BREAKING CHANGE: std.quantum.project_z returns Measurement. Use .read()
to retrieve bool.