### PR TITLE
chore: Enable verbose and duration logging for benchmarks

### DIFF
--- a/.github/workflows/benchmarks_base.yml
+++ b/.github/workflows/benchmarks_base.yml
@@ -44,4 +44,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: uv run pytest tests/ --codspeed -k "not executable"
+          run: uv run pytest tests/ --codspeed -k "not executable" -v --durations=0

--- a/.github/workflows/benchmarks_pr.yml
+++ b/.github/workflows/benchmarks_pr.yml
@@ -59,4 +59,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: uv run pytest tests/ --codspeed -k "not executable"
+          run: uv run pytest tests/ --codspeed -k "not executable" -v --durations=0


### PR DESCRIPTION
The benchmarks are now sometimes taking longer than 40 minutes to complete (on the main branch, that is). This is unacceptable and to consider which benchmarks we should cut down on (because after a certain point they stop being meaningful and just waste our time), we must log which ones are slowest. This shows all execution times of the benchmarks after they have been run.