### PR TITLE
fix: allow 'frozen' kwarg in _DummyGuppy mock class

### DIFF
--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -1,5 +1,7 @@
 from typing import Any, TypeVar
 
+from typing_extensions import dataclass_transform
+
 
 class _DummyGuppy:
     """A dummy class with the same interface as `@guppy` that does nothing when used to
@@ -15,6 +17,7 @@ class _DummyGuppy:
     def comptime(self, f: Any) -> Any:
         return f
 
+    @dataclass_transform()
     def struct(self, cls: Any, *args: Any, **kwargs: Any) -> Any:
         return cls
 

--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -15,7 +15,7 @@ class _DummyGuppy:
     def comptime(self, f: Any) -> Any:
         return f
 
-    def struct(self, cls: Any) -> Any:
+    def struct(self, cls: Any, **kwargs: Any) -> Any:
         return cls
 
     def enum(self, cls: Any) -> Any:

--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -15,7 +15,7 @@ class _DummyGuppy:
     def comptime(self, f: Any) -> Any:
         return f
 
-    def struct(self, cls: Any, **kwargs: Any) -> Any:
+    def struct(self, cls: Any, *args: Any, **kwargs: Any) -> Any:
         return cls
 
     def enum(self, cls: Any) -> Any:

--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -1,7 +1,5 @@
 from typing import Any, TypeVar
 
-from typing_extensions import dataclass_transform
-
 
 class _DummyGuppy:
     """A dummy class with the same interface as `@guppy` that does nothing when used to
@@ -17,9 +15,8 @@ class _DummyGuppy:
     def comptime(self, f: Any) -> Any:
         return f
 
-    @dataclass_transform()
-    def struct(self, cls: Any, *args: Any, **kwargs: Any) -> Any:
-        return cls
+    def struct(self, *args: Any, **kwargs: Any) -> Any:
+        return self
 
     def enum(self, cls: Any) -> Any:
         return cls


### PR DESCRIPTION
This is a fix to the `_DummyGuppy` class which mocks the guppy decorator to be more compatible with Sphinx. ~Still need to test if this works by pinning to a commit (hence draft)~.

Now tested with [4561d49](https://github.com/Quantinuum/guppylang/pull/1946/commits/4561d49698309ed044a9ffd830c2a24b97401910) and it has resolved all of the docs issues! I think I just had to bring the signature/return type of the mock method into alignment with `@guppy.struct`.