### PR TITLE
feat: Render diagnostics when stringifying `GuppyError`

### DIFF
--- a/guppylang-internals/src/guppylang_internals/error.py
+++ b/guppylang-internals/src/guppylang_internals/error.py
@@ -16,6 +16,17 @@ class GuppyError(Exception):
 
     error: "Error | Fatal"
 
+    def __str__(self) -> str:
+        from guppylang_internals.diagnostic import DiagnosticsRenderer
+        from guppylang_internals.engine import DEF_STORE
+
+        renderer = DiagnosticsRenderer(DEF_STORE.sources)
+        renderer.render_diagnostic(self.error)
+        return (
+            "\n".join(renderer.buffer)
+            + "\n\nGuppy compilation failed due to 1 previous error\n"
+        )
+
 
 class GuppyTypeError(GuppyError):
     """Special Guppy exception for type errors."""
@@ -87,13 +98,7 @@ def pretty_errors(f: FuncT) -> FuncT:
     ) -> None:
         """Custom `excepthook` that intercepts `GuppyExceptions` for pretty printing."""
         if isinstance(err, GuppyError):
-            from guppylang_internals.diagnostic import DiagnosticsRenderer
-            from guppylang_internals.engine import DEF_STORE
-
-            renderer = DiagnosticsRenderer(DEF_STORE.sources)
-            renderer.render_diagnostic(err.error)
-            sys.stderr.write("\n".join(renderer.buffer))
-            sys.stderr.write("\n\nGuppy compilation failed due to 1 previous error\n")
+            sys.stderr.write(str(err))
             return
 
         # If it's not a GuppyError, fall back to default hook

--- a/tests/integration/test_call.py
+++ b/tests/integration/test_call.py
@@ -15,7 +15,7 @@ def test_call(validate):
 
 def test_call_back(validate):
     @guppy
-    def foo(x: int) -> int:
+    def foo(x: float) -> int:
         return bar(x)
 
     @guppy

--- a/tests/integration/test_call.py
+++ b/tests/integration/test_call.py
@@ -15,7 +15,7 @@ def test_call(validate):
 
 def test_call_back(validate):
     @guppy
-    def foo(x: float) -> int:
+    def foo(x: int) -> int:
         return bar(x)
 
     @guppy

--- a/tests/integration/test_wasm_path_resolution.py
+++ b/tests/integration/test_wasm_path_resolution.py
@@ -96,7 +96,9 @@ def test_absolute_path_from_different_cwd(validate, monkeypatch, tmp_path):
 def test_nonexistent_relative_path_error():
     """A module using @wasm_module with a relative path that doesn't exist should
     raise WasmFileNotFound (See https://github.com/Quantinuum/guppylang/issues/1407)."""
-    with pytest.raises(GuppyError, match="WasmFileNotFound"):
+    with pytest.raises(
+        GuppyError, match=r"Error: Wasm file `no_such_file.wasm` not found"
+    ):
 
         @wasm_module("no_such_file.wasm")
         class BadWasm:
@@ -105,7 +107,9 @@ def test_nonexistent_relative_path_error():
 
 def test_nonexistent_absolute_path_error():
     """An absolute path that doesn't exist raises WasmFileNotFound."""
-    with pytest.raises(GuppyError, match="WasmFileNotFound"):
+    with pytest.raises(
+        GuppyError, match=r"Error: Wasm file `/nonexistent/path/to/file.wasm` not found"
+    ):
 
         @wasm_module("/nonexistent/path/to/file.wasm")
         class BadWasm:


### PR DESCRIPTION
Adding `__str__` to `GuppyError` means that reports in `pytest` will include into the same guppy compiler error banner. However, it may break some tests that rely on matching the error string. For example, the `wasm` tests that are fixed here. 