### PR TITLE
feat!: Add function item type

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -95,7 +95,7 @@ from guppylang_internals.definition.common import Definition
 from guppylang_internals.definition.parameter import ParamDef
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import CallableDef, ValueDef
-from guppylang_internals.engine import ENGINE
+from guppylang_internals.engine import DEF_STORE, ENGINE
 from guppylang_internals.error import (
     GuppyComptimeError,
     GuppyError,
@@ -165,6 +165,7 @@ from guppylang_internals.tys.ty import (
     EnumType,
     ExistentialTypeVar,
     FuncInput,
+    FunctionItemType,
     FunctionType,
     InputFlags,
     NoneType,
@@ -333,6 +334,9 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         if len(node.keywords) > 0:
             raise GuppyError(UnsupportedError(node.keywords[0], "Keyword arguments"))
         node.func, func_ty = self._synthesize(node.func, allow_free_vars=False)
+
+        if isinstance(func_ty, FunctionItemType):
+            node.func = function_item_to_global_name(node.func, func_ty)
 
         # First handle direct calls of user-defined functions and extension functions
         if isinstance(node.func, GlobalName):
@@ -544,6 +548,9 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
 
         """Checks a global definition in an expression position."""
         match defn:
+            case CallableDef() as defn:
+                ty = FunctionItemType(defn.id)
+                return with_loc(node, GlobalName(id=name, def_id=defn.id)), ty
             case ValueDef() as defn:
                 return with_loc(node, GlobalName(id=name, def_id=defn.id)), defn.ty
             # We need a special case for enums since they don't have a `__new__` method,
@@ -868,6 +875,8 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
     def visit_Subscript(self, node: ast.Subscript) -> tuple[ast.expr, Type]:
         node.value, ty = self.synthesize(node.value)
         # Special case for subscripts on functions: Those are type applications
+        if isinstance(ty, FunctionItemType):
+            ty = ty.sig
         if isinstance(ty, FunctionType):
             inst = check_type_apply(ty, node, self.ctx)
             return instantiate_poly(node.value, ty, inst), ty.instantiate(inst)
@@ -936,6 +945,9 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         if len(node.keywords) > 0:
             raise GuppyError(UnsupportedError(node.keywords[0], "Keyword arguments"))
         node.func, ty = self.synthesize(node.func)
+
+        if isinstance(ty, FunctionItemType):
+            node.func = function_item_to_global_name(node.func, ty)
 
         # First handle direct calls of user-defined functions and extension functions
         if isinstance(node.func, GlobalName):
@@ -1093,17 +1105,24 @@ def check_type_against(
     assert not isinstance(exp, FunctionType) or not exp.parametrized
     assert not act.unsolved_vars
 
+    # If the actual type is a function item, we coerce it early to allow for generic to
+    # be inferred below
+    if isinstance(act, FunctionItemType) and isinstance(exp, FunctionType):
+        node = function_item_to_global_name(node, act)
+        act = act.sig
+
     # The actual type may be parametrised. In that case, we have to find an
     # instantiation to avoid higher-rank types.
     subst: Subst | None
-    if isinstance(act, FunctionType) and act.parametrized:
+    if isinstance(act, FunctionType | FunctionItemType) and act.parametrized:
+        act_sig = act if isinstance(act, FunctionType) else act.sig
         unquantified, free_vars = act.unquantified()
         subst = unify(exp, unquantified, {})
         if subst is None:
             raise GuppyTypeError(TypeMismatchError(node, exp, act, kind))
         # Check that we have found a valid instantiation for all params
         for i, v in enumerate(free_vars):
-            param = act.params[i].name
+            param = act_sig.params[i].name
             if v not in subst:
                 err = TypeMismatchError(node, exp, act, kind)
                 err.add_sub_diagnostic(TypeMismatchError.CantInferParam(None, param))
@@ -1119,10 +1138,11 @@ def check_type_against(
 
         # Finally, check that the instantiation respects the linearity requirements and
         # if the unitary flags match
-        check_inst(act, inst, node)
+        check_inst(act_sig, inst, node)
         exp = exp.substitute(subst)
+        exp = exp.sig if isinstance(exp, FunctionItemType) else exp
         assert isinstance(exp, FunctionType)
-        check_unitary_flags(exp, act, node)
+        check_unitary_flags(exp, act_sig, node)
 
         return node, subst, inst
 
@@ -1151,7 +1171,15 @@ def try_coerce_to(
 
     Returns the coerced expression or `None` if the type cannot be implicitly coerced.
     """
-    # Currently, we only support implicit coercions of numeric types
+    # Function items coerce into opaque function types
+    if (
+        isinstance(act, FunctionItemType)
+        and isinstance(exp, FunctionType)
+        and act.sig == exp
+    ):
+        return function_item_to_global_name(node, act)
+
+    # We also support implicit coercions of numeric types
     if not isinstance(act, NumericType) or not isinstance(exp, NumericType):
         return None
     # Ordering on `NumericType.Kind` defines the coercion relation
@@ -1164,6 +1192,17 @@ def try_coerce_to(
         assert len(subst) == 0, "Coercion methods are not generic"
         return node
     return None
+
+
+def function_item_to_global_name(expr: AstNode, ty: FunctionItemType) -> GlobalName:
+    """Turns an expressions with a `FunctionItemType` into the corresponding
+    `GlobalName`.
+
+    This is allowed since the function item already uniquely identifies the function
+    value, so there is no need to keep the expression that evaluates to this value.
+    """
+    name = DEF_STORE.raw_defs[ty.def_id].name
+    return with_type(ty.sig, with_loc(expr, GlobalName(id=name, def_id=ty.def_id)))
 
 
 def check_unitary_flags(exp: FunctionType, act: FunctionType, node: AstNode) -> None:

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -165,7 +165,7 @@ from guppylang_internals.tys.ty import (
     EnumType,
     ExistentialTypeVar,
     FuncInput,
-    FunctionItemType,
+    FunctionDefType,
     FunctionType,
     InputFlags,
     NoneType,
@@ -335,8 +335,8 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             raise GuppyError(UnsupportedError(node.keywords[0], "Keyword arguments"))
         node.func, func_ty = self._synthesize(node.func, allow_free_vars=False)
 
-        if isinstance(func_ty, FunctionItemType):
-            node.func = function_item_to_global_name(node.func, func_ty)
+        if isinstance(func_ty, FunctionDefType):
+            node.func = function_def_value_to_global_name(node.func, func_ty)
 
         # First handle direct calls of user-defined functions and extension functions
         if isinstance(node.func, GlobalName):
@@ -549,7 +549,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         """Checks a global definition in an expression position."""
         match defn:
             case CallableDef() as defn:
-                ty = FunctionItemType(defn.id)
+                ty = FunctionDefType(defn.id)
                 return with_loc(node, GlobalName(id=name, def_id=defn.id)), ty
             case ValueDef() as defn:
                 return with_loc(node, GlobalName(id=name, def_id=defn.id)), defn.ty
@@ -875,7 +875,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
     def visit_Subscript(self, node: ast.Subscript) -> tuple[ast.expr, Type]:
         node.value, ty = self.synthesize(node.value)
         # Special case for subscripts on functions: Those are type applications
-        if isinstance(ty, FunctionItemType):
+        if isinstance(ty, FunctionDefType):
             ty = ty.sig
         if isinstance(ty, FunctionType):
             inst = check_type_apply(ty, node, self.ctx)
@@ -946,8 +946,8 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             raise GuppyError(UnsupportedError(node.keywords[0], "Keyword arguments"))
         node.func, ty = self.synthesize(node.func)
 
-        if isinstance(ty, FunctionItemType):
-            node.func = function_item_to_global_name(node.func, ty)
+        if isinstance(ty, FunctionDefType):
+            node.func = function_def_value_to_global_name(node.func, ty)
 
         # First handle direct calls of user-defined functions and extension functions
         if isinstance(node.func, GlobalName):
@@ -1107,14 +1107,14 @@ def check_type_against(
 
     # If the actual type is a function item, we coerce it early to allow for generic to
     # be inferred below
-    if isinstance(act, FunctionItemType) and isinstance(exp, FunctionType):
-        node = function_item_to_global_name(node, act)
+    if isinstance(act, FunctionDefType) and isinstance(exp, FunctionType):
+        node = function_def_value_to_global_name(node, act)
         act = act.sig
 
     # The actual type may be parametrised. In that case, we have to find an
     # instantiation to avoid higher-rank types.
     subst: Subst | None
-    if isinstance(act, FunctionType | FunctionItemType) and act.parametrized:
+    if isinstance(act, FunctionType | FunctionDefType) and act.parametrized:
         act_sig = act if isinstance(act, FunctionType) else act.sig
         unquantified, free_vars = act.unquantified()
         subst = unify(exp, unquantified, {})
@@ -1140,7 +1140,7 @@ def check_type_against(
         # if the unitary flags match
         check_inst(act_sig, inst, node)
         exp = exp.substitute(subst)
-        exp = exp.sig if isinstance(exp, FunctionItemType) else exp
+        exp = exp.sig if isinstance(exp, FunctionDefType) else exp
         assert isinstance(exp, FunctionType)
         check_unitary_flags(exp, act_sig, node)
 
@@ -1173,11 +1173,11 @@ def try_coerce_to(
     """
     # Function items coerce into opaque function types
     if (
-        isinstance(act, FunctionItemType)
+        isinstance(act, FunctionDefType)
         and isinstance(exp, FunctionType)
         and act.sig == exp
     ):
-        return function_item_to_global_name(node, act)
+        return function_def_value_to_global_name(node, act)
 
     # We also support implicit coercions of numeric types
     if not isinstance(act, NumericType) or not isinstance(exp, NumericType):
@@ -1194,8 +1194,8 @@ def try_coerce_to(
     return None
 
 
-def function_item_to_global_name(expr: AstNode, ty: FunctionItemType) -> GlobalName:
-    """Turns an expressions with a `FunctionItemType` into the corresponding
+def function_def_value_to_global_name(expr: AstNode, ty: FunctionDefType) -> GlobalName:
+    """Turns an expressions with a `FunctionDefType` into the corresponding
     `GlobalName`.
 
     This is allowed since the function item already uniquely identifies the function

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -85,7 +85,7 @@ from guppylang_internals.tys.const import BoundConstVar, Const, ConstValue
 from guppylang_internals.tys.subst import Inst
 from guppylang_internals.tys.ty import (
     FuncInput,
-    FunctionItemType,
+    FunctionDefType,
     FunctionType,
     InputFlags,
     NoneType,
@@ -260,7 +260,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             )
             raise GuppyError(err)
 
-        if isinstance(get_type(node), FunctionItemType):
+        if isinstance(get_type(node), FunctionDefType):
             # Function items don't need an actual runtime representation so we just
             # lower them to a unit value (see `FunctionItemType.to_hugr`)
             return self.builder.add_op(ops.MakeTuple())
@@ -407,7 +407,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             self._update_inout_ports(consumed_args, inout_returns, func_ty)
             return regular_returns, other_args
 
-        elif isinstance(func_ty, FunctionItemType):
+        elif isinstance(func_ty, FunctionDefType):
             input_len = len(func_ty.sig.inputs)
             consumed_args, other_args = args[0:input_len], args[input_len:]
             node = GlobalCall(def_id=func_ty.def_id, args=consumed_args, type_args=())
@@ -469,7 +469,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         # For now, we can only TypeApply global FunctionDefs/Decls.
         if not isinstance(node.value, GlobalName):
             raise InternalGuppyError("Dynamic TypeApply not supported yet!")
-        if isinstance(get_type(node), FunctionItemType):
+        if isinstance(get_type(node), FunctionDefType):
             # Function items don't need an actual runtime representation so we just
             # lower them to a unit value (see `FunctionItemType.to_hugr`)
             return self.builder.add_op(ops.MakeTuple())

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -85,6 +85,7 @@ from guppylang_internals.tys.const import BoundConstVar, Const, ConstValue
 from guppylang_internals.tys.subst import Inst
 from guppylang_internals.tys.ty import (
     FuncInput,
+    FunctionItemType,
     FunctionType,
     InputFlags,
     NoneType,
@@ -259,6 +260,10 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             )
             raise GuppyError(err)
 
+        if isinstance(get_type(node), FunctionItemType):
+            # Function items don't need an actual runtime representation so we just
+            # lower them to a unit value (see `FunctionItemType.to_hugr`)
+            return self.builder.add_op(ops.MakeTuple())
         defn = self.ctx.build_compiled_def(node.def_id, type_args=())
         assert isinstance(defn, CompiledValueDef)
         return defn.load(self.dfg, self.ctx, node)
@@ -401,6 +406,15 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             inout_returns = call[num_returns:]
             self._update_inout_ports(consumed_args, inout_returns, func_ty)
             return regular_returns, other_args
+
+        elif isinstance(func_ty, FunctionItemType):
+            input_len = len(func_ty.sig.inputs)
+            consumed_args, other_args = args[0:input_len], args[input_len:]
+            node = GlobalCall(def_id=func_ty.def_id, args=consumed_args, type_args=())
+            out = self.visit_GlobalCall(node)
+            returns = unpack_wire(out, func_ty.sig.output, self.builder, self.ctx, node)
+            return returns, other_args
+
         else:
             raise InternalGuppyError("Tensor element wasn't function or tuple")
 
@@ -455,6 +469,10 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         # For now, we can only TypeApply global FunctionDefs/Decls.
         if not isinstance(node.value, GlobalName):
             raise InternalGuppyError("Dynamic TypeApply not supported yet!")
+        if isinstance(get_type(node), FunctionItemType):
+            # Function items don't need an actual runtime representation so we just
+            # lower them to a unit value (see `FunctionItemType.to_hugr`)
+            return self.builder.add_op(ops.MakeTuple())
         defn = self.ctx.build_compiled_def(node.value.def_id, node.inst)
         assert isinstance(defn, CompiledCallableDef)
         return defn.load(self.dfg, self.ctx, node)

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -55,6 +55,7 @@ from guppylang_internals.tys.builtin import (
     daggerable_type_def,
     float_type_def,
     frozenarray_type_def,
+    function_item_type_def,
     function_type_def,
     int_type_def,
     list_type_def,
@@ -75,6 +76,7 @@ from guppylang_internals.tys.ty import (
     BoundTypeVar,
     EnumType,
     ExistentialTypeVar,
+    FunctionItemType,
     FunctionType,
     NoneType,
     NumericType,
@@ -86,6 +88,7 @@ from guppylang_internals.tys.ty import (
 
 BUILTIN_DEFS_LIST: list[RawDef] = [
     function_type_def,
+    function_item_type_def,
     unitary_type_def,
     daggerable_type_def,
     controllable_type_def,
@@ -350,6 +353,8 @@ class CompilationEngine:
                         return assert_never(kind)
             case FunctionType():
                 type_defn = function_type_def
+            case FunctionItemType():
+                type_defn = function_item_type_def
             case OpaqueType() as ty:
                 type_defn = ty.defn
             case StructType() as ty:

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -55,7 +55,7 @@ from guppylang_internals.tys.builtin import (
     daggerable_type_def,
     float_type_def,
     frozenarray_type_def,
-    function_item_type_def,
+    function_def_type_def,
     function_type_def,
     int_type_def,
     list_type_def,
@@ -76,7 +76,7 @@ from guppylang_internals.tys.ty import (
     BoundTypeVar,
     EnumType,
     ExistentialTypeVar,
-    FunctionItemType,
+    FunctionDefType,
     FunctionType,
     NoneType,
     NumericType,
@@ -88,7 +88,7 @@ from guppylang_internals.tys.ty import (
 
 BUILTIN_DEFS_LIST: list[RawDef] = [
     function_type_def,
-    function_item_type_def,
+    function_def_type_def,
     unitary_type_def,
     daggerable_type_def,
     controllable_type_def,
@@ -353,8 +353,8 @@ class CompilationEngine:
                         return assert_never(kind)
             case FunctionType():
                 type_defn = function_type_def
-            case FunctionItemType():
-                type_defn = function_item_type_def
+            case FunctionDefType():
+                type_defn = function_def_type_def
             case OpaqueType() as ty:
                 type_defn = ty.defn
             case StructType() as ty:

--- a/guppylang-internals/src/guppylang_internals/tys/builtin.py
+++ b/guppylang-internals/src/guppylang_internals/tys/builtin.py
@@ -27,7 +27,7 @@ from guppylang_internals.tys.protocol import ProtocolInst
 from guppylang_internals.tys.subst import Substituter
 from guppylang_internals.tys.ty import (
     BoundTypeVar,
-    FunctionItemType,
+    FunctionDefType,
     FunctionType,
     NoneType,
     NumericType,
@@ -238,7 +238,7 @@ class CallableProtocolInst(ProtocolInst):
             ConcreteImplProof,
         )
 
-        if isinstance(ty, FunctionType | FunctionItemType):
+        if isinstance(ty, FunctionType | FunctionDefType):
             assert not ty.parametrized
             sig = ty if isinstance(ty, FunctionType) else ty.sig
             subst = unify(self.sig, sig, {})
@@ -305,7 +305,7 @@ def _option_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
 
 
 function_type_def = FunctionTypeDef(DefId.fresh(), None, None)
-function_item_type_def = FunctionTypeDef(DefId.fresh(), None, None)
+function_def_type_def = FunctionTypeDef(DefId.fresh(), None, None)
 unitary_type_def = FunctionTypeDef(
     DefId.fresh(),
     None,

--- a/guppylang-internals/src/guppylang_internals/tys/builtin.py
+++ b/guppylang-internals/src/guppylang_internals/tys/builtin.py
@@ -27,6 +27,7 @@ from guppylang_internals.tys.protocol import ProtocolInst
 from guppylang_internals.tys.subst import Substituter
 from guppylang_internals.tys.ty import (
     BoundTypeVar,
+    FunctionItemType,
     FunctionType,
     NoneType,
     NumericType,
@@ -237,9 +238,10 @@ class CallableProtocolInst(ProtocolInst):
             ConcreteImplProof,
         )
 
-        if isinstance(ty, FunctionType):
+        if isinstance(ty, FunctionType | FunctionItemType):
             assert not ty.parametrized
-            subst = unify(self.sig, ty, {})
+            sig = ty if isinstance(ty, FunctionType) else ty.sig
+            subst = unify(self.sig, sig, {})
             if subst is not None:
                 return ConcreteImplProof(
                     self.transform(Substituter(subst)), ty, {}
@@ -303,6 +305,7 @@ def _option_to_hugr(args: Sequence[Argument], ctx: ToHugrContext) -> ht.Type:
 
 
 function_type_def = FunctionTypeDef(DefId.fresh(), None, None)
+function_item_type_def = FunctionTypeDef(DefId.fresh(), None, None)
 unitary_type_def = FunctionTypeDef(
     DefId.fresh(),
     None,

--- a/guppylang-internals/src/guppylang_internals/tys/printing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/printing.py
@@ -6,6 +6,7 @@ from guppylang_internals.tys.const import Const, ConstValue
 from guppylang_internals.tys.param import ConstParam, TypeParam
 from guppylang_internals.tys.ty import (
     EnumType,
+    FunctionItemType,
     FunctionType,
     InputFlags,
     NoneType,
@@ -106,6 +107,13 @@ class TypePrinter:
             del self.bound_names[: -len(ty.params)]
             return _wrap(f"forall {quantified}. {inputs} -> {output}", inside_row)
         return _wrap(f"{inputs} -> {output}", inside_row)
+
+    @_visit.register
+    def _visit_FunctionItemType(self, ty: FunctionItemType, inside_row: bool) -> str:
+        from guppylang_internals.engine import ENGINE
+
+        defn = ENGINE.get_parsed(ty.def_id)
+        return _wrap(signature_to_str(defn.name, ty.sig), inside_row)
 
     @_visit.register(OpaqueType)
     @_visit.register(StructType)

--- a/guppylang-internals/src/guppylang_internals/tys/printing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/printing.py
@@ -6,7 +6,7 @@ from guppylang_internals.tys.const import Const, ConstValue
 from guppylang_internals.tys.param import ConstParam, TypeParam
 from guppylang_internals.tys.ty import (
     EnumType,
-    FunctionItemType,
+    FunctionDefType,
     FunctionType,
     InputFlags,
     NoneType,
@@ -109,7 +109,7 @@ class TypePrinter:
         return _wrap(f"{inputs} -> {output}", inside_row)
 
     @_visit.register
-    def _visit_FunctionItemType(self, ty: FunctionItemType, inside_row: bool) -> str:
+    def _visit_FunctionItemType(self, ty: FunctionDefType, inside_row: bool) -> str:
         from guppylang_internals.engine import ENGINE
 
         defn = ENGINE.get_parsed(ty.def_id)

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -673,13 +673,16 @@ class FunctionType(ParametrizedTypeBase):
 
 
 @dataclass(frozen=True)
-class FunctionItemType(TypeBase):
+class FunctionDefType(TypeBase):
     """The type of function values associated with a concrete definition.
 
-    Unlike the `Function` type, which denotes an opaque function value, function items
-    are unique to one definition. For example, two functions `foo` and `bar` with the
-    same signature will still have two different item types. However, function items
-    can be implicitly coerced into opaque `Function` values.
+    Unlike the `Function` type, which denotes an opaque function value, function def
+    types are unique to one definition. For example, two functions `foo` and `bar` with
+    the same signature will still have two different item types. However, function def
+    types can be implicitly coerced into opaque `Function` values.
+
+    The equivalent concept in Rust are "function item types":
+    https://doc.rust-lang.org/reference/types/function-item.html
 
     Finally, users are not able to write out the type of a function item, they can only
     be produced by the compiler. In error messages, they are printed out in the
@@ -694,7 +697,7 @@ class FunctionItemType(TypeBase):
 
     @property
     def defn(self) -> "CallableDef":
-        """The definition object associated with this function item."""
+        """The definition object associated with this function def type."""
         from guppylang_internals.definition.value import CallableDef
         from guppylang_internals.engine import ENGINE
 
@@ -704,7 +707,7 @@ class FunctionItemType(TypeBase):
 
     @property
     def sig(self) -> FunctionType:
-        """The signature of this function."""
+        """The signature of this function def type."""
         generic_sig = self.defn.ty
         return generic_sig.instantiate(self.args) if self.args else generic_sig
 
@@ -731,14 +734,14 @@ class FunctionItemType(TypeBase):
 
     def transform(self, transformer: Transformer) -> "Type":
         """Accepts a transformer on this type."""
-        return transformer.transform(self) or FunctionItemType(
+        return transformer.transform(self) or FunctionDefType(
             self.def_id, tuple(arg.transform(transformer) for arg in self.args)
         )
 
-    def unquantified(self) -> tuple["FunctionItemType", Sequence[ExistentialVar]]:
+    def unquantified(self) -> tuple["FunctionDefType", Sequence[ExistentialVar]]:
         """Instantiates all parameters with existential variables.
 
-        The returned type is still a `FunctionItemType`, so we remember which definition
+        The returned type is still a `FunctionDefType`, so we remember which definition
         this instantiation came from.
         """
         from guppylang_internals.tys.subst import Instantiator
@@ -751,7 +754,7 @@ class FunctionItemType(TypeBase):
             exes.append(ex.transform(inst))
             args.append(arg.transform(inst))
 
-        return FunctionItemType(self.def_id, tuple(args)), exes
+        return FunctionDefType(self.def_id, tuple(args)), exes
 
 
 @dataclass(frozen=True, init=False)
@@ -965,7 +968,7 @@ Type: TypeAlias = (
     | ExistentialTypeVar
     | NumericType
     | NoneType
-    | FunctionItemType
+    | FunctionDefType
     | ParametrizedType
 )
 
@@ -1139,7 +1142,7 @@ def parse_function_tensor(ty: TupleType) -> list[FunctionType] | None:
     for el in ty.element_types:
         if isinstance(el, FunctionType):
             result.append(el)
-        elif isinstance(el, FunctionItemType):
+        elif isinstance(el, FunctionDefType):
             result.append(el.sig)
         elif isinstance(el, TupleType):
             funcs = parse_function_tensor(el)

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -10,6 +10,7 @@ import hugr.std.int
 from hugr import tys as ht
 from typing_extensions import assert_never
 
+from guppylang_internals.definition.common import DefId
 from guppylang_internals.error import GuppyError, InternalGuppyError
 from guppylang_internals.span import DUMMY_SPAN
 from guppylang_internals.tys.arg import Argument, ConstArg, TypeArg
@@ -30,6 +31,7 @@ if TYPE_CHECKING:
     from guppylang_internals.definition.struct import CheckedStructDef
     from guppylang_internals.definition.ty import OpaqueTypeDef
     from guppylang_internals.definition.util import CheckedField
+    from guppylang_internals.definition.value import CallableDef
     from guppylang_internals.tys.subst import Inst, PartialInst, Subst
 
 
@@ -670,6 +672,88 @@ class FunctionType(ParametrizedTypeBase):
         )
 
 
+@dataclass(frozen=True)
+class FunctionItemType(TypeBase):
+    """The type of function values associated with a concrete definition.
+
+    Unlike the `Function` type, which denotes an opaque function value, function items
+    are unique to one definition. For example, two functions `foo` and `bar` with the
+    same signature will still have two different item types. However, function items
+    can be implicitly coerced into opaque `Function` values.
+
+    Finally, users are not able to write out the type of a function item, they can only
+    be produced by the compiler. In error messages, they are printed out in the
+    following style: `def name(arg: ty) -> return`
+    """
+
+    def_id: DefId
+    args: "Inst" = ()
+
+    copyable: bool = field(default=True, init=True)
+    droppable: bool = field(default=True, init=True)
+
+    @property
+    def defn(self) -> "CallableDef":
+        """The definition object associated with this function item."""
+        from guppylang_internals.definition.value import CallableDef
+        from guppylang_internals.engine import ENGINE
+
+        defn = ENGINE.get_parsed(self.def_id)
+        assert isinstance(defn, CallableDef)
+        return defn
+
+    @property
+    def sig(self) -> FunctionType:
+        """The signature of this function."""
+        generic_sig = self.defn.ty
+        return generic_sig.instantiate(self.args) if self.args else generic_sig
+
+    @property
+    def parametrized(self) -> bool:
+        """Whether the function is parametrized."""
+        return self.sig.parametrized and not self.args
+
+    def cast(self) -> "Type":
+        """Casts an implementor of `TypeBase` into a `Type`."""
+        return self
+
+    def to_hugr(self, ctx: ToHugrContext) -> ht.Type:
+        """Computes the Hugr representation of the type."""
+        # We can compile function items into trivial Hugr types since all required
+        # information is available statically
+        return ht.Unit
+
+    def visit(self, visitor: Visitor) -> None:
+        """Accepts a visitor on this type."""
+        if not visitor.visit(self):
+            for arg in self.args:
+                visitor.visit(arg)
+
+    def transform(self, transformer: Transformer) -> "Type":
+        """Accepts a transformer on this type."""
+        return transformer.transform(self) or FunctionItemType(
+            self.def_id, tuple(arg.transform(transformer) for arg in self.args)
+        )
+
+    def unquantified(self) -> tuple["FunctionItemType", Sequence[ExistentialVar]]:
+        """Instantiates all parameters with existential variables.
+
+        The returned type is still a `FunctionItemType`, so we remember which definition
+        this instantiation came from.
+        """
+        from guppylang_internals.tys.subst import Instantiator
+
+        args: list[Argument] = []
+        exes = []
+        for param in self.defn.ty.params:
+            arg, ex = param.to_existential()
+            inst = Instantiator(args)
+            exes.append(ex.transform(inst))
+            args.append(arg.transform(inst))
+
+        return FunctionItemType(self.def_id, tuple(args)), exes
+
+
 @dataclass(frozen=True, init=False)
 class TupleType(ParametrizedTypeBase):
     """Type of tuples."""
@@ -877,7 +961,12 @@ ParametrizedType: TypeAlias = (
 #:   * https://peps.python.org/pep-0622/#sealed-classes-as-algebraic-data-types
 #:   * https://github.com/johnthagen/sealed-typing-pep
 Type: TypeAlias = (
-    BoundTypeVar | ExistentialTypeVar | NumericType | NoneType | ParametrizedType
+    BoundTypeVar
+    | ExistentialTypeVar
+    | NumericType
+    | NoneType
+    | FunctionItemType
+    | ParametrizedType
 )
 
 #: An immutable row of Guppy types.
@@ -1050,6 +1139,8 @@ def parse_function_tensor(ty: TupleType) -> list[FunctionType] | None:
     for el in ty.element_types:
         if isinstance(el, FunctionType):
             result.append(el)
+        elif isinstance(el, FunctionItemType):
+            result.append(el.sig)
         elif isinstance(el, TupleType):
             funcs = parse_function_tensor(el)
             if funcs:

--- a/tests/error/misc_errors/not_higher_order.err
+++ b/tests/error/misc_errors/not_higher_order.err
@@ -1,8 +1,8 @@
-Error: Not higher-order (at $FILE:6:8)
+Error: Not higher-order (at $FILE:7:28)
   | 
-4 | @compile_guppy
-5 | def foo() -> None:
-6 |     f = len
-  |         ^^^ Function `len` may not be used as a higher-order value
+5 | @compile_guppy
+6 | def foo() -> None:
+7 |     f: Function[[], None] = len
+  |                             ^^^ Function `len` may not be used as a higher-order value
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/not_higher_order.py
+++ b/tests/error/misc_errors/not_higher_order.py
@@ -1,6 +1,7 @@
+from guppylang.std.lang import Function
 from tests.util import compile_guppy
 
 
 @compile_guppy
 def foo() -> None:
-    f = len
+    f: Function[[], None] = len

--- a/tests/error/overload_errors/higher_order.err
+++ b/tests/error/overload_errors/higher_order.err
@@ -1,9 +1,9 @@
-Error: Higher-order overloaded function (at $FILE:18:8)
+Error: Higher-order overloaded function (at $FILE:19:28)
    | 
-16 | @guppy
-17 | def main() -> None:
-18 |     f = overloaded
-   |         ^^^^^^^^^^ Overloaded function `overloaded` may not be used as a
-   |                    higher-order value
+17 | @guppy
+18 | def main() -> None:
+19 |     f: Function[[], None] = overloaded
+   |                             ^^^^^^^^^^ Overloaded function `overloaded` may not be used as a
+   |                                        higher-order value
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/overload_errors/higher_order.py
+++ b/tests/error/overload_errors/higher_order.py
@@ -1,4 +1,5 @@
 from guppylang import guppy
+from guppylang.std.builtins import Function
 
 
 @guppy
@@ -15,7 +16,7 @@ def overloaded(): ...
 
 @guppy
 def main() -> None:
-    f = overloaded
+    f: Function[[], None] = overloaded
 
 
 main.compile()

--- a/tests/error/poly_errors/pass_poly_free_callable.err
+++ b/tests/error/poly_errors/pass_poly_free_callable.err
@@ -3,8 +3,8 @@ Error: Type mismatch (at $FILE:20:8)
 18 | @guppy
 19 | def main() -> None:
 20 |     foo(bar)
-   |         ^^^ Expected expression of type `?Callable[[T], T]`, got `forall
-   |             T. T -> T`
+   |         ^^^ Expected expression of type `?Callable[[T], T]`, got `def
+   |             bar(x: T) -> T`
 
 Note: Couldn't infer an instantiation for type variable `?T` (higher-rank
 polymorphic types are not supported)

--- a/tests/error/type_errors/fun_item_ty_mismatch.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch.err
@@ -1,0 +1,17 @@
+Error: Different types (at $FILE:18:11)
+   | 
+16 |     else:
+17 |         baz = bar
+18 |     return baz()
+   |            ^^^ Variable `baz` may refer to different types
+
+Notes:
+   | 
+14 |     if b:
+15 |         baz = foo
+   |         --- This is of type `def foo() -> int`
+16 |     else:
+17 |         baz = bar
+   |         --- This is of type `def bar() -> int`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch.py
+++ b/tests/error/type_errors/fun_item_ty_mismatch.py
@@ -1,0 +1,21 @@
+from guppylang import guppy
+
+
+@guppy.declare
+def foo() -> int: ...
+
+
+@guppy.declare
+def bar() -> int: ...
+
+
+@guppy
+def main(b: bool) -> int:
+    if b:
+        baz = foo
+    else:
+        baz = bar
+    return baz()
+
+
+main.compile_function()

--- a/tests/integration/test_higher_order.py
+++ b/tests/integration/test_higher_order.py
@@ -57,9 +57,9 @@ def test_conditional(validate):
     @guppy
     def main(b: bool) -> int:
         if b:
-            baz = foo
+            baz: Function[[], int] = foo
         else:
-            baz = bar
+            baz: Function[[], int] = bar
         return baz()
 
     validate(main.compile_function())

--- a/tests/integration/test_side_effect_ordering.py
+++ b/tests/integration/test_side_effect_ordering.py
@@ -137,10 +137,7 @@ def test_call(validate):
     # Check that we have the expected order edges between the allocations and calls
     hugr = compiled.modules[0]
     [a1, a2] = find_ext_nodes(hugr, QUANTUM_EXTENSION.get_op("QAlloc").qualified_name())
-    [d1] = [node for node, data in hugr.nodes() if isinstance(data.op, ops.Call)]
-    [d2] = [
-        node for node, data in hugr.nodes() if isinstance(data.op, ops.CallIndirect)
-    ]
+    [d1, d2] = [node for node, data in hugr.nodes() if isinstance(data.op, ops.Call)]
     check_order(hugr, [a1, d1, a2, d2])
 
 


### PR DESCRIPTION
Closes #1934

BREAKING CHANGE: Guppy functions now have a function item type by default. It implicitly coerces into the opaque `Function` type