### PR TITLE
feat: Point users of native Python lists experimental feature to array via helptext

### DIFF
--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -59,8 +59,7 @@ class ExperimentalFeatureError(Error):
 @dataclass(frozen=True)
 class NativePythonListsSuggestion(Help):
     message: ClassVar[str] = (
-        "Native Python lists are not supported here. "
-        "Use `array` from `guppylang.std.quantum` instead."
+        "You may be looking for `array` from `guppylang.std.array` or native Python tuples."
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -56,6 +56,14 @@ class ExperimentalFeatureError(Error):
         self.add_sub_diagnostic(ExperimentalFeatureError.Suggestion(None))
 
 
+@dataclass(frozen=True)
+class NativePythonListsSuggestion(Help):
+    message: ClassVar[str] = (
+        "Native Python lists are not supported here. "
+        "Use `array` from `guppylang.std.quantum` instead."
+    )
+
+
 def check_partial_functions_enabled(node: expr | None = None) -> None:
     if not EXPERIMENTAL_FEATURES_ENABLED:
         raise GuppyError(ExperimentalFeatureError(node, "Partial functions"))
@@ -68,7 +76,9 @@ def check_function_tensors_enabled(node: expr | None = None) -> None:
 
 def check_lists_enabled(loc: AstNode | None = None) -> None:
     if not EXPERIMENTAL_FEATURES_ENABLED:
-        raise GuppyError(ExperimentalFeatureError(loc, "Lists"))
+        err = ExperimentalFeatureError(loc, "Lists")
+        err.add_sub_diagnostic(NativePythonListsSuggestion(None))
+        raise GuppyError(err)
 
 
 def check_capturing_closures_enabled(loc: AstNode | None = None) -> None:

--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -59,7 +59,8 @@ class ExperimentalFeatureError(Error):
 @dataclass(frozen=True)
 class NativePythonListsSuggestion(Help):
     message: ClassVar[str] = (
-        "You may be looking for `array` from `guppylang.std.array` or native Python tuples."
+        "You may be looking for `array` from `guppylang.std.array` or native "
+        "Python tuples."
     )
 
 

--- a/tests/error/experimental_errors/list_comprehension.err
+++ b/tests/error/experimental_errors/list_comprehension.err
@@ -9,4 +9,7 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
+Help: Native Python lists are not supported here. Use `array` from
+`guppylang.std.quantum` instead.
+
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_comprehension.err
+++ b/tests/error/experimental_errors/list_comprehension.err
@@ -9,6 +9,7 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
-Help: You may be looking for `array` from `guppylang.std.array` or native Python tuples.
+Help: You may be looking for `array` from `guppylang.std.array` or native Python
+tuples.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_comprehension.err
+++ b/tests/error/experimental_errors/list_comprehension.err
@@ -9,7 +9,6 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
-Help: Native Python lists are not supported here. Use `array` from
-`guppylang.std.quantum` instead.
+Help: You may be looking for `array` from `guppylang.std.array` or native Python tuples.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_literal.err
+++ b/tests/error/experimental_errors/list_literal.err
@@ -9,4 +9,7 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
+Help: Native Python lists are not supported here. Use `array` from
+`guppylang.std.quantum` instead.
+
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_literal.err
+++ b/tests/error/experimental_errors/list_literal.err
@@ -9,6 +9,7 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
-Help: You may be looking for `array` from `guppylang.std.array` or native Python tuples.
+Help: You may be looking for `array` from `guppylang.std.array` or native Python
+tuples.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_literal.err
+++ b/tests/error/experimental_errors/list_literal.err
@@ -9,7 +9,6 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
-Help: Native Python lists are not supported here. Use `array` from
-`guppylang.std.quantum` instead.
+Help: You may be looking for `array` from `guppylang.std.array` or native Python tuples.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_type.err
+++ b/tests/error/experimental_errors/list_type.err
@@ -9,4 +9,7 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
+Help: Native Python lists are not supported here. Use `array` from
+`guppylang.std.quantum` instead.
+
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_type.err
+++ b/tests/error/experimental_errors/list_type.err
@@ -9,6 +9,7 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
-Help: You may be looking for `array` from `guppylang.std.array` or native Python tuples.
+Help: You may be looking for `array` from `guppylang.std.array` or native Python
+tuples.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/experimental_errors/list_type.err
+++ b/tests/error/experimental_errors/list_type.err
@@ -9,7 +9,6 @@ Help: Experimental features are currently disabled. You can enable them by
 calling `guppylang.enable_experimental_features()`, however note that these
 features are unstable and might break in the future.
 
-Help: Native Python lists are not supported here. Use `array` from
-`guppylang.std.quantum` instead.
+Help: You may be looking for `array` from `guppylang.std.array` or native Python tuples.
 
 Guppy compilation failed due to 1 previous error


### PR DESCRIPTION
When I first tried using lists, it wasn't immediately clear why I couldn't or what I should use instead. This should hopefully point users in the right direction.

The text still needs work.