### PR TITLE
chore: Remove version section from the release PR description

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -264,9 +264,6 @@ jobs:
             {
               echo "Automated release PR."
               echo
-              echo "- \`guppylang\` → \`$VERSION\`"
-              echo "- \`guppylang-internals\` → \`$VERSION\`"
-              echo
               echo "Remove the \`$REGEN_LABEL\` label to take manual control of the changelogs."
               echo
               echo "<!-- BEGIN RELEASE NOTES PREVIEW -->"


### PR DESCRIPTION
When manually forcing the target version of a release PR https://github.com/Quantinuum/guppylang/pull/1978 (from `a9` to `rc0`) I realised the version display does not change. But since it is already in the title, I do not think we need this display at all.