### PR TITLE
chore: Run missing CI on release branches

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - "release/**"
   pull_request:
     branches:
       - "**"

--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+      - "release/**"
     types:
       - opened
       - edited


### PR DESCRIPTION
Also need to backport this I think since it is a `push` trigger.