### PR TITLE
chore: Clean up generated release changelogs and gate preview creation

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -257,6 +257,7 @@ jobs:
 
       - name: Refresh release-notes preview
         uses: ./.github/actions/update-release-preview
+        if: steps.gate.outputs.proceed == 'true'
         with:
           pr-number: ${{ steps.openpr.outputs.number }}
           guppylang-version: ${{ steps.plan.outputs.guppylang }}

--- a/cliff.toml
+++ b/cliff.toml
@@ -37,7 +37,7 @@ body = """
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 * {{ commit.message | split(pat="\n") | first | upper_first }}\
- ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Quantinuum/guppylang/commit/{{ commit.id }}))\
+  ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Quantinuum/guppylang/commit/{{ commit.id }}))\
 {% endfor %}
 {% endfor %}\n
 """

--- a/cliff.toml
+++ b/cliff.toml
@@ -37,7 +37,7 @@ body = """
 ### {{ group | striptags | trim | upper_first }}
 {% for commit in commits %}
 * {{ commit.message | split(pat="\n") | first | upper_first }}\
- ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Quantinuum/guppylang/commit/{{ commit.id }}))
+ ([{{ commit.id | truncate(length=7, end="") }}](https://github.com/Quantinuum/guppylang/commit/{{ commit.id }}))\
 {% endfor %}
 {% endfor %}\n
 """


### PR DESCRIPTION
Three changes:
1. Removes superfluous line breaks from the automatic changelog
2. Inserts an additional whitespace between the commit title and the commit reference in the automatic changelog
3. Gates the creation of the preview behind the proceed flag as well. Workflows previously failed (see https://github.com/Quantinuum/guppylang/actions/runs/28158971495/job/83394420585) if the history since the last release only contained non-releasable commits (like chores)