### PR TITLE
chore: Update to tket 0.15.1

### DIFF
--- a/guppylang-internals/pyproject.toml
+++ b/guppylang-internals/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "hugr ~= 0.18.0",
     "wasmtime>=38.0,<46.1",
     "pytket>=2.7.0",
-    "tket[pytket]~=0.15.0",
+    "tket[pytket]~=0.15.1",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ guppylang-internals = { workspace = true }
 miette-py = { workspace = true }
 # Uncomment these to test the latest dependency version during development
 # hugr = { git = "https://github.com/quantinuum/hugr", subdirectory = "hugr-py", rev = "a4da8ef" }
-# tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "fd7b7d4" }
+tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "3e37623575602b830d7d3d778719e39005350306" }
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ guppylang-internals = { workspace = true }
 miette-py = { workspace = true }
 # Uncomment these to test the latest dependency version during development
 # hugr = { git = "https://github.com/quantinuum/hugr", subdirectory = "hugr-py", rev = "a4da8ef" }
-tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "3e37623575602b830d7d3d778719e39005350306" }
+# tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "3e37623575602b830d7d3d778719e39005350306" }
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/std/test_random.py
+++ b/tests/integration/std/test_random.py
@@ -15,10 +15,7 @@ def test_pcg32_compile(validate) -> None:
         second = rng.next_int()
         return first, second
 
-    # Current tket NormalizeGuppy function inlining over-expands this HUGR and
-    # panics in portgraph; keep validating the HUGR locally, but do not export it
-    # for tket normalization in CI.
-    validate(main.compile_function(), export=False)
+    validate(main.compile_function())
 
 
 def test_pcg32_sequence_seed_1(run_int_fn) -> None:

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -345,10 +345,7 @@ def test_self_qubit(validate):
         qubit().discard()
         return result.read()
 
-    # Current tket NormalizeGuppy redundant-order-edge cleanup panics on this
-    # HUGR after inlining; keep validating locally, but do not export it for
-    # tket normalization in CI.
-    validate(test.compile_function(), export=False)
+    validate(test.compile_function())
 
 
 def test_non_terminating(validate):

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -62,10 +62,7 @@ def test_assignment_in_dagger(validate):
         discard(q)
         discard(c)
 
-    # Current tket NormalizeGuppy modifier resolution cannot rewrite this shape
-    # yet; keep validating the HUGR locally, but do not export it for tket
-    # normalization in CI.
-    validate(main.compile_function(), export=False)
+    validate(main.compile_function())
 
 
 def test_control_simple(validate):

--- a/tests/integration/test_qsystem.py
+++ b/tests/integration/test_qsystem.py
@@ -235,11 +235,8 @@ def test_qsystem_sol_functional(validate):  # type: ignore[no-untyped-def]
         collect_measurements(measure_array(qc))
         return ms
 
-    # Current tket NormalizeGuppy redundant-order-edge cleanup panics on this
-    # HUGR after inlining; keep validating locally, but do not export it for
-    # tket normalization in CI.
-    validate(test.compile_function(), export=False)
-    validate(test_arrays.compile_function(), export=False)
+    validate(test.compile_function())
+    validate(test_arrays.compile_function())
 
 
 def test_measure_leaked(validate, qsys_mod: QsysMod):  # type: ignore[no-untyped-def]

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 requires-dist = [
     { name = "hugr", specifier = "~=0.18.0" },
     { name = "pytket", specifier = ">=2.7.0" },
-    { name = "tket", extras = ["pytket"], git = "https://github.com/quantinuum/tket2?subdirectory=tket-py&rev=3e37623575602b830d7d3d778719e39005350306" },
+    { name = "tket", extras = ["pytket"], specifier = "~=0.15.1" },
     { name = "tket-exts", specifier = "~=0.14.0" },
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
     { name = "wasmtime", specifier = ">=38.0,<46.1" },
@@ -4205,12 +4205,20 @@ wheels = [
 
 [[package]]
 name = "tket"
-version = "0.15.0"
-source = { git = "https://github.com/quantinuum/tket2?subdirectory=tket-py&rev=3e37623575602b830d7d3d778719e39005350306#3e37623575602b830d7d3d778719e39005350306" }
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hugr" },
     { name = "tket-eccs" },
     { name = "tket-exts" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/45/994a5c6065101adc2f6f668ec533e3a3f6a006481c91b7dd7599c315b85f/tket-0.15.1.tar.gz", hash = "sha256:2503079357dc45d401d7caf7368ac84b203ecacd6b90769559532b377c5b47e3", size = 664801, upload-time = "2026-06-30T15:52:07.915Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/2bb0ddc463834646c4a912ee3a362626c5da32e62002fec0b200a36c70d6/tket-0.15.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:80c6725109580df5157b4d76eb723b1707f9736d53b663636bbaccec32b96735", size = 10598217, upload-time = "2026-06-30T15:51:53.969Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/b8/53481cf2e716dcf616db03fcfbebf4f6efe83ff30501c83d429e37f6110b/tket-0.15.1-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:7fb11e6f6923e80674cd358a6f55246f342d1ee107298965598890bd1cf72939", size = 11571542, upload-time = "2026-06-30T15:51:56.604Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c3/157befcbd22127b994345735f05de93ae4d1bfcaca8e5f8c454b10358662/tket-0.15.1-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2624e34ceb30f8ae041f7fd59b6d2540f09457d2c639725f35a3943cb15dbac4", size = 12729086, upload-time = "2026-06-30T15:51:59.541Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/56/7f5a6f354e735b05fecca9338edc4dc638d0816f390b53382d995c3e17ac/tket-0.15.1-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e64ed9572a79b9a063fd887a486fb309e2979d834296fc72a87bfbc256c0d44d", size = 13841358, upload-time = "2026-06-30T15:52:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/af/61/3709fad27a77022558f20624960cae2e92f40e24b114e214f210f3106e29/tket-0.15.1-cp310-abi3-win_amd64.whl", hash = "sha256:351f327389396f78a1976181bca41b6adc88b05d36330a7bbbbd990afb61eed4", size = 10535819, upload-time = "2026-06-30T15:52:05.604Z" },
 ]
 
 [package.optional-dependencies]
@@ -4221,14 +4229,22 @@ pytket = [
 [[package]]
 name = "tket-eccs"
 version = "0.6.0"
-source = { git = "https://github.com/quantinuum/tket2?subdirectory=tket-eccs&rev=3e37623575602b830d7d3d778719e39005350306#3e37623575602b830d7d3d778719e39005350306" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/34/9cbb2a29aea965ebfa020a2a4b3f01168f057f2bc917de13d8557ba3f609/tket_eccs-0.6.0.tar.gz", hash = "sha256:979d7c9319d4968d49f63f582aac1a281a0226a649ceee8c27eb993593a7da4c", size = 7587847, upload-time = "2026-06-11T13:10:12.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/f1/99cf5b308a6528b6008c3bf87dc5e6a1f4e185db09ba7836754c68ac9048/tket_eccs-0.6.0-py3-none-any.whl", hash = "sha256:fd5651fdd28315614debc76a94ab1d3adb49aa95d0299baa6f4ccf0f2f071950", size = 7589693, upload-time = "2026-06-11T13:10:09.791Z" },
+]
 
 [[package]]
 name = "tket-exts"
 version = "0.14.0"
-source = { git = "https://github.com/quantinuum/tket2?subdirectory=tket-exts&rev=3e37623575602b830d7d3d778719e39005350306#3e37623575602b830d7d3d778719e39005350306" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hugr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e8/50/61f29d112058b28cce6fd049b8ab7c1b69554c11650d95655a362205bcac/tket_exts-0.14.0.tar.gz", hash = "sha256:113a396ed32fe7301eb5801b4b615dfe6e200f0f77d4c249014879f4bd7a0a6d", size = 24573, upload-time = "2026-06-29T17:12:35.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/c1/fbbe6e1c66867bf41ac2e5332c400f5477aa9e2974bf58a9ab9c224db4d6/tket_exts-0.14.0-py3-none-any.whl", hash = "sha256:b4fc89896f5a15fa2776e4c7ef55cb820c4a458da968fa374c9de1bf00aeaa9f", size = 41515, upload-time = "2026-06-29T17:12:34.104Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1063,7 +1063,7 @@ dependencies = [
 requires-dist = [
     { name = "hugr", specifier = "~=0.18.0" },
     { name = "pytket", specifier = ">=2.7.0" },
-    { name = "tket", extras = ["pytket"], specifier = "~=0.15.0" },
+    { name = "tket", extras = ["pytket"], git = "https://github.com/quantinuum/tket2?subdirectory=tket-py&rev=3e37623575602b830d7d3d778719e39005350306" },
     { name = "tket-exts", specifier = "~=0.14.0" },
     { name = "typing-extensions", specifier = ">=4.9.0,<5" },
     { name = "wasmtime", specifier = ">=38.0,<46.1" },
@@ -4206,19 +4206,11 @@ wheels = [
 [[package]]
 name = "tket"
 version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/quantinuum/tket2?subdirectory=tket-py&rev=3e37623575602b830d7d3d778719e39005350306#3e37623575602b830d7d3d778719e39005350306" }
 dependencies = [
     { name = "hugr" },
     { name = "tket-eccs" },
     { name = "tket-exts" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/e1/0f3c468cacef6e3cb722f8c097a838aaf49f509aa130568df621933cd3e5/tket-0.15.0.tar.gz", hash = "sha256:a47fcb07ccc8a46eec35661d440f043f1fb1f9b1b0a58ef13d77c3a43c55fca4", size = 663599, upload-time = "2026-06-30T09:49:47.143Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/ba/0c63eee9292f314859e89a27aee6886f2a58afea9ba4088247446d8b74f7/tket-0.15.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:a758c9d5999c9d17b52f435fbb85e6a62cc01ec734416d401ec7d9034b9f5df4", size = 10594632, upload-time = "2026-06-30T09:49:35.108Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/21/5a1169b601466eda87d731ea97304981fe64b4bb90441a8b194f83f22fd8/tket-0.15.0-cp310-abi3-macosx_11_0_x86_64.whl", hash = "sha256:09017b6d23c134a46f6fb7c9c4853ce0f2f46f5bb9e5dac38aaf9363e003fd64", size = 11581257, upload-time = "2026-06-30T09:49:37.718Z" },
-    { url = "https://files.pythonhosted.org/packages/94/a8/56e6ba5d04a9518477ccf5ad9181c423e323ed8768720496d494e483b217/tket-0.15.0-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:c541c8b552a00999f3e3d98f454bf67cdaccea038cd31bcdc2efeb63d7efaa22", size = 12734817, upload-time = "2026-06-30T09:49:40.365Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/1d/78ccfbed728b89263f3ef30e40ffeb61aab3baa773569ad4dbb7f4415637/tket-0.15.0-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:437283b103b8f2af295349e0ab133263a52a3d616a3cb0fd3c37cee0fb95f0e0", size = 13850586, upload-time = "2026-06-30T09:49:42.709Z" },
-    { url = "https://files.pythonhosted.org/packages/15/4a/defcc74452f49357e63a1431e1fafa85274f2802e1f950f96d5ac0b4844c/tket-0.15.0-cp310-abi3-win_amd64.whl", hash = "sha256:5c7f18499024045157def94d5ae113a6091a921ceb06d5ea496f411cf27ed020", size = 10562823, upload-time = "2026-06-30T09:49:44.979Z" },
 ]
 
 [package.optional-dependencies]
@@ -4229,22 +4221,14 @@ pytket = [
 [[package]]
 name = "tket-eccs"
 version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b5/34/9cbb2a29aea965ebfa020a2a4b3f01168f057f2bc917de13d8557ba3f609/tket_eccs-0.6.0.tar.gz", hash = "sha256:979d7c9319d4968d49f63f582aac1a281a0226a649ceee8c27eb993593a7da4c", size = 7587847, upload-time = "2026-06-11T13:10:12.039Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/f1/99cf5b308a6528b6008c3bf87dc5e6a1f4e185db09ba7836754c68ac9048/tket_eccs-0.6.0-py3-none-any.whl", hash = "sha256:fd5651fdd28315614debc76a94ab1d3adb49aa95d0299baa6f4ccf0f2f071950", size = 7589693, upload-time = "2026-06-11T13:10:09.791Z" },
-]
+source = { git = "https://github.com/quantinuum/tket2?subdirectory=tket-eccs&rev=3e37623575602b830d7d3d778719e39005350306#3e37623575602b830d7d3d778719e39005350306" }
 
 [[package]]
 name = "tket-exts"
 version = "0.14.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/quantinuum/tket2?subdirectory=tket-exts&rev=3e37623575602b830d7d3d778719e39005350306#3e37623575602b830d7d3d778719e39005350306" }
 dependencies = [
     { name = "hugr" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/50/61f29d112058b28cce6fd049b8ab7c1b69554c11650d95655a362205bcac/tket_exts-0.14.0.tar.gz", hash = "sha256:113a396ed32fe7301eb5801b4b615dfe6e200f0f77d4c249014879f4bd7a0a6d", size = 24573, upload-time = "2026-06-29T17:12:35.346Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/c1/fbbe6e1c66867bf41ac2e5332c400f5477aa9e2974bf58a9ab9c224db4d6/tket_exts-0.14.0-py3-none-any.whl", hash = "sha256:b4fc89896f5a15fa2776e4c7ef55cb820c4a458da968fa374c9de1bf00aeaa9f", size = 41515, upload-time = "2026-06-29T17:12:34.104Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Requires a `tket-py 0.15.1` release.

Re-enables exports disabled in the `0.15.0` bump, now that the errors have been fixed. 