### PR TITLE
refactor: Update codebase to python 3.12

### DIFF
--- a/guppylang-internals/src/guppylang_internals/ast_util.py
+++ b/guppylang-internals/src/guppylang_internals/ast_util.py
@@ -2,7 +2,7 @@ import ast
 import textwrap
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Generic, Optional, TypeVar, cast
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 if TYPE_CHECKING:
     from guppylang_internals.tys.ty import Type
@@ -23,10 +23,8 @@ AstNode = (
     | ast.FunctionDef
 )
 
-T = TypeVar("T", covariant=True)
 
-
-class AstVisitor(Generic[T]):
+class AstVisitor[T]:
     """
     Note: This class is based on the implementation of `ast.NodeVisitor` but
     allows extra arguments to be passed to the `visit` functions.
@@ -369,16 +367,13 @@ def get_line_offset(node: AstNode) -> int | None:
         return None
 
 
-A = TypeVar("A", bound=ast.AST)
-
-
-def with_loc(loc: ast.AST, node: A) -> A:
+def with_loc[A: ast.AST](loc: ast.AST, node: A) -> A:
     """Copy source location from one AST node to the other."""
     set_location_from(node, loc)
     return node
 
 
-def with_type(ty: "Type", node: A) -> A:
+def with_type[A: ast.AST](ty: "Type", node: A) -> A:
     """Annotates an AST node with a type."""
     node.type = ty  # type: ignore[attr-defined]
     return node

--- a/guppylang-internals/src/guppylang_internals/cfg/analysis.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/analysis.py
@@ -1,17 +1,13 @@
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from typing import Generic, TypeVar
+from collections.abc import Hashable, Iterable
 
-from guppylang_internals.cfg.bb import BB, VariableStats, VId
-
-# Type variable for the lattice domain
-T = TypeVar("T")
+from guppylang_internals.cfg.bb import BB, VariableStats
 
 # Analysis result is a mapping from basic blocks to lattice values
-Result = dict[BB, T]
+type Result[T] = dict[BB, T]
 
 
-class Analysis(ABC, Generic[T]):
+class Analysis[T](ABC):
     """Abstract base class for a program analysis pass over the lattice `T`"""
 
     def eq(self, t1: T, t2: T, /) -> bool:
@@ -39,7 +35,7 @@ class Analysis(ABC, Generic[T]):
         """
 
 
-class ForwardAnalysis(Analysis[T], ABC, Generic[T]):
+class ForwardAnalysis[T](Analysis[T], ABC):
     """Abstract base class for a program analysis pass running in forward direction."""
 
     @abstractmethod
@@ -71,7 +67,7 @@ class ForwardAnalysis(Analysis[T], ABC, Generic[T]):
         return vals_before
 
 
-class BackwardAnalysis(Analysis[T], ABC, Generic[T]):
+class BackwardAnalysis[T](Analysis[T], ABC):
     """Abstract base class for a program analysis pass running in backward direction."""
 
     @abstractmethod
@@ -102,10 +98,10 @@ class BackwardAnalysis(Analysis[T], ABC, Generic[T]):
 
 # For live variable analysis, we also store a BB in which a use occurs as evidence of
 # liveness.
-LivenessDomain = dict[VId, BB]
+type LivenessDomain[VId: Hashable] = dict[VId, BB]
 
 
-class LivenessAnalysis(BackwardAnalysis[LivenessDomain[VId]], Generic[VId]):
+class LivenessAnalysis[VId: Hashable](BackwardAnalysis[LivenessDomain[VId]]):
     """Live variable analysis pass.
 
     Computes the variables that are live before the execution of each BB. The analysis
@@ -151,17 +147,19 @@ class LivenessAnalysis(BackwardAnalysis[LivenessDomain[VId]], Generic[VId]):
 
 
 # Set of variables that are definitely assigned at the start of a BB
-DefAssignmentDomain = set[VId]
+type DefAssignmentDomain[VId: Hashable] = set[VId]
 
 # Set of variables that are assigned on (at least) some paths to a BB. Definitely
 # assigned variables are a subset of this
-MaybeAssignmentDomain = set[VId]
+type MaybeAssignmentDomain[VId: Hashable] = set[VId]
 
 # For assignment analysis, we do definite- and maybe-assignment in one pass
-AssignmentDomain = tuple[DefAssignmentDomain[VId], MaybeAssignmentDomain[VId]]
+type AssignmentDomain[VId: Hashable] = tuple[
+    DefAssignmentDomain[VId], MaybeAssignmentDomain[VId]
+]
 
 
-class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain[VId]], Generic[VId]):
+class AssignmentAnalysis[VId: Hashable](ForwardAnalysis[AssignmentDomain[VId]]):
     """Assigned variable analysis pass.
 
     Computes the set of variables (i.e. `V`s) that are definitely assigned at the start

--- a/guppylang-internals/src/guppylang_internals/cfg/bb.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/bb.py
@@ -2,7 +2,7 @@ import ast
 from abc import ABC
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, Self, TypeVar
+from typing import TYPE_CHECKING, Self
 
 from guppylang_internals.ast_util import AstNode, name_nodes_in_ast
 from guppylang_internals.nodes import (
@@ -19,13 +19,10 @@ if TYPE_CHECKING:
     from guppylang_internals.cfg.cfg import BaseCFG
 
 
-# Type variable for ids of entities which we may wish to track during program analysis
-# (generally ids for program variables or parts thereof)
-VId = TypeVar("VId", bound=Hashable)
-
-
+# VId is a type variable for ids of entities which we may wish to track during program
+# analysis (generally ids for program variables or parts thereof)
 @dataclass
-class VariableStats(Generic[VId]):
+class VariableStats[VId: Hashable]:
     """Stores variable usage information for a basic block."""
 
     # Variables that are assigned in the BB

--- a/guppylang-internals/src/guppylang_internals/cfg/bb.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/bb.py
@@ -2,9 +2,7 @@ import ast
 from abc import ABC
 from collections.abc import Hashable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Generic, TypeVar
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Generic, Self, TypeVar
 
 from guppylang_internals.ast_util import AstNode, name_nodes_in_ast
 from guppylang_internals.nodes import (

--- a/guppylang-internals/src/guppylang_internals/cfg/cfg.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/cfg.py
@@ -1,6 +1,5 @@
 from collections import deque
 from collections.abc import Iterator
-from typing import Generic, TypeVar
 
 from guppylang_internals.cfg.analysis import (
     AssignmentAnalysis,
@@ -14,10 +13,8 @@ from guppylang_internals.cfg.bb import BB, BBStatement, VariableStats
 from guppylang_internals.nodes import InoutReturnSentinel
 from guppylang_internals.tys.ty import UnitaryFlags
 
-T = TypeVar("T", bound=BB)
 
-
-class BaseCFG(Generic[T]):
+class BaseCFG[T: BB]:
     """Abstract base class for control-flow graphs."""
 
     bbs: list[T]

--- a/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
@@ -9,7 +9,7 @@ import collections
 import itertools
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar, Generic, TypeVar
+from typing import ClassVar
 
 from guppylang_internals.ast_util import line_col
 from guppylang_internals.cfg.bb import BB
@@ -19,7 +19,6 @@ from guppylang_internals.checker.core import (
     Globals,
     Locals,
     Place,
-    V,
     Variable,
 )
 from guppylang_internals.checker.expr_checker import ExprSynthesizer, to_bool
@@ -29,11 +28,11 @@ from guppylang_internals.error import GuppyError
 from guppylang_internals.tys.arg import Argument
 from guppylang_internals.tys.ty import InputFlags, Type
 
-Row = Sequence[V]
+type Row[V] = Sequence[V]
 
 
 @dataclass(frozen=True)
-class Signature(Generic[V]):
+class Signature[V]:
     """The signature of a basic block.
 
     Stores the input/output variables with their types. Generic over the representation
@@ -51,7 +50,7 @@ class Signature(Generic[V]):
 
 
 @dataclass(eq=False)  # Disable equality to recover hash from `object`
-class CheckedBB(BB, Generic[V]):
+class CheckedBB[V](BB):
     """Basic block annotated with an input and output type signature.
 
     The signature is generic over the representation of program variables.
@@ -60,7 +59,7 @@ class CheckedBB(BB, Generic[V]):
     sig: Signature[V] = field(default_factory=Signature.empty)
 
 
-class CheckedCFG(BaseCFG[CheckedBB[V]], Generic[V]):
+class CheckedCFG[V](BaseCFG[CheckedBB[V]]):
     input_tys: list[Type]
     output_ty: Type
 
@@ -427,10 +426,7 @@ def diagnose_maybe_undefined(
     return None
 
 
-T = TypeVar("T")
-
-
-def reverse_enumerate(xs: list[T]) -> Iterator[tuple[int, T]]:
+def reverse_enumerate[T](xs: list[T]) -> Iterator[tuple[int, T]]:
     """Enumerates a list in reverse order.
 
     Equivalent to `reversed(list(enumerate(data)))` without creating an intermediate

--- a/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
@@ -9,7 +9,7 @@ import collections
 import itertools
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar, Generic, TypeVar
+from typing import ClassVar
 
 from guppylang_internals.ast_util import line_col
 from guppylang_internals.cfg.bb import BB
@@ -20,7 +20,6 @@ from guppylang_internals.checker.core import (
     Globals,
     Locals,
     Place,
-    V,
     Variable,
 )
 from guppylang_internals.checker.expr_checker import (
@@ -39,11 +38,11 @@ from guppylang_internals.tys.ty import (
     Type,
 )
 
-Row = Sequence[V]
+type Row[V] = Sequence[V]
 
 
 @dataclass(frozen=True)
-class Signature(Generic[V]):
+class Signature[V]:
     """The signature of a basic block.
 
     Stores the input/output variables with their types. Generic over the representation
@@ -61,7 +60,7 @@ class Signature(Generic[V]):
 
 
 @dataclass(eq=False)  # Disable equality to recover hash from `object`
-class CheckedBB(BB, Generic[V]):
+class CheckedBB[V](BB):
     """Basic block annotated with an input and output type signature.
 
     The signature is generic over the representation of program variables.
@@ -70,7 +69,7 @@ class CheckedBB(BB, Generic[V]):
     sig: Signature[V] = field(default_factory=Signature.empty)
 
 
-class CheckedCFG(BaseCFG[CheckedBB[V]], Generic[V]):
+class CheckedCFG[V](BaseCFG[CheckedBB[V]]):
     input_tys: list[Type]
     output_ty: Type
 
@@ -498,10 +497,7 @@ def diagnose_maybe_undefined(
     return None
 
 
-T = TypeVar("T")
-
-
-def reverse_enumerate(xs: list[T]) -> Iterator[tuple[int, T]]:
+def reverse_enumerate[T](xs: list[T]) -> Iterator[tuple[int, T]]:
     """Enumerates a list in reverse order.
 
     Equivalent to `reversed(list(enumerate(data)))` without creating an intermediate

--- a/guppylang-internals/src/guppylang_internals/checker/core.py
+++ b/guppylang-internals/src/guppylang_internals/checker/core.py
@@ -1,23 +1,19 @@
 import ast
 import copy
 import itertools
-from collections.abc import Iterable, Iterator
+from collections.abc import Hashable, Iterable, Iterator
 from dataclasses import dataclass, field, replace
 from functools import cache, cached_property
 from types import FrameType
 from typing import (
     TYPE_CHECKING,
     Any,
-    Generic,
     NamedTuple,
-    TypeAlias,
-    TypeVar,
     assert_never,
     overload,
 )
 
 from guppylang_internals.ast_util import AstNode, name_nodes_in_ast
-from guppylang_internals.cfg.bb import VId
 from guppylang_internals.definition.common import (
     DefId,
     Definition,
@@ -48,12 +44,10 @@ if TYPE_CHECKING:
 #:
 #: All places are equipped with a unique id, a type and an optional definition AST
 #: location. During linearity checking, they are tracked separately.
-Place: TypeAlias = "Variable | FieldAccess | SubscriptAccess | TupleAccess"
+type Place = "Variable | FieldAccess | SubscriptAccess | TupleAccess"
 
 #: Unique identifier for a `Place`.
-PlaceId: TypeAlias = (
-    "Variable.Id | FieldAccess.Id | SubscriptAccess.Id | TupleAccess.Id"
-)
+type PlaceId = "Variable.Id | FieldAccess.Id | SubscriptAccess.Id | TupleAccess.Id"
 
 
 @dataclass(frozen=True)
@@ -385,11 +379,8 @@ class Globals:
                 return assert_never(x)
 
 
-V = TypeVar("V")
-
-
 @dataclass
-class Locals(Generic[VId, V]):
+class Locals[VId: Hashable, V]:
     """Scoped mapping from program variable ids to the corresponding program variable.
 
     Depending on which checking phase we are in (type checking or linearity checking),

--- a/guppylang-internals/src/guppylang_internals/checker/core.py
+++ b/guppylang-internals/src/guppylang_internals/checker/core.py
@@ -12,10 +12,9 @@ from typing import (
     NamedTuple,
     TypeAlias,
     TypeVar,
+    assert_never,
     overload,
 )
-
-from typing_extensions import assert_never
 
 from guppylang_internals.ast_util import AstNode, name_nodes_in_ast
 from guppylang_internals.cfg.bb import VId

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -7,7 +7,6 @@ node straight from the Python AST. We build a CFG, check it, and return a
 
 import ast
 import copy
-import sys
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, ClassVar, cast
 
@@ -31,6 +30,7 @@ from guppylang_internals.tys.parsing import (
     TypeParsingCtx,
     check_function_arg,
     parse_function_arg_annotation,
+    parse_parameter,
     type_from_ast,
     type_with_flags_from_ast,
 )
@@ -48,9 +48,6 @@ from guppylang_internals.tys.ty import (
 
 if TYPE_CHECKING:
     from guppylang_internals.definition.protocol import CheckedProtocolDef
-
-if sys.version_info >= (3, 12):
-    from guppylang_internals.tys.parsing import parse_parameter
 
 
 @dataclass(frozen=True)
@@ -326,10 +323,9 @@ def check_signature(
     # Prepopulate parameter mapping when using Python 3.12 style generic syntax
     if param_var_mapping is None:
         param_var_mapping = {}
-    if sys.version_info >= (3, 12):
-        for i, param_node in enumerate(func_def.type_params):
-            param = parse_parameter(param_node, i, globals, param_var_mapping)
-            param_var_mapping[param.name] = param
+    for i, param_node in enumerate(func_def.type_params):
+        param = parse_parameter(param_node, i, globals, param_var_mapping)
+        param_var_mapping[param.name] = param
 
     # Figure out if this is a method
     self_defn: ProtocolDef | TypeDef | None = None

--- a/guppylang-internals/src/guppylang_internals/checker/protocol_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/protocol_checker.py
@@ -1,7 +1,6 @@
 from abc import ABC
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TypeAlias
 
 from guppylang_internals.checker.errors.type_errors import (
     AmbiguousProtocol,
@@ -56,7 +55,7 @@ class AssumptionImplProof(ImplProofBase):
     ty: BoundTypeVar
 
 
-ImplProof: TypeAlias = ConcreteImplProof | AssumptionImplProof
+type ImplProof = ConcreteImplProof | AssumptionImplProof
 
 
 def _instantiate_self(

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -13,7 +13,7 @@ import functools
 from collections.abc import Iterable, Sequence
 from dataclasses import replace
 from itertools import takewhile
-from typing import TypeVar, cast
+from typing import cast
 
 from guppylang_internals.ast_util import (
     AstVisitor,
@@ -482,10 +482,7 @@ class StmtChecker(AstVisitor[BBStatement]):
         raise InternalGuppyError("Control-flow statement should not be present here.")
 
 
-T = TypeVar("T")
-
-
-def all_equal(xs: Iterable[T]) -> bool:
+def all_equal[T](xs: Iterable[T]) -> bool:
     """Checks if all elements yielded from an iterable are equal."""
     it = iter(xs)
     try:

--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -13,7 +13,7 @@ import functools
 from collections.abc import Iterable, Sequence
 from dataclasses import replace
 from itertools import takewhile
-from typing import TypeVar, cast
+from typing import cast
 
 from guppylang_internals.ast_util import (
     AstVisitor,
@@ -484,10 +484,7 @@ class StmtChecker(AstVisitor[BBStatement]):
         raise InternalGuppyError("Control-flow statement should not be present here.")
 
 
-T = TypeVar("T")
-
-
-def all_equal(xs: Iterable[T]) -> bool:
+def all_equal[T](xs: Iterable[T]) -> bool:
     """Checks if all elements yielded from an iterable are equal."""
     it = iter(xs)
     try:

--- a/guppylang-internals/src/guppylang_internals/compiler/builder.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Generic, Self, TypeVar, override
+from typing import Self, override
 
 from hugr import Node, Wire, ops, val
 from hugr import tys as ht
@@ -173,11 +173,8 @@ class DFBuilder(ABC, ToNode):
         return self._raw.add_const(value, parent)
 
 
-B = TypeVar("B", bound=hf.Function | Case | TailLoop | Block)
-
-
 @dataclass
-class _DFBuilderRaw(DFBuilder, Generic[B]):
+class _DFBuilderRaw[B: hf.Function | Case | TailLoop | Block](DFBuilder):
     _raw_builder: B
 
     @property

--- a/guppylang-internals/src/guppylang_internals/compiler/builder.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder.py
@@ -3,7 +3,7 @@ from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Generic, TypeVar
+from typing import Generic, Self, TypeVar, override
 
 from hugr import Node, Wire, ops, val
 from hugr import tys as ht
@@ -11,7 +11,6 @@ from hugr.build import Block, Case, Cfg, Conditional, TailLoop
 from hugr.build import function as hf
 from hugr.hugr.node_port import ToNode
 from hugr.metadata import HugrDebugInfo
-from typing_extensions import Self, override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.compiler.core import may_have_side_effect

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Generic, NamedTuple, TypeAlias, TypeVar
+from typing import Generic, Self, TypeVar, override
 
 from hugr import Node, Wire, val
 from hugr import tys as ht

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -3,7 +3,7 @@ from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Generic, Self, TypeVar, override
+from typing import Self, override
 
 from hugr import Node, Wire, val
 from hugr import tys as ht
@@ -12,7 +12,6 @@ from hugr.build import function as hf
 from hugr.hugr.node_port import ToNode
 from hugr.metadata import HugrDebugInfo
 from hugr.ops import DataflowOp, Output
-from typing_extensions import Self, override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.metadata.debug_info_util import (
@@ -21,7 +20,7 @@ from guppylang_internals.metadata.debug_info_util import (
 )
 from guppylang_internals.tys import Effect
 
-OpWithEffects: TypeAlias = tuple[DataflowOp, Iterable[Effect]]
+type OpWithEffects = tuple[DataflowOp, Iterable[Effect]]
 
 
 def pure(op: DataflowOp) -> OpWithEffects:
@@ -204,11 +203,8 @@ class DFBuilder(ABC, ToNode):
         return self._raw.add_const(value, parent)
 
 
-B = TypeVar("B", bound=hf.Function | Case | TailLoop | Block)
-
-
 @dataclass
-class _DFBuilderRaw(DFBuilder, Generic[B]):
+class _DFBuilderRaw[B: hf.Function | Case | TailLoop | Block](DFBuilder):
     _raw_builder: B
 
     @property

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -1,7 +1,7 @@
 import ast
 from collections.abc import Iterator, Sequence
 from contextlib import AbstractContextManager, ExitStack, contextmanager
-from typing import Any, TypeGuard, TypeVar
+from typing import Any, TypeGuard
 
 import hugr
 import hugr.std.float
@@ -801,9 +801,6 @@ def python_value_to_hugr(v: Any, exp_ty: Type, ctx: CompilerContext) -> hv.Value
     return None
 
 
-T = TypeVar("T")
-
-
-def doesnt_contain_none(xs: list[T | None]) -> TypeGuard[list[T]]:
+def doesnt_contain_none[T](xs: list[T | None]) -> TypeGuard[list[T]]:
     """Checks if a list contains `None`."""
     return all(x is not None for x in xs)

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -1,7 +1,7 @@
 import ast
 from collections.abc import Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, ExitStack, contextmanager
-from typing import Any, TypeGuard, TypeVar
+from typing import Any, TypeGuard
 
 import hugr
 import hugr.std.float
@@ -835,9 +835,6 @@ def python_value_to_hugr(v: Any, exp_ty: Type, ctx: ToHugrContext) -> hv.Value |
     return None
 
 
-T = TypeVar("T")
-
-
-def doesnt_contain_none(xs: list[T | None]) -> TypeGuard[list[T]]:
+def doesnt_contain_none[T](xs: list[T | None]) -> TypeGuard[list[T]]:
     """Checks if a list contains `None`."""
     return all(x is not None for x in xs)

--- a/guppylang-internals/src/guppylang_internals/decorator/custom.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/custom.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import TYPE_CHECKING
 
 from hugr import tys as ht
 
@@ -31,11 +31,8 @@ if TYPE_CHECKING:
     from guppylang_internals.tys.param import Parameter
     from guppylang_internals.tys.subst import Inst
 
-T = TypeVar("T")
-P = ParamSpec("P")
 
-
-def custom_function(
+def custom_function[**P, T](
     compiler: CustomInoutCallCompiler | None = None,
     checker: CustomCallChecker | None = None,
     higher_order_value: bool = True,
@@ -77,7 +74,7 @@ def custom_function(
     return dec
 
 
-def custom_type(
+def custom_type[T](
     hugr_ty: ht.Type | Callable[[Sequence[Argument], CompilerContext], ht.Type],
     name: str = "",
     copyable: bool = True,
@@ -124,7 +121,7 @@ def custom_type(
     return dec
 
 
-def hugr_op(
+def hugr_op[**P, T](
     op: Callable[[ht.FunctionType, Inst, CompilerContext], DataflowOp],
     checker: CustomCallChecker | None = None,
     higher_order_value: bool = True,

--- a/guppylang-internals/src/guppylang_internals/decorator/gpu.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/gpu.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from guppylang_internals.definition.common import DefId
 from guppylang_internals.definition.custom import DefaultCallChecker
@@ -24,11 +24,8 @@ if TYPE_CHECKING:
 
     from guppylang_internals.definition.ty import OpaqueTypeDef
 
-T = TypeVar("T")
-P = ParamSpec("P")
 
-
-def gpu_module(
+def gpu_module[T](
     filename: str, config_filename: str | None
 ) -> Callable[[builtins.type[T]], GuppyDefinition]:
     def type_def_wrapper(
@@ -51,10 +48,12 @@ def gpu_module(
 
 # Dual-form decorator, usable as @gpu and @gpu(<number>)
 @overload
-def gpu(fn_id: Callable[P, T]) -> GuppyFunctionDefinition[P, T]: ...
+def gpu[**P, T](fn_id: Callable[P, T]) -> GuppyFunctionDefinition[P, T]: ...
 @overload
-def gpu(fn_id: int) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]: ...
-def gpu(
+def gpu[**P, T](
+    fn_id: int,
+) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]: ...
+def gpu[**P, T](
     fn_id: int | Callable[P, T],
 ) -> (
     GuppyFunctionDefinition[P, T]
@@ -70,7 +69,9 @@ def gpu(
         return _gpu_helper(None, fn_id)
 
 
-def _gpu_helper(fn_id: int | None, f: Callable[P, T]) -> GuppyFunctionDefinition[P, T]:
+def _gpu_helper[**P, T](
+    fn_id: int | None, f: Callable[P, T]
+) -> GuppyFunctionDefinition[P, T]:
     from guppylang.defs import GuppyFunctionDefinition
 
     func = RawGpuFunctionDef(

--- a/guppylang-internals/src/guppylang_internals/decorator/ty.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/ty.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, ParamSpec, TypeVar
+from typing import TYPE_CHECKING
 
 from guppylang_internals.dummy_decorator import _dummy_custom_decorator, sphinx_running
 from guppylang_internals.engine import DEF_STORE
@@ -9,9 +9,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from guppylang_internals.definition.ty import TypeDef
-
-T = TypeVar("T")
-P = ParamSpec("P")
 
 
 def extend_type(defn: TypeDef, return_class: bool = False) -> Callable[[type], type]:

--- a/guppylang-internals/src/guppylang_internals/decorator/wasm.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/wasm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from guppylang_internals.definition.common import DefId
 from guppylang_internals.definition.wasm import RawWasmFunctionDef
@@ -32,12 +32,9 @@ if TYPE_CHECKING:
 
     from guppylang_internals.definition.ty import OpaqueTypeDef
 
-T = TypeVar("T")
-P = ParamSpec("P")
-
 
 @pretty_errors
-def wasm_module(
+def wasm_module[T](
     filename: str,
     wasm_platform: WasmPlatform = WasmPlatform.Helios,
 ) -> Callable[[builtins.type[T]], GuppyDefinition]:
@@ -82,10 +79,12 @@ def wasm_module(
 
 
 @overload
-def wasm(arg: Callable[P, T]) -> GuppyFunctionDefinition[P, T]: ...
+def wasm[**P, T](arg: Callable[P, T]) -> GuppyFunctionDefinition[P, T]: ...
 @overload
-def wasm(arg: int) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]: ...
-def wasm(
+def wasm[**P, T](
+    arg: int,
+) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]: ...
+def wasm[**P, T](
     arg: int | Callable[P, T],
 ) -> (
     GuppyFunctionDefinition[P, T]
@@ -101,7 +100,9 @@ def wasm(
         return _wasm_helper(None, arg)
 
 
-def _wasm_helper(fn_id: int | None, f: Callable[P, T]) -> GuppyFunctionDefinition[P, T]:
+def _wasm_helper[**P, T](
+    fn_id: int | None, f: Callable[P, T]
+) -> GuppyFunctionDefinition[P, T]:
     from guppylang.defs import GuppyFunctionDefinition
 
     func = RawWasmFunctionDef(

--- a/guppylang-internals/src/guppylang_internals/decorator/wasm.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/wasm.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import pathlib
-from typing import TYPE_CHECKING, ParamSpec, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 from guppylang.defs import GuppyFunctionDefinition
 
@@ -37,12 +37,9 @@ if TYPE_CHECKING:
 
     from guppylang_internals.definition.ty import OpaqueTypeDef
 
-T = TypeVar("T")
-P = ParamSpec("P")
-
 
 @pretty_errors
-def wasm_module(
+def wasm_module[T](
     filename: str,
     wasm_platform: WasmPlatform = WasmPlatform.Helios,
 ) -> Callable[[builtins.type[T]], GuppyDefinition]:
@@ -122,10 +119,12 @@ def wasm_module(
 
 
 @overload
-def wasm(arg: Callable[P, T]) -> GuppyFunctionDefinition[P, T]: ...
+def wasm[**P, T](arg: Callable[P, T]) -> GuppyFunctionDefinition[P, T]: ...
 @overload
-def wasm(arg: int) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]: ...
-def wasm(
+def wasm[**P, T](
+    arg: int,
+) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]: ...
+def wasm[**P, T](
     arg: int | Callable[P, T],
 ) -> (
     GuppyFunctionDefinition[P, T]
@@ -141,7 +140,9 @@ def wasm(
         return _wasm_helper(None, arg)
 
 
-def _wasm_helper(fn_id: int | None, f: Callable[P, T]) -> GuppyFunctionDefinition[P, T]:
+def _wasm_helper[**P, T](
+    fn_id: int | None, f: Callable[P, T]
+) -> GuppyFunctionDefinition[P, T]:
     from guppylang.defs import GuppyFunctionDefinition
 
     func = RawWasmFunctionDef(

--- a/guppylang-internals/src/guppylang_internals/definition/common.py
+++ b/guppylang-internals/src/guppylang_internals/definition/common.py
@@ -3,7 +3,7 @@ import itertools
 from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from dataclasses import InitVar, dataclass, field
-from typing import TYPE_CHECKING, ClassVar, TypeAlias
+from typing import TYPE_CHECKING, ClassVar
 
 from hugr.build.dfg import DefinitionBuilder, OpVar
 
@@ -17,9 +17,9 @@ if TYPE_CHECKING:
     from guppylang_internals.tys.subst import Inst
 
 
-RawDef: TypeAlias = "ParsableDef | ParsedDef"
-ParsedDef: TypeAlias = "CheckableDef | CheckableGenericDef | CheckedDef"
-CheckedDef: TypeAlias = "CompilableDef | CompiledDef"
+type RawDef = "ParsableDef | ParsedDef"
+type ParsedDef = "CheckableDef | CheckableGenericDef | CheckedDef"
+type CheckedDef = "CompilableDef | CompiledDef"
 
 
 @dataclass(frozen=True)

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -3,12 +3,11 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, override
 
 from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
-from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -4,13 +4,12 @@ from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, override
 
 from hugr import Wire
 from hugr import tys as ht
 from hugr.ops import DataflowOp
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
-from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -1,13 +1,12 @@
 import ast
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar
+from typing import ClassVar, override
 
 from hugr import Node, Wire
 from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.metadata import HugrDebugInfo
-from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/enum.py
+++ b/guppylang-internals/src/guppylang_internals/definition/enum.py
@@ -2,7 +2,7 @@ import ast
 import keyword
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar, Generic, TypeVar
+from typing import ClassVar, TypeVar
 
 from hugr import Wire, ops
 
@@ -74,7 +74,7 @@ F = TypeVar("F", UncheckedField, CheckedField)
 
 
 @dataclass(frozen=True)
-class EnumVariant(Generic[F]):
+class EnumVariant[F]:
     index: int
     name: str
     fields: Sequence[F]

--- a/guppylang-internals/src/guppylang_internals/definition/enum.py
+++ b/guppylang-internals/src/guppylang_internals/definition/enum.py
@@ -2,7 +2,7 @@ import ast
 import keyword
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import ClassVar, Generic, TypeVar
+from typing import ClassVar, TypeVar
 
 from hugr import Wire
 
@@ -76,7 +76,7 @@ F = TypeVar("F", UncheckedField, CheckedField)
 
 
 @dataclass(frozen=True)
-class EnumVariant(Generic[F]):
+class EnumVariant[F]:
     index: int
     name: str
     fields: Sequence[F]

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -2,13 +2,12 @@ import ast
 import inspect
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.debug_info import DISubprogram
 from hugr.hugr.node_port import ToNode
-from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -2,13 +2,12 @@ import ast
 import inspect
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.debug_info import DISubprogram
 from hugr.hugr.node_port import ToNode
-from typing_extensions import override
 
 from guppylang_internals.ast_util import (
     AstNode,

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -1,10 +1,9 @@
 import ast
 import copy
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, NamedTuple, NoReturn
+from typing import Any, ClassVar, NamedTuple, NoReturn, override
 
 from hugr import Wire
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import Context

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -2,10 +2,9 @@ import ast
 import copy
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, ClassVar, NamedTuple, NoReturn
+from typing import Any, ClassVar, NamedTuple, NoReturn, override
 
 from hugr import Wire
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import Context

--- a/guppylang-internals/src/guppylang_internals/definition/protocol.py
+++ b/guppylang-internals/src/guppylang_internals/definition/protocol.py
@@ -1,5 +1,4 @@
 import ast
-import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
@@ -77,19 +76,16 @@ class RawProtocolDef(ProtocolDef, ParsableDef):
         # Look for generic parameters from Python 3.12 style syntax.
         params = []
         params_span: Span | None = None
-        if sys.version_info >= (3, 12):
-            from guppylang_internals.tys.parsing import parse_parameter
+        from guppylang_internals.tys.parsing import parse_parameter
 
-            if cls_def.type_params:
-                first, last = cls_def.type_params[0], cls_def.type_params[-1]
-                params_span = Span(to_span(first).start, to_span(last).end)
-                param_vars_mapping: dict[str, Parameter] = {}
-                for idx, param_node in enumerate(cls_def.type_params):
-                    param = parse_parameter(
-                        param_node, idx, globals, param_vars_mapping
-                    )
-                    param_vars_mapping[param.name] = param
-                    params.append(param)
+        if cls_def.type_params:
+            first, last = cls_def.type_params[0], cls_def.type_params[-1]
+            params_span = Span(to_span(first).start, to_span(last).end)
+            param_vars_mapping: dict[str, Parameter] = {}
+            for idx, param_node in enumerate(cls_def.type_params):
+                param = parse_parameter(param_node, idx, globals, param_vars_mapping)
+                param_vars_mapping[param.name] = param
+                params.append(param)
 
         match cls_def.bases:
             case []:

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -1,6 +1,6 @@
 import ast
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, cast, override
 
 import hugr.build.function as hf
 from guppylang.defs import GuppyDefinition
@@ -11,7 +11,6 @@ from hugr.debug_info import DILocation, DISubprogram
 from hugr.envelope import EnvelopeConfig
 from hugr.metadata import HugrDebugInfo
 from hugr.std.float import FLOAT_T
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode, has_empty_body, with_loc
 from guppylang_internals.checker.core import Context, Globals

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -1,7 +1,7 @@
 import ast
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, cast
+from typing import Any, cast, override
 
 import hugr.build.function as hf
 from guppylang.defs import GuppyDefinition
@@ -12,7 +12,6 @@ from hugr.debug_info import DILocation, DISubprogram
 from hugr.envelope import EnvelopeConfig
 from hugr.metadata import HugrDebugInfo
 from hugr.std.float import FLOAT_T
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode, has_empty_body, with_loc
 from guppylang_internals.checker.core import Context, Globals

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -1,14 +1,13 @@
 import ast
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, override
 
 import hugr.build.function as hf
 import hugr.tys as ht
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.metadata import HugrDebugInfo
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode, with_loc
 from guppylang_internals.checker.core import Context, Globals

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -1,14 +1,13 @@
 import ast
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, override
 
 import hugr.build.function as hf
 import hugr.tys as ht
 from hugr import Node, Wire
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.metadata import HugrDebugInfo
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode, with_loc
 from guppylang_internals.checker.core import Context, Globals

--- a/guppylang-internals/src/guppylang_internals/definition/util.py
+++ b/guppylang-internals/src/guppylang_internals/definition/util.py
@@ -1,7 +1,6 @@
 import ast
 import inspect
 import linecache
-import sys
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from types import FrameType
@@ -27,12 +26,10 @@ from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.parsing import (
     TypeParsingCtx,
     annotation_nodes,
+    parse_parameter,
     try_parse_defn,
 )
 from guppylang_internals.tys.ty import Type
-
-if sys.version_info >= (3, 12):
-    from guppylang_internals.tys.parsing import parse_parameter
 
 if TYPE_CHECKING:
     from guppylang_internals.definition.alias import ParsedTypeAliasDef
@@ -259,15 +256,14 @@ def extract_generic_params(
     params_span: Span | None = None
 
     # Look for generic parameters from Python 3.12 style syntax
-    if sys.version_info >= (3, 12):
-        if cls_def.type_params:
-            first, last = cls_def.type_params[0], cls_def.type_params[-1]
-            params_span = Span(to_span(first).start, to_span(last).end)
-            param_vars_mapping: dict[str, Parameter] = {}
-            for idx, param_node in enumerate(cls_def.type_params):
-                param = parse_parameter(param_node, idx, globals, param_vars_mapping)
-                param_vars_mapping[param.name] = param
-                params.append(param)
+    if cls_def.type_params:
+        first, last = cls_def.type_params[0], cls_def.type_params[-1]
+        params_span = Span(to_span(first).start, to_span(last).end)
+        param_vars_mapping: dict[str, Parameter] = {}
+        for idx, param_node in enumerate(cls_def.type_params):
+            param = parse_parameter(param_node, idx, globals, param_vars_mapping)
+            param_vars_mapping[param.name] = param
+            params.append(param)
 
     base_params: list[Parameter] = []
     for base in cls_def.bases:

--- a/guppylang-internals/src/guppylang_internals/definition/util.py
+++ b/guppylang-internals/src/guppylang_internals/definition/util.py
@@ -4,7 +4,7 @@ import linecache
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from types import FrameType
-from typing import TYPE_CHECKING, ClassVar, TypeAlias, TypeGuard
+from typing import TYPE_CHECKING, ClassVar, TypeGuard
 
 from guppylang_internals.ast_util import AstNode, annotate_location, parse_source
 from guppylang_internals.checker.core import Globals
@@ -37,9 +37,7 @@ if TYPE_CHECKING:
     from guppylang_internals.definition.struct import ParsedStructDef
 
 
-ParsedRecursiveTypeDef: TypeAlias = (
-    "ParsedStructDef | ParsedEnumDef | ParsedTypeAliasDef"
-)
+type ParsedRecursiveTypeDef = "ParsedStructDef | ParsedEnumDef | ParsedTypeAliasDef"
 
 
 @dataclass(frozen=True)

--- a/guppylang-internals/src/guppylang_internals/diagnostic.py
+++ b/guppylang-internals/src/guppylang_internals/diagnostic.py
@@ -10,11 +10,10 @@ from typing import (
     Final,
     Literal,
     Protocol,
+    Self,
     overload,
     runtime_checkable,
 )
-
-from typing_extensions import Self
 
 from guppylang_internals.error import InternalGuppyError
 from guppylang_internals.span import Loc, SourceMap, Span, ToSpan, to_span

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from types import FrameType
-from typing import ClassVar, cast
+from typing import ClassVar, assert_never, cast
 
 import hugr
 import hugr.build.function as hf
@@ -15,7 +15,6 @@ from hugr.ext import Extension, ExtensionRegistry
 from hugr.metadata import HugrDebugInfo, HugrGenerator, HugrUsedExtensions
 from hugr.package import ModulePointer, Package
 from semver import Version
-from typing_extensions import assert_never
 
 import guppylang_internals
 from guppylang_internals.debug_mode import debug_mode_enabled

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -4,7 +4,7 @@ from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from types import FrameType
-from typing import ClassVar, cast
+from typing import ClassVar, assert_never, cast
 
 import hugr
 import hugr.build.function as hf
@@ -15,7 +15,6 @@ from hugr.metadata import HugrDebugInfo, HugrGenerator, HugrUsedExtensions
 from hugr.ops import FuncDecl
 from hugr.package import ModulePointer, Package
 from semver import Version
-from typing_extensions import assert_never
 
 import guppylang_internals
 from guppylang_internals.debug_mode import debug_mode_enabled

--- a/guppylang-internals/src/guppylang_internals/error.py
+++ b/guppylang-internals/src/guppylang_internals/error.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from guppylang_internals.diagnostic import Error, Fatal
@@ -117,10 +117,7 @@ def saved_exception_hook() -> Iterator[None]:
         sys.excepthook = old_hook
 
 
-FuncT = TypeVar("FuncT", bound=Callable[..., Any])
-
-
-def pretty_errors(f: FuncT) -> FuncT:
+def pretty_errors[**P, T](f: Callable[P, T]) -> Callable[P, T]:
     """Decorator to print custom error banners when a `GuppyError` occurs."""
 
     def hook(
@@ -139,4 +136,4 @@ def pretty_errors(f: FuncT) -> FuncT:
         with exception_hook(hook):
             return f(*args, **kwargs)
 
-    return cast("FuncT", pretty_errors_wrapped)
+    return cast("Callable[P, Any]", pretty_errors_wrapped)

--- a/guppylang-internals/src/guppylang_internals/span.py
+++ b/guppylang-internals/src/guppylang_internals/span.py
@@ -3,7 +3,6 @@
 import ast
 import linecache
 from dataclasses import dataclass
-from typing import TypeAlias
 
 from guppylang_internals.ast_util import get_file, get_line_offset, get_source
 from guppylang_internals.error import InternalGuppyError
@@ -102,7 +101,7 @@ class Span:
 
 
 #: Objects in the compiler that are associated with a source span
-ToSpan: TypeAlias = ast.AST | Span
+type ToSpan = ast.AST | Span
 
 
 def to_span(x: ToSpan) -> Span:
@@ -155,7 +154,7 @@ def function_header_span(func_def: ast.FunctionDef) -> Span:
 
 
 #: List of source lines in a file
-SourceLines: TypeAlias = list[str]
+type SourceLines = list[str]
 
 
 class SourceMap:

--- a/guppylang-internals/src/guppylang_internals/span.py
+++ b/guppylang-internals/src/guppylang_internals/span.py
@@ -3,7 +3,6 @@
 import ast
 import linecache
 from dataclasses import dataclass
-from typing import TypeAlias
 
 from guppylang_internals.ast_util import get_file, get_line_offset, get_source
 from guppylang_internals.error import InternalGuppyError
@@ -102,7 +101,7 @@ class Span:
 
 
 #: Objects in the compiler that are associated with a source span
-ToSpan: TypeAlias = ast.AST | Span
+type ToSpan = ast.AST | Span
 
 
 def to_span(x: ToSpan) -> Span:
@@ -159,7 +158,7 @@ def function_header_span(func_def: ast.FunctionDef) -> Span:
 
 
 #: List of source lines in a file
-SourceLines: TypeAlias = list[str]
+type SourceLines = list[str]
 
 
 class SourceMap:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -1,8 +1,6 @@
 import ast
 from dataclasses import dataclass
-from typing import ClassVar
-
-from typing_extensions import assert_never, override
+from typing import ClassVar, assert_never, override
 
 from guppylang_internals.ast_util import fake_call, get_type, with_loc, with_type
 from guppylang_internals.checker.core import Context, Variable

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -1,9 +1,7 @@
 import ast
 from contextlib import suppress
 from dataclasses import dataclass
-from typing import ClassVar
-
-from typing_extensions import assert_never, override
+from typing import ClassVar, assert_never, override
 
 from guppylang_internals.ast_util import fake_call, get_type, with_loc, with_type
 from guppylang_internals.checker.core import Context, Variable

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import hugr
 from hugr import Wire, ops
@@ -268,9 +268,6 @@ def array_swap(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
 # ------------------------------------------------------
 # --------- Custom compilers for non-native ops --------
 # ------------------------------------------------------
-
-
-P = TypeVar("P", bound=ops.DfParentOp)
 
 
 def unpack_array(

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
@@ -4,12 +4,12 @@ multiple nodes.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 import hugr.std.collections.list
 from hugr import Wire
 from hugr import tys as ht
-from hugr.ops import DfParentOp, ExtOp
+from hugr.ops import ExtOp
 from hugr.std.collections.list import List, ListVal
 
 from guppylang_internals.compiler.builder import OpWithEffects, ops, pure
@@ -319,9 +319,6 @@ class ListLengthCompiler(CustomCallCompiler):
 
     def compile(self, args: list[Wire]) -> list[Wire]:
         raise InternalGuppyError("Call compile_with_inouts instead")
-
-
-P = TypeVar("P", bound=DfParentOp)
 
 
 def list_new(builder: DFBuilder, elem_type: ht.Type, args: list[Wire]) -> Wire:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/platform.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/platform.py
@@ -1,10 +1,9 @@
 import ast
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import ClassVar, override
 
 import hugr
 from hugr import Wire, ops, tys
-from typing_extensions import override
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.errors.type_errors import TypeMismatchError

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Final, TypeVar
+from typing import TYPE_CHECKING, Final
 
 import hugr.std.collections
 import hugr.std.int
@@ -94,8 +94,6 @@ def make_error() -> OpWithEffects:
 # ------------------------------------------------------
 # --------- Custom compilers for non-native ops --------
 # ------------------------------------------------------
-
-P = TypeVar("P", bound=ops.DfParentOp)
 
 
 def build_panic(

--- a/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/debug.py
@@ -1,8 +1,6 @@
 import ast
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, ClassVar, cast
-
-from typing_extensions import override
+from typing import TYPE_CHECKING, ClassVar, cast, override
 
 from guppylang_internals.ast_util import with_loc
 from guppylang_internals.checker.core import ComptimeVariable

--- a/guppylang-internals/src/guppylang_internals/std/_internal/decorator.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/decorator.py
@@ -1,7 +1,7 @@
 import ast
 import builtins
 from collections.abc import Callable
-from typing import Protocol, TypeVar
+from typing import Protocol
 
 from guppylang.defs import GuppyDefinition
 
@@ -24,9 +24,6 @@ from guppylang_internals.tys.ty import (
     NumericType,
 )
 
-T = TypeVar("T")
-T2 = TypeVar("T2", contravariant=True)
-
 
 class CreateTypeDef(Protocol):
     def __call__(
@@ -39,13 +36,13 @@ class CreateTypeDef(Protocol):
     ) -> OpaqueTypeDef: ...
 
 
-class CreateModuleDecorator(Protocol[T2]):
+class CreateModuleDecorator[T2](Protocol):
     def __call__(
         self, filename: str, config_filename: str | None
     ) -> Callable[[builtins.type[T2]], GuppyDefinition]: ...
 
 
-def ext_module_decorator(
+def ext_module_decorator[T](
     create_type_def: CreateTypeDef,
     init_compiler: CustomInoutCallCompiler,
     discard_compiler: CustomInoutCallCompiler,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/moved.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/moved.py
@@ -1,7 +1,5 @@
 from collections.abc import Callable
-from typing import Any, ParamSpec, TypeVar
-
-from typing_extensions import Self
+from typing import Any, ParamSpec, Self, TypeVar
 
 P = ParamSpec("P")
 Out = TypeVar("Out")

--- a/guppylang-internals/src/guppylang_internals/std/_internal/moved.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/moved.py
@@ -1,11 +1,8 @@
 from collections.abc import Callable
-from typing import Any, ParamSpec, Self, TypeVar
-
-P = ParamSpec("P")
-Out = TypeVar("Out")
+from typing import Any, Self
 
 
-def produce_moved_function(
+def produce_moved_function[**P, Out](
     module: str, old_name: str, new_location: str
 ) -> Callable[P, Out]:
     """Produces a function that raises an import error when used, stating that it
@@ -27,7 +24,7 @@ def produce_moved_class(module: str, old_name: str, new_location: str) -> type:
     mechanism, and should be considered for removal several months after the move."""
 
     class MovedClass:
-        def __new__(cls, *_args: P.args, **_kwargs: P.kwargs) -> Self:  # type: ignore[valid-type]
+        def __new__[**P](cls, *_args: P.args, **_kwargs: P.kwargs) -> Self:  # type: ignore[valid-type]
             raise ImportError(
                 f"The class `{old_name}` has been moved to `{new_location}`, and "
                 f"can no longer be imported from `{module}`."

--- a/guppylang-internals/src/guppylang_internals/tracing/compile.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/compile.py
@@ -1,6 +1,7 @@
+from typing import assert_never
+
 import hugr.build.function as hf
 from hugr import Wire
-from typing_extensions import assert_never
 
 from guppylang_internals.checker.core import ComptimeVariable
 from guppylang_internals.compiler.builder import FunctionBuilder, ops

--- a/guppylang-internals/src/guppylang_internals/tracing/frozenlist.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/frozenlist.py
@@ -1,6 +1,4 @@
-from typing import Any
-
-from typing_extensions import Self
+from typing import Any, Self
 
 from guppylang_internals.error import GuppyComptimeError
 

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, NamedTuple, TypeAlias
+from typing import Any, ClassVar, NamedTuple
 
 from hugr import Wire
 
@@ -46,8 +46,8 @@ reverse_binary_table = {
     for method, reverse_method, display_name in expr_checker.binary_table.values()
 }
 
-UnaryDunderMethod: TypeAlias = Callable[["DunderMixin"], Any]
-BinaryDunderMethod: TypeAlias = Callable[["DunderMixin", Any], Any]
+type UnaryDunderMethod = Callable[["DunderMixin"], Any]
+type BinaryDunderMethod = Callable[["DunderMixin", Any], Any]
 
 
 def unary_operation(f: UnaryDunderMethod) -> UnaryDunderMethod:

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Iterator, Sequence
 from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, ClassVar, NamedTuple, TypeAlias
+from typing import Any, ClassVar, NamedTuple
 
 import guppylang_internals.checker.expr_checker as expr_checker
 from guppylang_internals.checker.errors.generic import UnsupportedError
@@ -45,8 +45,8 @@ reverse_binary_table = {
     for method, reverse_method, display_name in expr_checker.binary_table.values()
 }
 
-UnaryDunderMethod: TypeAlias = Callable[["DunderMixin"], Any]
-BinaryDunderMethod: TypeAlias = Callable[["DunderMixin", Any], Any]
+type UnaryDunderMethod = Callable[["DunderMixin"], Any]
+type BinaryDunderMethod = Callable[["DunderMixin", Any], Any]
 
 
 def unary_operation(f: UnaryDunderMethod) -> UnaryDunderMethod:

--- a/guppylang-internals/src/guppylang_internals/tracing/recorder.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/recorder.py
@@ -1,7 +1,7 @@
 import ast
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, TypeAlias, overload
+from typing import TYPE_CHECKING, Any, overload
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import ComptimeVariable, Place
@@ -29,7 +29,7 @@ class TraceWire:
 #: A value usable as an input to an op/call in a trace, i.e. that will be resolved
 #: to a Hugr `Wire` during compilation. (`ComptimeVariable`s are resolved via the
 #: state held in the DFContainer.)
-TraceOutput: TypeAlias = TraceWire | ComptimeVariable
+type TraceOutput = TraceWire | ComptimeVariable
 
 
 @dataclass(frozen=True)

--- a/guppylang-internals/src/guppylang_internals/tracing/util.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/util.py
@@ -2,13 +2,9 @@ import functools
 import sys
 from collections.abc import Callable
 from types import TracebackType
-from typing import ParamSpec, TypeVar
 
 from guppylang_internals.error import GuppyComptimeError, GuppyError, exception_hook
 from guppylang_internals.frame_util import remove_internal_frames
-
-P = ParamSpec("P")
-T = TypeVar("T")
 
 
 class capture_guppy_errors:
@@ -43,7 +39,7 @@ class capture_guppy_errors:
             # the traceback.
             raise GuppyComptimeError(msg) from None
 
-    def __call__(self, f: Callable[P, T]) -> Callable[P, T]:
+    def __call__[**P, T](self, f: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(f)
         def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
             with self:
@@ -52,7 +48,7 @@ class capture_guppy_errors:
         return wrapped
 
 
-def hide_trace(f: Callable[P, T]) -> Callable[P, T]:
+def hide_trace[**P, T](f: Callable[P, T]) -> Callable[P, T]:
     """Function decorator that hides compiler-internal frames from the traceback of any
     exception thrown by the decorated function."""
 

--- a/guppylang-internals/src/guppylang_internals/tys/arg.py
+++ b/guppylang-internals/src/guppylang_internals/tys/arg.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 from hugr import tys as ht
 
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 # Note that this might become obsolete in case the `@sealed` decorator is added:
 #  * https://peps.python.org/pep-0622/#sealed-classes-as-algebraic-data-types
 #  * https://github.com/johnthagen/sealed-typing-pep
-Argument: TypeAlias = "TypeArg | ConstArg"
+type Argument = "TypeArg | ConstArg"
 
 
 @dataclass(frozen=True)

--- a/guppylang-internals/src/guppylang_internals/tys/common.py
+++ b/guppylang-internals/src/guppylang_internals/tys/common.py
@@ -1,7 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Generic, Protocol, TypeVar
-
-T = TypeVar("T")
+from typing import Any, Protocol
 
 
 class ToHugrContext(Protocol):
@@ -15,7 +13,7 @@ class ToHugrContext(Protocol):
     """
 
 
-class ToHugr(ABC, Generic[T]):
+class ToHugr[T](ABC):
     """Abstract base class for objects that have a Hugr representation."""
 
     @abstractmethod
@@ -58,7 +56,7 @@ class Visitable(ABC):
         """
 
 
-class Transformable(Visitable, ABC, Generic[T]):
+class Transformable[T](Visitable, ABC):
     """Abstract base class for objects that can be recursively transformed."""
 
     @abstractmethod

--- a/guppylang-internals/src/guppylang_internals/tys/const.py
+++ b/guppylang-internals/src/guppylang_internals/tys/const.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any
 
 from guppylang_internals.tys.common import Transformable, Transformer, Visitor
 from guppylang_internals.tys.var import BoundVar, ExistentialVar
@@ -136,4 +136,4 @@ class ExistentialConstVar(ExistentialVar, ConstBase):
         )
 
 
-Const: TypeAlias = ConstValue | BoundConstVar | ExistentialConstVar
+type Const = ConstValue | BoundConstVar | ExistentialConstVar

--- a/guppylang-internals/src/guppylang_internals/tys/param.py
+++ b/guppylang-internals/src/guppylang_internals/tys/param.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Self, TypeAlias
+from typing import TYPE_CHECKING, Self
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.errors.generic import ExpectedError
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
 # Note that this might become obsolete in case the `@sealed` decorator is added:
 #  * https://peps.python.org/pep-0622/#sealed-classes-as-algebraic-data-types
 #  * https://github.com/johnthagen/sealed-typing-pep
-Parameter: TypeAlias = "TypeParam | ConstParam"
+type Parameter = "TypeParam | ConstParam"
 
 
 @dataclass(frozen=True)

--- a/guppylang-internals/src/guppylang_internals/tys/param.py
+++ b/guppylang-internals/src/guppylang_internals/tys/param.py
@@ -1,9 +1,7 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, TypeAlias
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Self, TypeAlias
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.errors.generic import ExpectedError

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -2,7 +2,7 @@ import ast
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from guppylang_internals.ast_util import (
     AstNode,
@@ -211,7 +211,7 @@ def try_parse_defn(node: AstNode, ctx: TypeParsingCtx) -> Definition | None:
                     if x in module.__dict__:
                         val = module.__dict__[x]
                         if isinstance(val, GuppyDefinition):
-                            return ENGINE.get_parsed(val.id)
+                            return cast("Definition", ENGINE.get_parsed(val.id))
                     raise GuppyError(
                         ModuleMemberNotFoundError(node, module.__name__, x)
                     )

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -2,7 +2,7 @@ import ast
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
 from guppylang_internals.ast_util import (
     AstNode,
@@ -215,7 +215,7 @@ def try_parse_defn(node: AstNode, ctx: TypeParsingCtx) -> Definition | None:
                     if x in module.__dict__:
                         val = module.__dict__[x]
                         if isinstance(val, GuppyDefinition):
-                            return ENGINE.get_parsed(val.id)
+                            return cast("Definition", ENGINE.get_parsed(val.id))
                     raise GuppyError(
                         ModuleMemberNotFoundError(node, module.__name__, x)
                     )

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -1,5 +1,4 @@
 import ast
-import sys
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from types import ModuleType
@@ -426,120 +425,113 @@ def check_function_arg(
     return FuncInput(ty, flags, name)
 
 
-if sys.version_info >= (3, 12):
+def parse_parameter(
+    node: ast.type_param,
+    idx: int,
+    globals: Globals,
+    param_var_mapping: dict[str, Parameter],
+    allow_free_vars: bool = False,
+) -> Parameter:
+    """Parses a `Variable: Bound` generic type parameter declaration."""
+    if isinstance(node, ast.TypeVarTuple | ast.ParamSpec):
+        raise GuppyError(UnsupportedError(node, "Variadic generic parameters"))
+    assert isinstance(node, ast.TypeVar)
 
-    def parse_parameter(
-        node: ast.type_param,
-        idx: int,
-        globals: Globals,
-        param_var_mapping: dict[str, Parameter],
-        allow_free_vars: bool = False,
-    ) -> Parameter:
-        """Parses a `Variable: Bound` generic type parameter declaration."""
-        if isinstance(node, ast.TypeVarTuple | ast.ParamSpec):
-            raise GuppyError(UnsupportedError(node, "Variadic generic parameters"))
-        assert isinstance(node, ast.TypeVar)
+    match node.bound:
+        # No bound means it's a linear type parameter
+        case None:
+            return TypeParam(
+                idx, node.name, must_be_copyable=False, must_be_droppable=False
+            )
+        # Special `Copy` or `Drop` bounds for types
+        case ast.Name(id="Copy"):
+            return TypeParam(
+                idx, node.name, must_be_copyable=True, must_be_droppable=False
+            )
+        case ast.Name(id="Drop"):
+            return TypeParam(
+                idx, node.name, must_be_copyable=False, must_be_droppable=True
+            )
+        # Copy and drop is annotated as `T: (Copy, Drop)`
+        # TODO: Should we also allow `T: Copy + Drop`? Mypy would complain about it
+        case ast.Tuple(elts=elts):
+            bounds: list[ProtocolInst] = []
+            for elt in elts:
+                match elt:
+                    case ast.Name(id="Copy"):
+                        continue
+                    case ast.Name(id="Drop"):
+                        continue
+                    case _:
+                        if proto_inst := parse_bound(
+                            elt, globals, param_var_mapping, allow_free_vars
+                        ):
+                            bounds.append(proto_inst)
+                        else:
+                            raise GuppyError(UnrecognisedBound(elt, ast.unparse(elt)))
+            return TypeParam(
+                idx,
+                node.name,
+                must_be_copyable=True,
+                must_be_droppable=True,
+                must_implement=bounds,
+            )
 
-        match node.bound:
-            # No bound means it's a linear type parameter
-            case None:
-                return TypeParam(
-                    idx, node.name, must_be_copyable=False, must_be_droppable=False
-                )
-            # Special `Copy` or `Drop` bounds for types
-            case ast.Name(id="Copy"):
-                return TypeParam(
-                    idx, node.name, must_be_copyable=True, must_be_droppable=False
-                )
-            case ast.Name(id="Drop"):
-                return TypeParam(
-                    idx, node.name, must_be_copyable=False, must_be_droppable=True
-                )
-            # Copy and drop is annotated as `T: (Copy, Drop)`
-            # TODO: Should we also allow `T: Copy + Drop`? Mypy would complain about it
-            case ast.Tuple(elts=elts):
-                bounds: list[ProtocolInst] = []
-                for elt in elts:
-                    match elt:
-                        case ast.Name(id="Copy"):
-                            continue
-                        case ast.Name(id="Drop"):
-                            continue
-                        case _:
-                            if proto_inst := parse_bound(
-                                elt, globals, param_var_mapping, allow_free_vars
-                            ):
-                                bounds.append(proto_inst)
-                            else:
-                                raise GuppyError(
-                                    UnrecognisedBound(elt, ast.unparse(elt))
-                                )
+        # Otherwise, it must be either a protocol or a const parameter
+        case bound:
+            if proto_inst := parse_bound(
+                bound, globals, param_var_mapping, allow_free_vars
+            ):
                 return TypeParam(
                     idx,
                     node.name,
                     must_be_copyable=True,
                     must_be_droppable=True,
-                    must_implement=bounds,
+                    must_implement=[proto_inst],
                 )
+            else:
+                # TODO: In the future we might want to allow stuff like
+                #   `def foo[T, XS: array[T, 42]]` and so on
+                ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
+                ty = type_from_ast(bound, ctx)
+                if not ty.copyable or not ty.droppable:
+                    raise GuppyError(LinearConstParamError(bound, ty))
+                return ConstParam(idx, node.name, ty)
 
-            # Otherwise, it must be either a protocol or a const parameter
-            case bound:
-                if proto_inst := parse_bound(
-                    bound, globals, param_var_mapping, allow_free_vars
-                ):
-                    return TypeParam(
-                        idx,
-                        node.name,
-                        must_be_copyable=True,
-                        must_be_droppable=True,
-                        must_implement=[proto_inst],
-                    )
-                else:
-                    # TODO: In the future we might want to allow stuff like
-                    #   `def foo[T, XS: array[T, 42]]` and so on
-                    ctx = TypeParsingCtx(
-                        globals, param_var_mapping, {}, allow_free_vars
-                    )
-                    ty = type_from_ast(bound, ctx)
-                    if not ty.copyable or not ty.droppable:
-                        raise GuppyError(LinearConstParamError(bound, ty))
-                    return ConstParam(idx, node.name, ty)
 
-    def parse_bound(
-        bound: ast.expr,
-        globals: Globals,
-        param_var_mapping: dict[str, Parameter],
-        allow_free_vars: bool,
-    ) -> ProtocolInst | None:
-        from guppylang_internals.definition.protocol import ParsedProtocolDef
+def parse_bound(
+    bound: ast.expr,
+    globals: Globals,
+    param_var_mapping: dict[str, Parameter],
+    allow_free_vars: bool,
+) -> ProtocolInst | None:
+    from guppylang_internals.definition.protocol import ParsedProtocolDef
 
-        ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
+    ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
 
-        # First, try to see if this is a protocol bound by checking if can find
-        # a protocol definition with this name. In contrast to normal
-        # parameters, protocol parameters could be parametrised themselves.
-        proto_defn = None
-        proto_args = []
-        if isinstance(bound, ast.Subscript):
-            proto_defn = try_parse_defn(bound.value, ctx)
-            arg_nodes = (
-                bound.slice.elts
-                if isinstance(bound.slice, ast.Tuple)
-                else [bound.slice]
-            )
-            # Special case for the `Callable` protocol
-            if isinstance(proto_defn, CallableProtocolDef):
-                sig = _parse_function_type(arg_nodes, bound, ctx, "Callable")
-                return CallableProtocolInst(sig)
-            proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
-        else:
-            proto_defn = try_parse_defn(bound, ctx)
+    # First, try to see if this is a protocol bound by checking if can find
+    # a protocol definition with this name. In contrast to normal
+    # parameters, protocol parameters could be parametrised themselves.
+    proto_defn = None
+    proto_args = []
+    if isinstance(bound, ast.Subscript):
+        proto_defn = try_parse_defn(bound.value, ctx)
+        arg_nodes = (
+            bound.slice.elts if isinstance(bound.slice, ast.Tuple) else [bound.slice]
+        )
+        # Special case for the `Callable` protocol
+        if isinstance(proto_defn, CallableProtocolDef):
+            sig = _parse_function_type(arg_nodes, bound, ctx, "Callable")
+            return CallableProtocolInst(sig)
+        proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
+    else:
+        proto_defn = try_parse_defn(bound, ctx)
 
-        if isinstance(proto_defn, ParsedProtocolDef):
-            checked_defn = proto_defn.check(globals)
-            inst = checked_defn.check_instantiate(proto_args, bound)
-            return inst
-        return None
+    if isinstance(proto_defn, ParsedProtocolDef):
+        checked_defn = proto_defn.check(globals)
+        inst = checked_defn.check_instantiate(proto_args, bound)
+        return inst
+    return None
 
 
 _type_param = TypeParam(0, "T", False, False)

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, Flag, auto
 from functools import cached_property, total_ordering
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, assert_never, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, assert_never, cast
 
 import hugr.std.float
 import hugr.std.int
@@ -948,9 +948,7 @@ class EnumType(ParametrizedTypeBase):
 
 
 #: The type of parametrized Guppy types.
-ParametrizedType: TypeAlias = (
-    FunctionType | TupleType | OpaqueType | StructType | EnumType
-)
+type ParametrizedType = FunctionType | TupleType | OpaqueType | StructType | EnumType
 
 
 #: The type of Guppy types.
@@ -962,7 +960,7 @@ ParametrizedType: TypeAlias = (
 #: This might become obsolete in case the @sealed decorator is added:
 #:   * https://peps.python.org/pep-0622/#sealed-classes-as-algebraic-data-types
 #:   * https://github.com/johnthagen/sealed-typing-pep
-Type: TypeAlias = (
+type Type = (
     BoundTypeVar
     | ExistentialTypeVar
     | NumericType
@@ -972,7 +970,7 @@ Type: TypeAlias = (
 )
 
 #: An immutable row of Guppy types.
-TypeRow: TypeAlias = Sequence[Type]
+type TypeRow = Sequence[Type]
 
 
 def row_to_type(row: TypeRow) -> Type:
@@ -1017,13 +1015,13 @@ def unify(s: Type | Const, t: Type | Const, subst: "Subst | None") -> "Subst | N
     match s, t:
         case ExistentialVar(id=s_id), ExistentialVar(id=t_id) if s_id == t_id:
             return subst
-        case ExistentialTypeVar() as s_var, t if isinstance(t, Type):
+        case ExistentialTypeVar() as s_var, t if isinstance(t, Type.__value__):
             return _unify_type_var(s_var, t, subst)
-        case ExistentialConstVar() as s_var, t if isinstance(t, Const):
+        case ExistentialConstVar() as s_var, t if isinstance(t, Const.__value__):
             return _unify_const_var(s_var, t, subst)
-        case s, ExistentialTypeVar() as t_var if isinstance(s, Type):
+        case s, ExistentialTypeVar() as t_var if isinstance(s, Type.__value__):
             return _unify_type_var(t_var, s, subst)
-        case s, ExistentialConstVar() as t_var if isinstance(s, Const):
+        case s, ExistentialConstVar() as t_var if isinstance(s, Const.__value__):
             return _unify_const_var(t_var, s, subst)
         case BoundVar(idx=s_idx), BoundVar(idx=t_idx) if s_idx == t_idx:
             return subst

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -3,12 +3,11 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, Flag, auto
 from functools import cached_property, total_ordering
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, assert_never, cast
 
 import hugr.std.float
 import hugr.std.int
 from hugr import tys as ht
-from typing_extensions import assert_never
 
 from guppylang_internals.definition.common import DefId
 from guppylang_internals.error import GuppyError, InternalGuppyError
@@ -1068,7 +1067,7 @@ def _unify_type_var(var: ExistentialTypeVar, t: Type, subst: "Subst") -> "Subst 
                 loc = DUMMY_SPAN  # We catch the error later so the span doesn't matter
                 _, proto_subst = proto.check_implemented_by(t, loc)
                 subst |= proto_subst
-            except GuppyError:  # noqa: PERF203
+            except GuppyError:
                 # At this point, we only use protocol checking to infer types. If the
                 # protocol is not satisfied, we still keep going. The error will be
                 # raised later when we check the inferred instantiation.

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, Flag, auto
 from functools import cached_property, total_ordering
-from typing import TYPE_CHECKING, ClassVar, Literal, assert_never, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, assert_never, cast
 
 import hugr.std.float
 import hugr.std.int
@@ -20,7 +20,11 @@ from guppylang_internals.tys.common import (
     Transformer,
     Visitor,
 )
-from guppylang_internals.tys.const import Const, ConstValue, ExistentialConstVar
+from guppylang_internals.tys.const import (
+    Const,
+    ConstValue,
+    ExistentialConstVar,
+)
 from guppylang_internals.tys.param import ConstParam, Parameter
 from guppylang_internals.tys.protocol import ProtocolInst
 from guppylang_internals.tys.var import BoundVar, ExistentialVar
@@ -957,6 +961,32 @@ type Type = (
     | ParametrizedType
 )
 
+
+def is_type(t: Any) -> Type | None:
+    """Typechecker nonsense"""
+    if isinstance(t, BoundTypeVar):
+        return t
+    if isinstance(t, ExistentialTypeVar):
+        return t
+    if isinstance(t, NumericType):
+        return t
+    if isinstance(t, NoneType):
+        return t
+    if isinstance(t, FunctionDefType):
+        return t
+    if isinstance(t, FunctionType):
+        return t
+    if isinstance(t, TupleType):
+        return t
+    if isinstance(t, OpaqueType):
+        return t
+    if isinstance(t, StructType):
+        return t
+    if isinstance(t, EnumType):
+        return t
+    return None
+
+
 #: An immutable row of Guppy types.
 type TypeRow = Sequence[Type]
 
@@ -1051,12 +1081,12 @@ def unify_const(s: Const, t: Const, subst: "Subst | None") -> "Subst | None":
 def _unify_type_var(var: ExistentialTypeVar, t: Type, subst: "Subst") -> "Subst | None":
     """Helper function for unification of type variables."""
     if var in subst:
-        s = subst[var]
-        assert isinstance(s, Type)
+        s = is_type(subst[var])
+        assert s is not None
         return unify(s, t, subst)
     if isinstance(t, ExistentialTypeVar) and t in subst:
-        s = subst[t]
-        assert isinstance(s, Type)
+        s = is_type(subst[t])
+        assert s is not None
         return unify(var, s, subst)
     if var in t.unsolved_vars:
         return None

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -963,19 +963,20 @@ type Type = (
 
 
 def is_type(t: Any) -> TypeGuard[Type]:
-    return any(
+    return isinstance(
+        t,
         (
-            isinstance(t, BoundTypeVar),
-            isinstance(t, ExistentialTypeVar),
-            isinstance(t, NumericType),
-            isinstance(t, NoneType),
-            isinstance(t, FunctionDefType),
-            isinstance(t, FunctionType),
-            isinstance(t, TupleType),
-            isinstance(t, OpaqueType),
-            isinstance(t, StructType),
-            isinstance(t, EnumType),
-        )
+            BoundTypeVar,
+            ExistentialTypeVar,
+            NumericType,
+            NoneType,
+            FunctionDefType,
+            FunctionType,
+            TupleType,
+            OpaqueType,
+            StructType,
+            EnumType,
+        ),
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -3,12 +3,11 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, Flag, auto
 from functools import cached_property, total_ordering
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, assert_never, cast
 
 import hugr.std.float
 import hugr.std.int
 from hugr import tys as ht
-from typing_extensions import assert_never
 
 from guppylang_internals.definition.common import DefId
 from guppylang_internals.error import GuppyError, InternalGuppyError
@@ -1070,7 +1069,7 @@ def _unify_type_var(var: ExistentialTypeVar, t: Type, subst: "Subst") -> "Subst 
                 loc = DUMMY_SPAN  # We catch the error later so the span doesn't matter
                 _, proto_subst = proto.check_implemented_by(t, loc)
                 subst |= proto_subst
-            except GuppyError:  # noqa: PERF203
+            except GuppyError:
                 # At this point, we only use protocol checking to infer types. If the
                 # protocol is not satisfied, we still keep going. The error will be
                 # raised later when we check the inferred instantiation.

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, Flag, auto
 from functools import cached_property, total_ordering
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, assert_never, cast
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, TypeGuard, assert_never, cast
 
 import hugr.std.float
 import hugr.std.int
@@ -962,29 +962,21 @@ type Type = (
 )
 
 
-def is_type(t: Any) -> Type | None:
-    """Typechecker nonsense"""
-    if isinstance(t, BoundTypeVar):
-        return t
-    if isinstance(t, ExistentialTypeVar):
-        return t
-    if isinstance(t, NumericType):
-        return t
-    if isinstance(t, NoneType):
-        return t
-    if isinstance(t, FunctionDefType):
-        return t
-    if isinstance(t, FunctionType):
-        return t
-    if isinstance(t, TupleType):
-        return t
-    if isinstance(t, OpaqueType):
-        return t
-    if isinstance(t, StructType):
-        return t
-    if isinstance(t, EnumType):
-        return t
-    return None
+def is_type(t: Any) -> TypeGuard[Type]:
+    return any(
+        (
+            isinstance(t, BoundTypeVar),
+            isinstance(t, ExistentialTypeVar),
+            isinstance(t, NumericType),
+            isinstance(t, NoneType),
+            isinstance(t, FunctionDefType),
+            isinstance(t, FunctionType),
+            isinstance(t, TupleType),
+            isinstance(t, OpaqueType),
+            isinstance(t, StructType),
+            isinstance(t, EnumType),
+        )
+    )
 
 
 #: An immutable row of Guppy types.
@@ -1081,12 +1073,12 @@ def unify_const(s: Const, t: Const, subst: "Subst | None") -> "Subst | None":
 def _unify_type_var(var: ExistentialTypeVar, t: Type, subst: "Subst") -> "Subst | None":
     """Helper function for unification of type variables."""
     if var in subst:
-        s = is_type(subst[var])
-        assert s is not None
+        s = subst[var]
+        assert is_type(s)
         return unify(s, t, subst)
     if isinstance(t, ExistentialTypeVar) and t in subst:
         s = is_type(subst[t])
-        assert s is not None
+        assert is_type(s)
         return unify(var, s, subst)
     if var in t.unsolved_vars:
         return None

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -3,7 +3,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from enum import Enum, Flag, auto
 from functools import cached_property, total_ordering
-from typing import TYPE_CHECKING, ClassVar, Literal, TypeAlias, assert_never, cast
+from typing import TYPE_CHECKING, ClassVar, Literal, assert_never, cast
 
 import hugr.std.float
 import hugr.std.int
@@ -936,9 +936,7 @@ class EnumType(ParametrizedTypeBase):
 
 
 #: The type of parametrized Guppy types.
-ParametrizedType: TypeAlias = (
-    FunctionType | TupleType | OpaqueType | StructType | EnumType
-)
+type ParametrizedType = FunctionType | TupleType | OpaqueType | StructType | EnumType
 
 
 #: The type of Guppy types.
@@ -950,7 +948,7 @@ ParametrizedType: TypeAlias = (
 #: This might become obsolete in case the @sealed decorator is added:
 #:   * https://peps.python.org/pep-0622/#sealed-classes-as-algebraic-data-types
 #:   * https://github.com/johnthagen/sealed-typing-pep
-Type: TypeAlias = (
+type Type = (
     BoundTypeVar
     | ExistentialTypeVar
     | NumericType
@@ -960,7 +958,7 @@ Type: TypeAlias = (
 )
 
 #: An immutable row of Guppy types.
-TypeRow: TypeAlias = Sequence[Type]
+type TypeRow = Sequence[Type]
 
 
 def row_to_type(row: TypeRow) -> Type:

--- a/guppylang-internals/src/guppylang_internals/tys/ty.py
+++ b/guppylang-internals/src/guppylang_internals/tys/ty.py
@@ -1077,7 +1077,7 @@ def _unify_type_var(var: ExistentialTypeVar, t: Type, subst: "Subst") -> "Subst 
         assert is_type(s)
         return unify(s, t, subst)
     if isinstance(t, ExistentialTypeVar) and t in subst:
-        s = is_type(subst[t])
+        s = subst[t]
         assert is_type(s)
         return unify(var, s, subst)
     if var in t.unsolved_vars:

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -10,7 +10,9 @@ from typing import (
     ParamSpec,
     TypedDict,
     TypeVar,
+    Unpack,
     cast,
+    dataclass_transform,
     overload,
 )
 
@@ -54,7 +56,6 @@ from guppylang_internals.tys.ty import (
     UnitaryFlags,
 )
 from hugr import val as hv
-from typing_extensions import Unpack, dataclass_transform
 
 from guppylang.defs import (
     GuppyDefinition,

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -7,7 +7,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     NamedTuple,
-    ParamSpec,
     TypedDict,
     TypeVar,
     Unpack,
@@ -65,12 +64,7 @@ from guppylang.defs import (
 )
 from guppylang.library import _get_link_name
 
-K = TypeVar("K")
-S = TypeVar("S")
-T = TypeVar("T")
-F = TypeVar("F", bound=Callable[..., Any])
-P = ParamSpec("P")
-Decorator = Callable[[S], T]
+type Decorator[S, T] = Callable[[S], T]
 
 AnyRawFunctionDef = (
     RawFunctionDef,
@@ -121,14 +115,16 @@ class _Guppy:
     """Class for the `@guppy` decorator."""
 
     @overload
-    def __call__(
+    def __call__[**P, T](
         self, /, **kwargs: Unpack[GuppyKwargs]
     ) -> Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]: ...
 
     @overload
-    def __call__(self, f: Callable[P, T], /) -> GuppyFunctionDefinition[P, T]: ...
+    def __call__[**P, T](
+        self, f: Callable[P, T], /
+    ) -> GuppyFunctionDefinition[P, T]: ...
 
-    def __call__(
+    def __call__[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -154,14 +150,16 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)
 
     @overload
-    def comptime(
+    def comptime[**P, T](
         self, /, **kwargs: Unpack[GuppyKwargs]
     ) -> Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]: ...
 
     @overload
-    def comptime(self, f: Callable[P, T], /) -> GuppyFunctionDefinition[P, T]: ...
+    def comptime[**P, T](
+        self, f: Callable[P, T], /
+    ) -> GuppyFunctionDefinition[P, T]: ...
 
-    def comptime(
+    def comptime[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -200,7 +198,7 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)
 
     @dataclass_transform()
-    def struct(
+    def struct[T](
         self, *args: Any, **kwargs: Unpack[GuppyStructKwargs]
     ) -> builtins.type[T]:
         """Registers a class as a Guppy struct.
@@ -252,7 +250,9 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)  # type: ignore[return-value]
 
     @dataclass_transform()
-    def enum(self, *args: Any, **kwargs: Unpack[GuppyEnumKwargs]) -> builtins.type[T]:
+    def enum[T](
+        self, *args: Any, **kwargs: Unpack[GuppyEnumKwargs]
+    ) -> builtins.type[T]:
         """Registers a class as a Guppy enum.
 
         .. code-block:: python
@@ -296,7 +296,7 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)  # type: ignore[return-value]
 
     @dataclass_transform()
-    def protocol(self, cls: builtins.type[T]) -> builtins.type[T]:
+    def protocol[T](self, cls: builtins.type[T]) -> builtins.type[T]:
         """Registers a class as a Guppy protocol.
 
         .. code-block:: python
@@ -320,7 +320,7 @@ class _Guppy:
         # a `GuppyDefinition` that handles the comptime logic
         return GuppyDefinition(defn)  # type: ignore[return-value]
 
-    def require(
+    def require[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -430,14 +430,16 @@ class _Guppy:
         return GuppyDefinition(defn)
 
     @overload
-    def declare(
+    def declare[**P, T](
         self, /, **kwargs: Unpack[GuppyKwargs]
     ) -> Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]: ...
 
     @overload
-    def declare(self, f: Callable[P, T], /) -> GuppyFunctionDefinition[P, T]: ...
+    def declare[**P, T](
+        self, f: Callable[P, T], /
+    ) -> GuppyFunctionDefinition[P, T]: ...
 
-    def declare(
+    def declare[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -464,7 +466,7 @@ class _Guppy:
 
         return _with_optional_kwargs(decorator, args, kwargs)
 
-    def overload(
+    def overload[**P, T](
         self, *funcs: Any
     ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
         """Collects multiple function definitions into one overloaded function.
@@ -532,7 +534,7 @@ class _Guppy:
 
         return decorator
 
-    def constant(self, name: str, ty: str, value: hv.Value) -> T:  # type: ignore[type-var]  # Since we're returning a free type variable
+    def constant[T](self, name: str, ty: str, value: hv.Value) -> T:  # type: ignore[type-var]  # Since we're returning a free type variable
         """Adds a constant to a module, backed by a `hugr.val.Value`."""
         type_ast = _parse_expr_string(
             ty, f"Not a valid Guppy type: `{ty}`", DEF_STORE.sources
@@ -543,7 +545,7 @@ class _Guppy:
         # a `GuppyDefinition` that handles the comptime logic
         return GuppyDefinition(defn)  # type: ignore[return-value]
 
-    def _extern(
+    def _extern[T](
         self,
         name: str,
         ty: str,
@@ -562,7 +564,7 @@ class _Guppy:
         # a `GuppyDefinition` that handles the comptime logic
         return GuppyDefinition(defn)  # type: ignore[return-value]
 
-    def pytket(
+    def pytket[**P, T](
         self, input_circuit: Any
     ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
         """Backs a function declaration by the given pytket circuit. The declaration
@@ -773,7 +775,7 @@ def _find_load_call(sources: SourceMap) -> Span | None:
     return None
 
 
-def _set_firstlineno(cls: builtins.type[T], frame: FrameType) -> builtins.type[T]:
+def _set_firstlineno[T](cls: builtins.type[T], frame: FrameType) -> builtins.type[T]:
     """Helper function to set the `__firstlineno__` attribute on a class if it is not
     already there.
 
@@ -786,7 +788,7 @@ def _set_firstlineno(cls: builtins.type[T], frame: FrameType) -> builtins.type[T
     return cls
 
 
-def custom_guppy_decorator(f: F) -> F:
+def custom_guppy_decorator[F: Callable[..., Any]](f: F) -> F:
     """Decorator to mark user-defined decorators that wrap builtin `guppy` decorators.
 
     Example:
@@ -827,7 +829,7 @@ def get_calling_frame() -> FrameType:
     raise RuntimeError("Couldn't obtain stack frame for definition")
 
 
-def _with_optional_kwargs(
+def _with_optional_kwargs[S, K, T](
     decorator: Callable[[S, K], T], args: tuple[Any, ...], kwargs: K
 ) -> T | Callable[[S], T]:
     """Helper function to define decorators that may be used directly (`@decorator`) but

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     NamedTuple,
-    ParamSpec,
     TypedDict,
     TypeVar,
     Unpack,
@@ -66,12 +65,7 @@ from guppylang.defs import (
 )
 from guppylang.library import _get_link_name
 
-K = TypeVar("K")
-S = TypeVar("S")
-T = TypeVar("T")
-F = TypeVar("F", bound=Callable[..., Any])
-P = ParamSpec("P")
-Decorator = Callable[[S], T]
+type Decorator[S, T] = Callable[[S], T]
 
 AnyRawFunctionDef = (
     RawFunctionDef,
@@ -122,14 +116,16 @@ class _Guppy:
     """Class for the `@guppy` decorator."""
 
     @overload
-    def __call__(
+    def __call__[**P, T](
         self, /, **kwargs: Unpack[GuppyKwargs]
     ) -> Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]: ...
 
     @overload
-    def __call__(self, f: Callable[P, T], /) -> GuppyFunctionDefinition[P, T]: ...
+    def __call__[**P, T](
+        self, f: Callable[P, T], /
+    ) -> GuppyFunctionDefinition[P, T]: ...
 
-    def __call__(
+    def __call__[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -155,14 +151,16 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)
 
     @overload
-    def comptime(
+    def comptime[**P, T](
         self, /, **kwargs: Unpack[GuppyKwargs]
     ) -> Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]: ...
 
     @overload
-    def comptime(self, f: Callable[P, T], /) -> GuppyFunctionDefinition[P, T]: ...
+    def comptime[**P, T](
+        self, f: Callable[P, T], /
+    ) -> GuppyFunctionDefinition[P, T]: ...
 
-    def comptime(
+    def comptime[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -201,7 +199,7 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)
 
     @dataclass_transform()
-    def struct(
+    def struct[T](
         self, *args: Any, **kwargs: Unpack[GuppyStructKwargs]
     ) -> builtins.type[T]:
         """Registers a class as a Guppy struct.
@@ -253,7 +251,9 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)  # type: ignore[return-value]
 
     @dataclass_transform()
-    def enum(self, *args: Any, **kwargs: Unpack[GuppyEnumKwargs]) -> builtins.type[T]:
+    def enum[T](
+        self, *args: Any, **kwargs: Unpack[GuppyEnumKwargs]
+    ) -> builtins.type[T]:
         """Registers a class as a Guppy enum.
 
         .. code-block:: python
@@ -297,7 +297,7 @@ class _Guppy:
         return _with_optional_kwargs(decorator, args, kwargs)  # type: ignore[return-value]
 
     @dataclass_transform()
-    def protocol(self, cls: builtins.type[T]) -> builtins.type[T]:
+    def protocol[T](self, cls: builtins.type[T]) -> builtins.type[T]:
         """Registers a class as a Guppy protocol.
 
         .. code-block:: python
@@ -321,7 +321,7 @@ class _Guppy:
         # a `GuppyDefinition` that handles the comptime logic
         return GuppyDefinition(defn)  # type: ignore[return-value]
 
-    def require(
+    def require[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -431,14 +431,16 @@ class _Guppy:
         return GuppyDefinition(defn)
 
     @overload
-    def declare(
+    def declare[**P, T](
         self, /, **kwargs: Unpack[GuppyKwargs]
     ) -> Decorator[Callable[P, T], GuppyFunctionDefinition[P, T]]: ...
 
     @overload
-    def declare(self, f: Callable[P, T], /) -> GuppyFunctionDefinition[P, T]: ...
+    def declare[**P, T](
+        self, f: Callable[P, T], /
+    ) -> GuppyFunctionDefinition[P, T]: ...
 
-    def declare(
+    def declare[**P, T](
         self, *args: Any, **kwargs: Unpack[GuppyKwargs]
     ) -> (
         GuppyFunctionDefinition[P, T]
@@ -465,7 +467,7 @@ class _Guppy:
 
         return _with_optional_kwargs(decorator, args, kwargs)
 
-    def overload(
+    def overload[**P, T](
         self, *funcs: Any
     ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
         """Collects multiple function definitions into one overloaded function.
@@ -533,7 +535,7 @@ class _Guppy:
 
         return decorator
 
-    def constant(self, name: str, ty: str, value: hv.Value) -> T:  # type: ignore[type-var]  # Since we're returning a free type variable
+    def constant[T](self, name: str, ty: str, value: hv.Value) -> T:  # type: ignore[type-var]  # Since we're returning a free type variable
         """Adds a constant to a module, backed by a `hugr.val.Value`."""
         type_ast = _parse_expr_string(
             ty, f"Not a valid Guppy type: `{ty}`", DEF_STORE.sources
@@ -544,7 +546,7 @@ class _Guppy:
         # a `GuppyDefinition` that handles the comptime logic
         return GuppyDefinition(defn)  # type: ignore[return-value]
 
-    def _extern(
+    def _extern[T](
         self,
         name: str,
         ty: str,
@@ -563,7 +565,7 @@ class _Guppy:
         # a `GuppyDefinition` that handles the comptime logic
         return GuppyDefinition(defn)  # type: ignore[return-value]
 
-    def pytket(
+    def pytket[**P, T](
         self, input_circuit: Any
     ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
         """Backs a function declaration by the given pytket circuit. The declaration
@@ -779,7 +781,7 @@ def _find_load_call(sources: SourceMap) -> Span | None:
     return None
 
 
-def _set_firstlineno(cls: builtins.type[T], frame: FrameType) -> builtins.type[T]:
+def _set_firstlineno[T](cls: builtins.type[T], frame: FrameType) -> builtins.type[T]:
     """Helper function to set the `__firstlineno__` attribute on a class if it is not
     already there.
 
@@ -794,7 +796,7 @@ def _set_firstlineno(cls: builtins.type[T], frame: FrameType) -> builtins.type[T
     return cls
 
 
-def custom_guppy_decorator(f: F) -> F:
+def custom_guppy_decorator[F: Callable[..., Any]](f: F) -> F:
     """Decorator to mark user-defined decorators that wrap builtin `guppy` decorators.
 
     Example:
@@ -835,7 +837,7 @@ def get_calling_frame() -> FrameType:
     raise RuntimeError("Couldn't obtain stack frame for definition")
 
 
-def _with_optional_kwargs(
+def _with_optional_kwargs[S, K, T](
     decorator: Callable[[S, K], T], args: tuple[Any, ...], kwargs: K
 ) -> T | Callable[[S], T]:
     """Helper function to define decorators that may be used directly (`@decorator`) but

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -11,7 +11,9 @@ from typing import (
     ParamSpec,
     TypedDict,
     TypeVar,
+    Unpack,
     cast,
+    dataclass_transform,
     overload,
 )
 
@@ -55,7 +57,6 @@ from guppylang_internals.tys.ty import (
     UnitaryFlags,
 )
 from hugr import val as hv
-from typing_extensions import Unpack, dataclass_transform
 
 from guppylang.defs import (
     GuppyDefinition,

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -10,8 +10,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
-    Generic,
-    ParamSpec,
     Protocol,
     TypeVar,
     cast,
@@ -60,10 +58,6 @@ __all__ = (
     "OptimizationLevel",
     "OptimizerInstance",
 )
-
-
-P = ParamSpec("P")
-Out = TypeVar("Out")
 
 
 def _update_generator_metadata(hugr: Hugr[Any]) -> None:
@@ -117,7 +111,7 @@ class GuppyDefinition(TracingDefMixin):
 
     def check(self) -> None:
         """Type-check a Guppy definition."""
-        return ENGINE.check_single(self.id)
+        ENGINE.check_single(self.id)
 
 
 @dataclass(frozen=True)
@@ -216,7 +210,7 @@ class GuppyCompilableProgram(Protocol):
 
 
 @dataclass(frozen=True)
-class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P, Out]):
+class GuppyFunctionDefinition[**P, Out](GuppyDefinition, GuppyCompilableProgram):
     """A Guppy function definition."""
 
     @hide_trace

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -11,8 +11,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
-    Generic,
-    ParamSpec,
     Protocol,
     TypeVar,
     cast,
@@ -66,10 +64,6 @@ __all__ = (
     "OptimizationLevel",
     "OptimizerInstance",
 )
-
-
-P = ParamSpec("P")
-Out = TypeVar("Out")
 
 
 def _update_generator_metadata(hugr: Hugr[Any]) -> None:
@@ -138,7 +132,7 @@ class GuppyDefinition(TracingDefMixin):
 
     def check(self) -> None:
         """Type-check a Guppy definition."""
-        return ENGINE.check_single(self.id)
+        ENGINE.check_single(self.id)
 
 
 @dataclass(frozen=True)
@@ -248,7 +242,7 @@ class GuppyCompilableProgram(Protocol):
 
 
 @dataclass(frozen=True)
-class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P, Out]):
+class GuppyFunctionDefinition[**P, Out](GuppyDefinition, GuppyCompilableProgram):
     """A Guppy function definition."""
 
     @hide_trace

--- a/guppylang/src/guppylang/emulator/builder.py
+++ b/guppylang/src/guppylang/emulator/builder.py
@@ -5,10 +5,9 @@ Compiling and building emulator instances for guppy programs.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Self
 
 import selene_sim
-from typing_extensions import Self
 
 from .instance import EmulatorInstance
 

--- a/guppylang/src/guppylang/emulator/instance.py
+++ b/guppylang/src/guppylang/emulator/instance.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from hugr.qsystem.result import QsysShot
 from selene_argreader_plugin import ArgProvider
@@ -15,7 +15,6 @@ from selene_sim.backends.bundled_runtimes import SimpleRuntime
 from selene_sim.backends.bundled_simulators import Coinflip, Quest, Stim
 from selene_sim.event_hooks import EventHook, NoEventHook
 from tqdm import tqdm
-from typing_extensions import Self
 
 from ._args import (
     ArgValue,

--- a/guppylang/src/guppylang/emulator/state.py
+++ b/guppylang/src/guppylang/emulator/state.py
@@ -5,12 +5,11 @@ Debug querying the internal state of the emulator.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Protocol, TypeVar
+from typing import Protocol, Self, TypeVar
 
 import numpy as np
 import numpy.typing as npt
 from selene_quest_plugin.state import SeleneQuestState, TracedState
-from typing_extensions import Self
 
 __all__ = [
     "NotSingleStateError",

--- a/guppylang/src/guppylang/library.py
+++ b/guppylang/src/guppylang/library.py
@@ -1,11 +1,10 @@
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Self
 
 from guppylang_internals.definition.common import DefId
 from guppylang_internals.engine import DEF_STORE, ENGINE
 from hugr.package import Package
-from typing_extensions import Self
 
 from guppylang.defs import GuppyDefinition, _update_generator_metadata
 

--- a/guppylang/src/guppylang/optimizer.py
+++ b/guppylang/src/guppylang/optimizer.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
-    Generic,
     ParamSpec,
     TypeVar,
 )
@@ -101,7 +100,7 @@ def _apply_passes(package: Package, passes: Sequence[ComposablePass]) -> Package
 
 
 @dataclass(frozen=True)
-class OptimizerInstance(Generic[P, Out]):
+class OptimizerInstance[**P, Out]:
     """Builder used to configure optimizations for compiling a Guppy program."""
 
     definition: GuppyFunctionDefinition[P, Out]

--- a/guppylang/src/guppylang/optimizer.py
+++ b/guppylang/src/guppylang/optimizer.py
@@ -122,7 +122,6 @@ from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import (
     TYPE_CHECKING,
-    Generic,
     ParamSpec,
     TypeVar,
 )
@@ -215,7 +214,7 @@ def _apply_passes(package: Package, passes: Sequence[ComposablePass]) -> Package
 
 
 @dataclass(frozen=True)
-class OptimizerInstance(Generic[P, Out]):
+class OptimizerInstance[**P, Out]:
     """Builder used to configure optimizations for compiling a Guppy program.
 
     Obtained by calling :py:meth:`GuppyFunctionDefinition.with_opt_level` or

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import builtins
 from types import GeneratorType
-from typing import TYPE_CHECKING, Generic, TypeVar, no_type_check
+from typing import TYPE_CHECKING, no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.definition.custom import CopyInoutCompiler
@@ -35,19 +35,13 @@ from guppylang_internals.tys.builtin import array_type_def, frozenarray_type_def
 from guppylang import guppy
 from guppylang.std.err import Result, err, ok
 from guppylang.std.iter import SizedIter
+from guppylang.std.lang import Copy
 from guppylang.std.mem import mem_swap
+from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
 
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
-
-
-T = guppy.type_var("T")
-L = guppy.type_var("L", copyable=False, droppable=False)
-n = guppy.nat_var("n")
-
-_T = TypeVar("_T")
-_n = TypeVar("_n")
 
 
 @extend_type(
@@ -57,18 +51,20 @@ _n = TypeVar("_n")
     # comptime to behave like lists.
     return_class=True,
 )
-class array(builtins.list[_T], Generic[_T, _n]):
+class array[T, n: nat](builtins.list[T]):
     """Sequence of homogeneous values with statically known fixed length."""
 
     @custom_function(ArrayGetitemCompiler(), checker=ArrayIndexChecker())
-    def __getitem__(self: array[L, n], idx: int) -> L: ...
+    def __getitem__[L, n: nat](self: array[L, n], idx: int) -> L: ...
 
     @custom_function(ArraySetitemCompiler(), checker=ArrayIndexChecker())
-    def __setitem__(self: array[L, n], idx: int, value: L @ owned) -> None: ...
+    def __setitem__[L, n: nat](
+        self: array[L, n], idx: int, value: L @ owned
+    ) -> None: ...
 
     @guppy
     @no_type_check
-    def __len__(self: array[L, n]) -> int:
+    def __len__[L, n: nat](self: array[L, n]) -> int:
         return n
 
     @custom_function(NewArrayCompiler(), NewArrayChecker(), higher_order_value=False)
@@ -81,15 +77,15 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def __iter__(self: array[L, n] @ owned) -> SizedIter[ArrayIter[L, n], n]:
+    def __iter__[L, n: nat](self: array[L, n] @ owned) -> SizedIter[ArrayIter[L, n], n]:
         return SizedIter(ArrayIter(self, 0))
 
     @custom_function(CopyInoutCompiler(), ArrayCopyChecker())
-    def copy(self: array[T, n]) -> array[T, n]:
+    def copy[T: Copy, n: nat](self: array[T, n]) -> array[T, n]:
         """Copy an array instance. Will only work if T is a copyable type."""
 
     @custom_function(ArrayIsBorrowedCompiler(), checker=ArrayIndexChecker())
-    def is_borrowed(self: array[L, n], idx: int) -> bool:
+    def is_borrowed[L, n: nat](self: array[L, n], idx: int) -> bool:
         """Checks if an element has been taken out of the array.
 
         This is the case whenever a non-copyable element is borrowed, or when an element
@@ -107,7 +103,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         """
 
     @custom_function(ArrayGetitemCompiler(), checker=ArrayIndexChecker())
-    def take(self: array[L, n], idx: int) -> L:
+    def take[L, n: nat](self: array[L, n], idx: int) -> L:
         """Takes an element out of the array.
 
         While regular indexing into an array only allows borrowing of elements, `take`
@@ -137,7 +133,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def try_take(self: array[L, n], idx: int) -> Option[L]:
+    def try_take[L, n: nat](self: array[L, n], idx: int) -> Option[L]:
         """Tries to take an element out of the array.
 
         While regular indexing into an array only allows borrowing of elements, `take`
@@ -168,7 +164,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
     @custom_function(
         ArraySetitemCompiler(elem_first=True), checker=ArrayIndexChecker(expr_index=2)
     )
-    def put(self: array[L, n], elem: L @ owned, idx: int) -> None:
+    def put[L, n: nat](self: array[L, n], elem: L @ owned, idx: int) -> None:
         """Puts an element back into the array if it has been taken out previously.
 
         This is the complement of `array.take`. It may be used to fill the "hole" left
@@ -192,7 +188,9 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def try_put(self: array[L, n], elem: L @ owned, idx: int) -> Result[None, L]:
+    def try_put[L, n: nat](
+        self: array[L, n], elem: L @ owned, idx: int
+    ) -> Result[None, L]:
         """Tries to put an element back into the array if it has been taken out
         previously.
 
@@ -219,7 +217,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         return ok(None)
 
     @custom_function(ArrayDiscardAllUsedCompiler())
-    def discard_all_taken(self: array[L, n] @ owned) -> None:
+    def discard_all_taken[L, n: nat](self: array[L, n] @ owned) -> None:
         """Discards array assuming that all elements have been taken out, and panics if
         that is not the case.
 
@@ -234,7 +232,9 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def try_discard_all_taken(self: array[L, n] @ owned) -> Result[None, array[L, n]]:
+    def try_discard_all_taken[L, n: nat](
+        self: array[L, n] @ owned,
+    ) -> Result[None, array[L, n]]:
         """Similar to `discard_all_taken`, but instead of panicking returns the
         unmodified array when not all elements have been taken out.
 
@@ -251,7 +251,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         self.discard_all_taken()
         return ok(None)
 
-    def __new__(cls, *args: _T) -> builtins.list[_T]:  # type: ignore[no-redef]
+    def __new__(cls, *args: T) -> builtins.list[T]:  # type: ignore[no-redef]
         # Runtime array constructor that is used for comptime. We return an actual list
         # in line with the comptime unpacking logic that turns arrays into lists.
         if len(args) == 1 and isinstance(args[0], GeneratorType):
@@ -273,7 +273,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
 
 @guppy.struct
-class ArrayIter(Generic[L, n]):
+class ArrayIter[L, n: nat]:
     """Iterator over arrays."""
 
     _xs: array[L, n]
@@ -293,7 +293,7 @@ class ArrayIter(Generic[L, n]):
 
 
 @custom_function(ArraySwapCompiler())
-def array_swap(arr: array[L, n], idx: int, idx2: int) -> None:
+def array_swap[L, n: nat](arr: array[L, n], idx: int, idx2: int) -> None:
     """Swap two elements in an array at indices idx and idx2.
 
     Exchanges the elements at two indices within the array. This operation
@@ -317,11 +317,11 @@ def array_swap(arr: array[L, n], idx: int, idx2: int) -> None:
 
 
 @extend_type(frozenarray_type_def)
-class frozenarray(Generic[T, n]):
+class frozenarray[T, n: nat]:
     """An immutable array of fixed static size."""
 
     @custom_function(FrozenarrayGetitemCompiler())
-    def __getitem__(self: frozenarray[T, n], item: int) -> T: ...  # type: ignore[type-arg]
+    def __getitem__(self: frozenarray[T, n], item: int) -> T: ...
 
     @guppy
     @no_type_check
@@ -341,10 +341,10 @@ class frozenarray(Generic[T, n]):
 
 
 @guppy.struct
-class FrozenarrayIter(Generic[T, n]):
+class FrozenarrayIter[T, n: nat]:
     """Iterator for frozenarrays."""
 
-    _xs: frozenarray[T, n]  # type: ignore[type-arg]
+    _xs: frozenarray[T, n]
     _i: int
 
     @guppy

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import builtins
 from types import GeneratorType
-from typing import TYPE_CHECKING, Generic, TypeVar, no_type_check
+from typing import TYPE_CHECKING, no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.definition.custom import CopyInoutCompiler
@@ -37,19 +37,13 @@ from guppylang_internals.tys.ty import UnitaryFlags
 from guppylang import guppy
 from guppylang.std.err import Result, err, ok
 from guppylang.std.iter import SizedIter
+from guppylang.std.lang import Copy
 from guppylang.std.mem import mem_swap
+from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
 
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
-
-
-T = guppy.type_var("T")
-L = guppy.type_var("L", copyable=False, droppable=False)
-n = guppy.nat_var("n")
-
-_T = TypeVar("_T")
-_n = TypeVar("_n")
 
 
 @extend_type(
@@ -59,24 +53,26 @@ _n = TypeVar("_n")
     # comptime to behave like lists.
     return_class=True,
 )
-class array(builtins.list[_T], Generic[_T, _n]):
+class array[T, n: nat](builtins.list[T]):
     """Sequence of homogeneous values with statically known fixed length."""
 
     @custom_function(
         ArrayGetitemCompiler(),
         checker=ArrayIndexChecker(),
     )
-    def __getitem__(self: array[L, n], idx: int) -> L: ...
+    def __getitem__[L, n: nat](self: array[L, n], idx: int) -> L: ...
 
     @custom_function(
         ArraySetitemCompiler(),
         checker=ArrayIndexChecker(),
     )
-    def __setitem__(self: array[L, n], idx: int, value: L @ owned) -> None: ...
+    def __setitem__[L, n: nat](
+        self: array[L, n], idx: int, value: L @ owned
+    ) -> None: ...
 
     @guppy
     @no_type_check
-    def __len__(self: array[L, n]) -> int:
+    def __len__[L, n: nat](self: array[L, n]) -> int:
         return n
 
     @custom_function(
@@ -94,13 +90,13 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def __iter__(self: array[L, n] @ owned) -> SizedIter[ArrayIter[L, n], n]:
+    def __iter__[L, n: nat](self: array[L, n] @ owned) -> SizedIter[ArrayIter[L, n], n]:
         return SizedIter(ArrayIter(self, 0))
 
     @custom_function(
         CopyInoutCompiler(), ArrayCopyChecker(), unitary_flags=UnitaryFlags.Dagger
     )
-    def copy(self: array[T, n]) -> array[T, n]:
+    def copy[T: Copy, n: nat](self: array[T, n]) -> array[T, n]:
         """Copy an array instance. Will only work if T is a copyable type."""
 
     @custom_function(
@@ -108,7 +104,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         checker=ArrayIndexChecker(),
         unitary_flags=UnitaryFlags.Dagger,
     )
-    def is_borrowed(self: array[L, n], idx: int) -> bool:
+    def is_borrowed[L, n: nat](self: array[L, n], idx: int) -> bool:
         """Checks if an element has been taken out of the array.
 
         This is the case whenever a non-copyable element is borrowed, or when an element
@@ -129,7 +125,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         ArrayGetitemCompiler(),
         checker=ArrayIndexChecker(),
     )
-    def take(self: array[L, n], idx: int) -> L:
+    def take[L, n: nat](self: array[L, n], idx: int) -> L:
         """Takes an element out of the array.
 
         While regular indexing into an array only allows borrowing of elements, `take`
@@ -159,7 +155,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def try_take(self: array[L, n], idx: int) -> Option[L]:
+    def try_take[L, n: nat](self: array[L, n], idx: int) -> Option[L]:
         """Tries to take an element out of the array.
 
         While regular indexing into an array only allows borrowing of elements, `take`
@@ -191,7 +187,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         ArraySetitemCompiler(elem_first=True),
         checker=ArrayIndexChecker(expr_index=2),
     )
-    def put(self: array[L, n], elem: L @ owned, idx: int) -> None:
+    def put[L, n: nat](self: array[L, n], elem: L @ owned, idx: int) -> None:
         """Puts an element back into the array if it has been taken out previously.
 
         This is the complement of `array.take`. It may be used to fill the "hole" left
@@ -215,7 +211,9 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def try_put(self: array[L, n], elem: L @ owned, idx: int) -> Result[None, L]:
+    def try_put[L, n: nat](
+        self: array[L, n], elem: L @ owned, idx: int
+    ) -> Result[None, L]:
         """Tries to put an element back into the array if it has been taken out
         previously.
 
@@ -242,7 +240,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         return ok(None)
 
     @custom_function(ArrayDiscardAllUsedCompiler())
-    def discard_all_taken(self: array[L, n] @ owned) -> None:
+    def discard_all_taken[L, n: nat](self: array[L, n] @ owned) -> None:
         """Discards array assuming that all elements have been taken out, and panics if
         that is not the case.
 
@@ -257,7 +255,9 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
     @guppy
     @no_type_check
-    def try_discard_all_taken(self: array[L, n] @ owned) -> Result[None, array[L, n]]:
+    def try_discard_all_taken[L, n: nat](
+        self: array[L, n] @ owned,
+    ) -> Result[None, array[L, n]]:
         """Similar to `discard_all_taken`, but instead of panicking returns the
         unmodified array when not all elements have been taken out.
 
@@ -274,7 +274,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
         self.discard_all_taken()
         return ok(None)
 
-    def __new__(cls, *args: _T) -> builtins.list[_T]:  # type: ignore[no-redef]
+    def __new__(cls, *args: T) -> builtins.list[T]:  # type: ignore[no-redef]
         # Runtime array constructor that is used for comptime. We return an actual list
         # in line with the comptime unpacking logic that turns arrays into lists.
         if len(args) == 1 and isinstance(args[0], GeneratorType):
@@ -296,7 +296,7 @@ class array(builtins.list[_T], Generic[_T, _n]):
 
 
 @guppy.struct
-class ArrayIter(Generic[L, n]):
+class ArrayIter[L, n: nat]:
     """Iterator over arrays."""
 
     _xs: array[L, n]
@@ -316,7 +316,7 @@ class ArrayIter(Generic[L, n]):
 
 
 @custom_function(ArraySwapCompiler())
-def array_swap(arr: array[L, n], idx: int, idx2: int) -> None:
+def array_swap[L, n: nat](arr: array[L, n], idx: int, idx2: int) -> None:
     """Swap two elements in an array at indices idx and idx2.
 
     Exchanges the elements at two indices within the array. This operation
@@ -340,7 +340,7 @@ def array_swap(arr: array[L, n], idx: int, idx2: int) -> None:
 
 
 @extend_type(frozenarray_type_def)
-class frozenarray(Generic[T, n]):
+class frozenarray[T, n: nat]:
     """An immutable array of fixed static size."""
 
     # Panics on out-of-range.
@@ -348,7 +348,7 @@ class frozenarray(Generic[T, n]):
         FrozenarrayGetitemCompiler(),
         effects=[Effect.ANY],
     )
-    def __getitem__(self: frozenarray[T, n], item: int) -> T: ...  # type: ignore[type-arg]
+    def __getitem__(self: frozenarray[T, n], item: int) -> T: ...
 
     @guppy
     @no_type_check
@@ -368,10 +368,10 @@ class frozenarray(Generic[T, n]):
 
 
 @guppy.struct
-class FrozenarrayIter(Generic[T, n]):
+class FrozenarrayIter[T, n: nat]:
     """Iterator for frozenarrays."""
 
-    _xs: frozenarray[T, n]  # type: ignore[type-arg]
+    _xs: frozenarray[T, n]
     _i: int
 
     @guppy

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -37,13 +37,18 @@ from guppylang_internals.tys.ty import UnitaryFlags
 from guppylang import guppy
 from guppylang.std.err import Result, err, ok
 from guppylang.std.iter import SizedIter
-from guppylang.std.lang import Copy
+from guppylang.std.lang import Copy, Drop
 from guppylang.std.mem import mem_swap
 from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
 
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
+
+
+T = guppy.type_var("T")
+n = guppy.nat_var("n")
+L = guppy.type_var("L", copyable=False, droppable=False)
 
 
 @extend_type(
@@ -348,27 +353,27 @@ class frozenarray[T, n: nat]:
         FrozenarrayGetitemCompiler(),
         effects=[Effect.ANY],
     )
-    def __getitem__(self: frozenarray[T, n], item: int) -> T: ...
+    def __getitem__(self, item: int) -> T: ...
 
     @guppy
     @no_type_check
-    def __len__(self: frozenarray[T, n]) -> int:
+    def __len__(self) -> int:
         return n
 
     @guppy
     @no_type_check
-    def __iter__(self: frozenarray[T, n]) -> SizedIter[FrozenarrayIter[T, n], n]:
+    def __iter__(self) -> SizedIter[FrozenarrayIter[T, n], n]:
         return SizedIter(FrozenarrayIter(self, 0))
 
     @guppy
     @no_type_check
-    def mutable_copy(self: frozenarray[T, n]) -> array[T, n]:
+    def mutable_copy(self) -> array[T, n]:
         """Creates a mutable copy of this array."""
         return array(x for x in self)
 
 
 @guppy.struct
-class FrozenarrayIter[T, n: nat]:
+class FrozenarrayIter[T: (Copy, Drop), n: nat]:
     """Iterator for frozenarrays."""
 
     _xs: frozenarray[T, n]

--- a/guppylang/src/guppylang/std/collections/priority_queue.py
+++ b/guppylang/src/guppylang/std/collections/priority_queue.py
@@ -1,18 +1,15 @@
 from __future__ import annotations
 
-from typing import Generic, Self, no_type_check
+from typing import Self, no_type_check
 
 from guppylang.decorator import guppy
 from guppylang.std.builtins import array, owned, panic
+from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
-
-T = guppy.type_var("T", copyable=False, droppable=False)
-TCopyable = guppy.type_var("TCopyable", copyable=True, droppable=False)
-MAX_SIZE = guppy.nat_var("MAX_SIZE")
 
 
 @guppy.struct
-class PriorityQueue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
+class PriorityQueue[T, MAX_SIZE: nat]:
     """A queue of values ordered by priority.
 
     Values with the lowest priority value will be popped from the queue first.
@@ -28,7 +25,7 @@ class PriorityQueue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
     #:
     #: INVARIANT: All array elements up to and including index `self._size - 1` are
     #: `option.some` variants and all further ones are `option.nothing`.
-    _buf: array[Option[tuple[int, T]], MAX_SIZE]  # type: ignore[valid-type, type-arg]
+    _buf: array[Option[tuple[int, T]], MAX_SIZE]
 
     #: Index of the next free index in `self._buf`.
     _size: int
@@ -64,7 +61,7 @@ class PriorityQueue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
         Panics if the priority queue has already reached its maximum size.
         """
-        if self._size >= MAX_SIZE:
+        if self._size >= MAX_SIZE:  # type: ignore[misc]
             panic("PriorityQueue.push: max size reached")
         self._buf[self._size].swap(some((priority, value))).unwrap_nothing()
         i = self._size
@@ -131,7 +128,7 @@ class PriorityQueue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
     @guppy
     @no_type_check
-    def peek(self: PriorityQueue[TCopyable, MAX_SIZE] @ owned) -> tuple[int, TCopyable]:
+    def peek[TC: Copy](self: PriorityQueue[TC, MAX_SIZE] @ owned) -> tuple[int, TC]:
         """Returns a copy of the next element in the priority queue without removing it.
 
         Panics if the priority queue is empty.
@@ -160,7 +157,7 @@ class PriorityQueue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
 @guppy
 @no_type_check
-def empty_priority_queue() -> PriorityQueue[T, MAX_SIZE]:
+def empty_priority_queue[T, MAX_SIZE: nat]() -> PriorityQueue[T, MAX_SIZE]:
     """Constructs a new empty priority queue."""
-    buf = array(nothing[tuple[int, T]]() for _ in range(MAX_SIZE))  # type: ignore[valid-type]
+    buf = array(nothing[tuple[int, T]]() for _ in range(MAX_SIZE))  # type: ignore[name-defined]
     return PriorityQueue(buf, 0)

--- a/guppylang/src/guppylang/std/collections/priority_queue.py
+++ b/guppylang/src/guppylang/std/collections/priority_queue.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import Generic, no_type_check
-
-from typing_extensions import Self
+from typing import Generic, Self, no_type_check
 
 from guppylang.decorator import guppy
 from guppylang.std.builtins import array, owned, panic

--- a/guppylang/src/guppylang/std/collections/priority_queue.py
+++ b/guppylang/src/guppylang/std/collections/priority_queue.py
@@ -7,6 +7,10 @@ from guppylang.std.builtins import array, owned, panic
 from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
 
+T = guppy.type_var("T", copyable=False, droppable=False)
+TCopyable = guppy.type_var("TCopyable", copyable=True, droppable=False)
+MAX_SIZE = guppy.nat_var("MAX_SIZE")
+
 
 @guppy.struct
 class PriorityQueue[T, MAX_SIZE: nat]:
@@ -157,7 +161,7 @@ class PriorityQueue[T, MAX_SIZE: nat]:
 
 @guppy
 @no_type_check
-def empty_priority_queue[T, MAX_SIZE: nat]() -> PriorityQueue[T, MAX_SIZE]:
+def empty_priority_queue() -> PriorityQueue[T, MAX_SIZE]:
     """Constructs a new empty priority queue."""
-    buf = array(nothing[tuple[int, T]]() for _ in range(MAX_SIZE))  # type: ignore[name-defined]
+    buf = array(nothing[tuple[int, T]]() for _ in range(MAX_SIZE))  # type: ignore[valid-type]
     return PriorityQueue(buf, 0)

--- a/guppylang/src/guppylang/std/collections/queue.py
+++ b/guppylang/src/guppylang/std/collections/queue.py
@@ -1,22 +1,19 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Self, no_type_check
+from typing import TYPE_CHECKING, Self, no_type_check
 
 from guppylang.decorator import guppy
 from guppylang.std.array import array
+from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
 from guppylang.std.platform import panic
 
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
 
-T = guppy.type_var("T", copyable=False, droppable=False)
-TCopyable = guppy.type_var("TCopyable", copyable=True, droppable=False)
-MAX_SIZE = guppy.nat_var("MAX_SIZE")
-
 
 @guppy.struct
-class Queue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
+class Queue[T, MAX_SIZE: nat]:
     """A first-in-first-out (FIFO) growable collection of values.
 
     To ensure static allocation, the maximum queue size must be specified in advance
@@ -38,7 +35,7 @@ class Queue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
     #: Without this, then the queue would be limited to MAX_SIZE - 1 since
     #: we cannot distinguish completely full and completely empty states
     #: with just using `self._start` and `self._end`.
-    _buf: array[Option[T], MAX_SIZE]  # type: ignore[valid-type, type-arg]
+    _buf: array[Option[T], MAX_SIZE]
     #: Index of the current front of the queue (first element to be popped).
     _start: int
     #: Index of the next free slot in `self._buf`.
@@ -74,10 +71,10 @@ class Queue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
         Panics if the queue has already reached its maximum size.
         """
-        if self._size >= MAX_SIZE:
+        if self._size >= MAX_SIZE:  # type: ignore[misc]
             panic("Queue.push: max size reached")
         self._buf[self._end].swap(some(elem)).unwrap_nothing()
-        self._end = (self._end + 1) % MAX_SIZE
+        self._end = (self._end + 1) % MAX_SIZE  # type: ignore[misc]
         self._size += 1
 
     @guppy
@@ -91,13 +88,13 @@ class Queue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
         if self._size == 0:
             panic("Queue.pop: queue is empty")
         elem = self._buf[self._start].take().unwrap()
-        self._start = (self._start + 1) % MAX_SIZE
+        self._start = (self._start + 1) % MAX_SIZE  # type: ignore[misc]
         self._size -= 1
         return elem
 
     @guppy
     @no_type_check
-    def peek(self: Queue[TCopyable, MAX_SIZE] @ owned) -> TCopyable:
+    def peek[TC: Copy](self: Queue[TC, MAX_SIZE] @ owned) -> TC:
         """Returns a copy of the top element of the queue without removing it.
 
         Panics if the queue is empty.
@@ -125,7 +122,7 @@ class Queue(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
 @guppy
 @no_type_check
-def empty_queue() -> Queue[T, MAX_SIZE]:
+def empty_queue[T, MAX_SIZE: nat]() -> Queue[T, MAX_SIZE]:
     """Constructs a new empty queue."""
-    buf = array(nothing[T]() for _ in range(MAX_SIZE))
+    buf = array(nothing[T]() for _ in range(MAX_SIZE))  # type: ignore[name-defined]
     return Queue(buf, 0, 0, 0)

--- a/guppylang/src/guppylang/std/collections/queue.py
+++ b/guppylang/src/guppylang/std/collections/queue.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, no_type_check
-
-from typing_extensions import Self
+from typing import TYPE_CHECKING, Generic, Self, no_type_check
 
 from guppylang.decorator import guppy
 from guppylang.std.array import array

--- a/guppylang/src/guppylang/std/collections/queue.py
+++ b/guppylang/src/guppylang/std/collections/queue.py
@@ -11,6 +11,10 @@ from guppylang.std.platform import panic
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
 
+T = guppy.type_var("T", copyable=False, droppable=False)
+TCopyable = guppy.type_var("TCopyable", copyable=True, droppable=False)
+MAX_SIZE = guppy.nat_var("MAX_SIZE")
+
 
 @guppy.struct
 class Queue[T, MAX_SIZE: nat]:
@@ -124,5 +128,5 @@ class Queue[T, MAX_SIZE: nat]:
 @no_type_check
 def empty_queue[T, MAX_SIZE: nat]() -> Queue[T, MAX_SIZE]:
     """Constructs a new empty queue."""
-    buf = array(nothing[T]() for _ in range(MAX_SIZE))  # type: ignore[name-defined]
+    buf = array(nothing[T]() for _ in range(MAX_SIZE))
     return Queue(buf, 0, 0, 0)

--- a/guppylang/src/guppylang/std/collections/queue.py
+++ b/guppylang/src/guppylang/std/collections/queue.py
@@ -108,7 +108,7 @@ class Queue[T, MAX_SIZE: nat]:
 
     @guppy
     @no_type_check
-    def discard_empty(self: Queue[T, MAX_SIZE] @ owned) -> None:
+    def discard_empty(self: Self @ owned) -> None:
         """Discards a queue of potentially non-droppable elements assuming that the
         queue is empty.
 

--- a/guppylang/src/guppylang/std/collections/stack.py
+++ b/guppylang/src/guppylang/std/collections/stack.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, Self, no_type_check
+from typing import TYPE_CHECKING, Self, no_type_check
 
 from guppylang_internals.std._internal.moved import (
     produce_moved_class,
@@ -9,19 +9,16 @@ from guppylang_internals.std._internal.moved import (
 
 from guppylang.decorator import guppy
 from guppylang.std.array import array
+from guppylang.std.num import nat
 from guppylang.std.option import Option, nothing, some
 from guppylang.std.platform import panic
 
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
 
-T = guppy.type_var("T", copyable=False, droppable=False)
-TCopyable = guppy.type_var("TCopyable", copyable=True, droppable=False)
-MAX_SIZE = guppy.nat_var("MAX_SIZE")
-
 
 @guppy.struct
-class Stack(Generic[T, MAX_SIZE]):  # type: ignore[misc]
+class Stack[T, MAX_SIZE: nat]:
     """A last-in-first-out (LIFO) growable collection of values.
 
     To ensure static allocation, the maximum stack size must be specified in advance and
@@ -35,7 +32,7 @@ class Stack(Generic[T, MAX_SIZE]):  # type: ignore[misc]
     #:
     #: INVARIANT: All array elements up to and including index `self._end - 1` are
     #: `option.some` variants and all further ones are `option.nothing`.
-    _buf: array[Option[T], MAX_SIZE]  # type: ignore[valid-type, type-arg]
+    _buf: array[Option[T], MAX_SIZE]
 
     #: Index of the next free index in `self._buf`.
     _end: int
@@ -68,7 +65,7 @@ class Stack(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
         Panics if the stack has already reached its maximum size.
         """
-        if self._end >= MAX_SIZE:
+        if self._end >= MAX_SIZE:  # type: ignore[misc]
             panic("Stack.push: max size reached")
         self._buf[self._end].swap(some(elem)).unwrap_nothing()
         self._end += 1
@@ -89,7 +86,7 @@ class Stack(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
     @guppy
     @no_type_check
-    def peek(self: Stack[TCopyable, MAX_SIZE] @ owned) -> TCopyable:
+    def peek[TC: Copy](self: Stack[TC, MAX_SIZE] @ owned) -> TC:
         """Returns a copy of the top element of the stack without removing it.
 
         Panics if the stack is empty.
@@ -116,9 +113,9 @@ class Stack(Generic[T, MAX_SIZE]):  # type: ignore[misc]
 
 @guppy
 @no_type_check
-def empty_stack() -> Stack[T, MAX_SIZE]:
+def empty_stack[T, MAX_SIZE: nat]() -> Stack[T, MAX_SIZE]:
     """Constructs a new empty stack."""
-    buf = array(nothing[T]() for _ in range(MAX_SIZE))
+    buf = array(nothing[T]() for _ in range(MAX_SIZE))  # type: ignore[name-defined]
     return Stack(buf, 0)
 
 

--- a/guppylang/src/guppylang/std/collections/stack.py
+++ b/guppylang/src/guppylang/std/collections/stack.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic, no_type_check
+from typing import TYPE_CHECKING, Generic, Self, no_type_check
 
 from guppylang_internals.std._internal.moved import (
     produce_moved_class,
     produce_moved_function,
 )
-from typing_extensions import Self
 
 from guppylang.decorator import guppy
 from guppylang.std.array import array

--- a/guppylang/src/guppylang/std/collections/stack.py
+++ b/guppylang/src/guppylang/std/collections/stack.py
@@ -16,6 +16,10 @@ from guppylang.std.platform import panic
 if TYPE_CHECKING:
     from guppylang.std.lang import owned
 
+T = guppy.type_var("T", copyable=False, droppable=False)
+TCopyable = guppy.type_var("TCopyable", copyable=True, droppable=False)
+MAX_SIZE = guppy.nat_var("MAX_SIZE")
+
 
 @guppy.struct
 class Stack[T, MAX_SIZE: nat]:
@@ -115,7 +119,7 @@ class Stack[T, MAX_SIZE: nat]:
 @no_type_check
 def empty_stack[T, MAX_SIZE: nat]() -> Stack[T, MAX_SIZE]:
     """Constructs a new empty stack."""
-    buf = array(nothing[T]() for _ in range(MAX_SIZE))  # type: ignore[name-defined]
+    buf = array(nothing[T]() for _ in range(MAX_SIZE))
     return Stack(buf, 0)
 
 

--- a/guppylang/src/guppylang/std/collections/stack.py
+++ b/guppylang/src/guppylang/std/collections/stack.py
@@ -99,7 +99,7 @@ class Stack[T, MAX_SIZE: nat]:
 
     @guppy
     @no_type_check
-    def discard_empty(self: Stack[T, MAX_SIZE] @ owned) -> None:
+    def discard_empty(self: Self @ owned) -> None:
         """Discards a stack of potentially non-droppable elements assuming that the
         stack is empty.
 

--- a/guppylang/src/guppylang/std/either.py
+++ b/guppylang/src/guppylang/std/either.py
@@ -3,7 +3,7 @@
 Type `Either[L, R]` represents a value of either typr `L` ("left") or `R` ("right").
 """
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type
 from guppylang_internals.std._internal.compiler.either import (
@@ -19,15 +19,13 @@ from guppylang import guppy
 from guppylang.std.lang import owned
 from guppylang.std.option import Option
 
-L = guppy.type_var("L", copyable=False, droppable=False)
-R = guppy.type_var("R", copyable=False, droppable=False)
 Droppable = guppy.type_var("Droppable", copyable=False, droppable=True)
 
 _params = [TypeParam(0, "L", False, False), TypeParam(1, "L", False, False)]
 
 
 @custom_type(either_to_hugr, params=_params)
-class Either(Generic[L, R]):  # type: ignore[misc]
+class Either[L, R]:
     """Represents a union of either a `left` or a `right` value."""
 
     @custom_function(EitherTestCompiler(0))
@@ -77,11 +75,11 @@ class Either(Generic[L, R]):  # type: ignore[misc]
 
 @custom_function(EitherConstructor(0))
 @no_type_check
-def left(val: L @ owned) -> Either[L, R]:
+def left[L, R](val: L @ owned) -> Either[L, R]:
     """Constructs a `left` either value."""
 
 
 @custom_function(EitherConstructor(1))
 @no_type_check
-def right(val: R @ owned) -> Either[L, R]:
+def right[L, R](val: R @ owned) -> Either[L, R]:
     """Constructs a `right` either value."""

--- a/guppylang/src/guppylang/std/either.py
+++ b/guppylang/src/guppylang/std/either.py
@@ -20,8 +20,6 @@ from guppylang import guppy
 from guppylang.std.lang import owned
 from guppylang.std.option import Option
 
-L = guppy.type_var("L", copyable=False, droppable=False)
-R = guppy.type_var("R", copyable=False, droppable=False)
 Droppable = guppy.type_var("Droppable", copyable=False, droppable=True)
 
 _params = [TypeParam(0, "L", False, False), TypeParam(1, "L", False, False)]
@@ -78,7 +76,7 @@ class Either[L, R]:
 
 @custom_function(EitherConstructor(0), unitary_flags=UnitaryFlags.Dagger)
 @no_type_check
-def left(val: L @ owned) -> Either[L, R]:
+def left[L, R](val: L @ owned) -> Either[L, R]:
     """Constructs a `left` either value."""
 
 

--- a/guppylang/src/guppylang/std/either.py
+++ b/guppylang/src/guppylang/std/either.py
@@ -20,9 +20,11 @@ from guppylang import guppy
 from guppylang.std.lang import owned
 from guppylang.std.option import Option
 
+L = guppy.type_var("L", copyable=False, droppable=False)
+R = guppy.type_var("R", copyable=False, droppable=False)
 Droppable = guppy.type_var("Droppable", copyable=False, droppable=True)
 
-_params = [TypeParam(0, "L", False, False), TypeParam(1, "L", False, False)]
+_params = [TypeParam(0, "L", False, False), TypeParam(1, "R", False, False)]
 
 
 @custom_type(either_to_hugr, params=_params)

--- a/guppylang/src/guppylang/std/err.py
+++ b/guppylang/src/guppylang/std/err.py
@@ -1,6 +1,6 @@
 """Error handling with the `Result` type."""
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type
 from guppylang_internals.definition.custom import NoopCompiler
@@ -23,7 +23,7 @@ _params = [TypeParam(0, "T", False, False), TypeParam(1, "E", False, False)]
 
 
 @custom_type(either_to_hugr, params=_params)
-class Result(Generic[T, E]):  # type: ignore[misc]
+class Result[T, E]:
     """Represents a union of either an `ok(T)` or an `err(E)` value."""
 
     @custom_function(EitherTestCompiler(0))

--- a/guppylang/src/guppylang/std/futures.py
+++ b/guppylang/src/guppylang/std/futures.py
@@ -1,21 +1,18 @@
 """Guppy standard library for future type and its operations"""
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_type, hugr_op
 from guppylang_internals.std._internal.compiler.futures import future_op, future_to_hugr
 from guppylang_internals.tys.param import TypeParam
 
-from guppylang import guppy
 from guppylang.std.lang import owned
-
-T = guppy.type_var("T", copyable=False, droppable=False)
 
 _future_params = [TypeParam(0, "T", must_be_copyable=False, must_be_droppable=False)]
 
 
 @custom_type(future_to_hugr, copyable=False, droppable=False, params=_future_params)
-class Future(Generic[T]):  # type: ignore[misc]
+class Future[T]:
     """A value of type `T` that is computed asynchronously."""
 
     @hugr_op(future_op("Read"))

--- a/guppylang/src/guppylang/std/futures.py
+++ b/guppylang/src/guppylang/std/futures.py
@@ -6,8 +6,10 @@ from guppylang_internals.decorator import custom_type, hugr_op
 from guppylang_internals.std._internal.compiler.futures import future_op, future_to_hugr
 from guppylang_internals.tys.param import TypeParam
 
+from guppylang import guppy
 from guppylang.std.lang import owned
 
+T = guppy.type_var("T")
 _future_params = [TypeParam(0, "T", must_be_copyable=False, must_be_droppable=False)]
 
 

--- a/guppylang/src/guppylang/std/futures.py
+++ b/guppylang/src/guppylang/std/futures.py
@@ -9,7 +9,7 @@ from guppylang_internals.tys.param import TypeParam
 from guppylang import guppy
 from guppylang.std.lang import owned
 
-T = guppy.type_var("T")
+T = guppy.type_var("T", copyable=False, droppable=False)
 _future_params = [TypeParam(0, "T", must_be_copyable=False, must_be_droppable=False)]
 
 

--- a/guppylang/src/guppylang/std/iter.py
+++ b/guppylang/src/guppylang/std/iter.py
@@ -4,12 +4,11 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, no_type_check
+from typing import TYPE_CHECKING, Any, Self, no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.definition.custom import NoopCompiler
 from guppylang_internals.tys.builtin import sized_iter_type_def
-from typing_extensions import Self
 
 from guppylang import guppy
 from guppylang.std.option import Option, nothing, some

--- a/guppylang/src/guppylang/std/lang.py
+++ b/guppylang/src/guppylang/std/lang.py
@@ -1,11 +1,9 @@
 """Provides Python objects for builtin language keywords."""
 
 from collections.abc import Callable, Generator
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol
 
 from guppylang_internals.error import GuppyComptimeError
-
-T = TypeVar("T")
 
 _MODIFIER_COMPTIME_ERROR = (
     "The `{modifier}` modifier is not supported in comptime functions"
@@ -15,7 +13,7 @@ _MODIFIER_COMPTIME_ERROR = (
 class _Comptime:
     """Dummy class to support `@comptime` annotations and `comptime(...)` expressions"""
 
-    def __call__(self, v: T) -> T:
+    def __call__[T](self, v: T) -> T:
         return v
 
     def __rmatmul__(self, other: Any) -> Any:
@@ -70,23 +68,19 @@ def power(*args: Any, **kwargs: Any) -> Generator[None]:
     raise GuppyComptimeError(_MODIFIER_COMPTIME_ERROR.format(modifier="power"))
 
 
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-class Unitary(Generic[P, R]):
+class Unitary[**P, R]:
     if TYPE_CHECKING:
 
         def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
 
 
-class Daggerable(Generic[P, R]):
+class Daggerable[**P, R]:
     if TYPE_CHECKING:
 
         def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
 
 
-class Controllable(Generic[P, R]):
+class Controllable[**P, R]:
     if TYPE_CHECKING:
 
         def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...

--- a/guppylang/src/guppylang/std/lang.py
+++ b/guppylang/src/guppylang/std/lang.py
@@ -1,11 +1,9 @@
 """Provides Python objects for builtin language keywords."""
 
 from collections.abc import Callable, Generator
-from typing import TYPE_CHECKING, Any, Generic, ParamSpec, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol
 
 from guppylang_internals.error import GuppyComptimeError
-
-T = TypeVar("T")
 
 _MODIFIER_COMPTIME_ERROR = (
     "The `{modifier}` modifier is not supported in comptime functions"
@@ -15,7 +13,7 @@ _MODIFIER_COMPTIME_ERROR = (
 class _Comptime:
     """Dummy class to support `@comptime` annotations and `comptime(...)` expressions"""
 
-    def __call__(self, v: T) -> T:
+    def __call__[T](self, v: T) -> T:
         return v
 
     def __rmatmul__(self, other: Any) -> Any:
@@ -75,23 +73,19 @@ def power(*args: Any, **kwargs: Any) -> Generator[None]:
     raise GuppyComptimeError(_MODIFIER_COMPTIME_ERROR.format(modifier="power"))
 
 
-P = ParamSpec("P")
-R = TypeVar("R")
-
-
-class Unitary(Generic[P, R]):
+class Unitary[**P, R]:
     if TYPE_CHECKING:
 
         def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
 
 
-class Daggerable(Generic[P, R]):
+class Daggerable[**P, R]:
     if TYPE_CHECKING:
 
         def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...
 
 
-class Controllable(Generic[P, R]):
+class Controllable[**P, R]:
     if TYPE_CHECKING:
 
         def __call__(self, *args: P.args, **kwargs: P.kwargs) -> R: ...

--- a/guppylang/src/guppylang/std/lang.py
+++ b/guppylang/src/guppylang/std/lang.py
@@ -1,9 +1,11 @@
 """Provides Python objects for builtin language keywords."""
 
 from collections.abc import Callable, Generator
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, ParamSpec, Protocol, TypeVar
 
 from guppylang_internals.error import GuppyComptimeError
+
+T = TypeVar("T")
 
 _MODIFIER_COMPTIME_ERROR = (
     "The `{modifier}` modifier is not supported in comptime functions"
@@ -71,6 +73,10 @@ def power(*args: Any, **kwargs: Any) -> Generator[None]:
         ``power`` is an experimental feature and is not fully operational yet.
     """
     raise GuppyComptimeError(_MODIFIER_COMPTIME_ERROR.format(modifier="power"))
+
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class Unitary[**P, R]:

--- a/guppylang/src/guppylang/std/list.py
+++ b/guppylang/src/guppylang/std/list.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generic
+from typing import TYPE_CHECKING
 
 from guppylang_internals.decorator import custom_function, extend_type, hugr_op
 from guppylang_internals.definition.custom import NoopCompiler
@@ -32,7 +32,7 @@ L = guppy.type_var("L", copyable=False, droppable=False)
 
 
 @extend_type(list_type_def)
-class list(Generic[T]):
+class list[T]:
     """Mutable sequence items with homogeneous types."""
 
     @custom_function(ListGetitemCompiler())

--- a/guppylang/src/guppylang/std/option.py
+++ b/guppylang/src/guppylang/std/option.py
@@ -1,6 +1,6 @@
 """Guppy standard library for option type and its operations"""
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.std._internal.compiler.option import (
@@ -19,7 +19,7 @@ L = guppy.type_var("T", copyable=False, droppable=False)
 
 
 @extend_type(option_type_def)
-class Option(Generic[L]):  # type: ignore[misc]
+class Option[L]:
     """Represents an optional value."""
 
     @custom_function(OptionTestCompiler(0))

--- a/guppylang/src/guppylang/std/option.py
+++ b/guppylang/src/guppylang/std/option.py
@@ -1,6 +1,6 @@
 """Guppy standard library for option type and its operations"""
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, extend_type
 from guppylang_internals.std._internal.compiler.option import (
@@ -21,7 +21,7 @@ L = guppy.type_var("T", copyable=False, droppable=False)
 
 
 @extend_type(option_type_def)
-class Option(Generic[L]):  # type: ignore[misc]
+class Option[L]:
     """Represents an optional value."""
 
     @custom_function(OptionTestCompiler(0), unitary_flags=UnitaryFlags.Dagger)

--- a/guppylang/src/guppylang/std/qsystem/_common.py
+++ b/guppylang/src/guppylang/std/qsystem/_common.py
@@ -25,7 +25,7 @@ class MaybeLeaked:  # type: ignore[misc]  # Error for Python < 3.13
     return a boolean measurement result or indicate that the qubit has leaked.
     """
 
-    _measurement: Future[int]  # type: ignore[type-arg]
+    _measurement: Future[int]
 
     @guppy
     @no_type_check

--- a/guppylang/src/guppylang/std/qsystem/random.py
+++ b/guppylang/src/guppylang/std/qsystem/random.py
@@ -2,7 +2,7 @@
 discrete probability distributions."""
 
 # mypy: disable-error-code="no-any-return"
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type, hugr_op
 from guppylang_internals.std._internal.compiler.qsystem import (
@@ -21,12 +21,11 @@ from guppylang import guppy
 from guppylang.std.angles import angle, pi
 from guppylang.std.array import array_swap
 from guppylang.std.builtins import array, owned, panic
+from guppylang.std.num import nat
 from guppylang.std.option import Option
 
 SHUFFLE_N = guppy.nat_var("SHUFFLE_N")
 SHUFFLE_T = guppy.type_var("SHUFFLE_T", copyable=False, droppable=False)
-
-DISCRETE_N = guppy.nat_var("DISCRETE_N")
 
 
 @hugr_op(external_op("NewRNGContext", [], ext=QSYSTEM_RANDOM_EXTENSION))
@@ -100,7 +99,7 @@ class RNG:
 
 
 @guppy.struct(frozen=True)
-class DiscreteDistribution(Generic[DISCRETE_N]):  # type: ignore[misc]
+class DiscreteDistribution[DISCRETE_N: nat]:  # type: ignore[misc]
     """A generic probability distribution over a set of the form {0, 1, ..., N-1}.
 
     Objects of this class should be generated using
@@ -109,7 +108,7 @@ class DiscreteDistribution(Generic[DISCRETE_N]):  # type: ignore[misc]
 
     # The `sums` array represents the cumulative probability distribution. That is,
     # sums[i] is the probability of drawing a value <= i from the distribution.
-    _sums: array[float, DISCRETE_N]  # type: ignore[valid-type]
+    _sums: array[float, DISCRETE_N]
 
     @guppy
     @no_type_check
@@ -132,7 +131,7 @@ class DiscreteDistribution(Generic[DISCRETE_N]):  # type: ignore[misc]
 
 @guppy
 @no_type_check
-def make_discrete_distribution(
+def make_discrete_distribution[DISCRETE_N: nat](
     weights: array[float, DISCRETE_N],
 ) -> DiscreteDistribution[DISCRETE_N]:
     """Construct a discrete probability distribution over the set
@@ -146,10 +145,10 @@ def make_discrete_distribution(
         W += w
     if W == 0.0:
         panic("No positive weights included in discrete distribution.")
-    sums = array(0.0 for _ in range(DISCRETE_N))
+    sums = array(0.0 for _ in range(DISCRETE_N))  # type:ignore[name-defined]
     s = 0.0
-    for i in range(DISCRETE_N - 1):
+    for i in range(DISCRETE_N - 1):  # type:ignore[name-defined]
         s += weights[i]
         sums[i] = s / W
-    sums[DISCRETE_N - 1] = 1.0
+    sums[DISCRETE_N - 1] = 1.0  # type:ignore[name-defined]
     return DiscreteDistribution(sums)

--- a/guppylang/src/guppylang/std/qsystem/random.py
+++ b/guppylang/src/guppylang/std/qsystem/random.py
@@ -112,7 +112,7 @@ class DiscreteDistribution[DISCRETE_N: nat]:  # type: ignore[misc]
 
     @guppy
     @no_type_check
-    def sample(self: "DiscreteDistribution[DISCRETE_N]", rng: RNG) -> int:
+    def sample(self, rng: RNG) -> int:
         """Return a sample value from the distribution, using the provided
         :py:class:`RNG`.
         """

--- a/guppylang/src/guppylang/std/qsystem/random.py
+++ b/guppylang/src/guppylang/std/qsystem/random.py
@@ -27,6 +27,8 @@ from guppylang.std.option import Option
 SHUFFLE_N = guppy.nat_var("SHUFFLE_N")
 SHUFFLE_T = guppy.type_var("SHUFFLE_T", copyable=False, droppable=False)
 
+DISCRETE_N = guppy.nat_var("DISCRETE_N")
+
 
 @hugr_op(external_op("NewRNGContext", [], ext=QSYSTEM_RANDOM_EXTENSION))
 @no_type_check
@@ -145,10 +147,10 @@ def make_discrete_distribution[DISCRETE_N: nat](
         W += w
     if W == 0.0:
         panic("No positive weights included in discrete distribution.")
-    sums = array(0.0 for _ in range(DISCRETE_N))  # type:ignore[name-defined]
+    sums = array(0.0 for _ in range(DISCRETE_N))
     s = 0.0
-    for i in range(DISCRETE_N - 1):  # type:ignore[name-defined]
+    for i in range(DISCRETE_N - 1):
         s += weights[i]
         sums[i] = s / W
-    sums[DISCRETE_N - 1] = 1.0  # type:ignore[name-defined]
+    sums[DISCRETE_N - 1] = 1.0
     return DiscreteDistribution(sums)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ test = [
 ]
 
 [tool.uv]
-prerelease = "if-necessary"
+prerelease = "if-necessary-or-explicit"
 
 [tool.uv.workspace]
 members = ["guppylang", "guppylang-internals", "miette-py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ test = [
 ]
 
 [tool.uv]
-prerelease = "if-necessary-or-explicit"
+prerelease = "if-necessary"
 
 [tool.uv.workspace]
 members = ["guppylang", "guppylang-internals", "miette-py"]

--- a/ruff.toml
+++ b/ruff.toml
@@ -83,9 +83,6 @@ ignore = [
 "scripts/release/*" = ["T201"]                                        # CLI scripts print to stdout
 "__init__.py" = ["F401"]                                              # module imported but unused
 
-[per-file-target-version]
-"guppylang/src/guppylang/std/*" = "py310"
-
 # [pydocstyle]
 # convention = "google"
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 # See https://docs.astral.sh/ruff/rules/
-target-version = "py310"
+target-version = "py312"
 
 line-length = 88
 
@@ -84,7 +84,7 @@ ignore = [
 "__init__.py" = ["F401"]                                              # module imported but unused
 
 [per-file-target-version]
-"tests/*/*_py312.py" = "py312"
+"guppylang/src/guppylang/std/*" = "py310"
 
 # [pydocstyle]
 # convention = "google"

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 # See https://docs.astral.sh/ruff/rules/
-target-version = "py310"
+target-version = "py312"
 
 line-length = 88
 
@@ -84,9 +84,7 @@ ignore = [
 "__init__.py" = ["F401"]                                              # module imported but unused
 
 [per-file-target-version]
-"tests/*/*_py312.py" = "py312"
-"guppylang/src/guppylang/std/either.py" = "py312"
-"guppylang/src/guppylang/std/err.py" = "py312"
+"guppylang/src/guppylang/std/*" = "py310"
 
 # [pydocstyle]
 # convention = "google"

--- a/scripts/release/compute_versions.py
+++ b/scripts/release/compute_versions.py
@@ -31,11 +31,11 @@ import re
 import subprocess
 import sys
 from dataclasses import dataclass
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 
-class BumpMode(str, Enum):
+class BumpMode(StrEnum):
     auto = "auto"
     alpha = "alpha"
     alpha_patch = "alpha-patch"
@@ -49,7 +49,7 @@ class BumpMode(str, Enum):
     major = "major"
 
 
-class PreLabel(str, Enum):
+class PreLabel(StrEnum):
     alpha = "a"
     beta = "b"
     rc = "rc"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,9 @@
 import argparse
-import sys
 from pathlib import Path
 
 import guppylang
 
 guppylang.enable_experimental_features()
-
-
-if sys.version_info < (3, 12):
-    # Ignore tests that require Python 3.12 syntax
-    collect_ignore_glob = ["*_py312.py"]
 
 
 def pytest_addoption(parser):

--- a/tests/error/alias_errors/too_many_args.py
+++ b/tests/error/alias_errors/too_many_args.py
@@ -1,13 +1,8 @@
-from typing import Generic
-
 from guppylang import guppy
 
 
-T = guppy.type_var("T")
-
-
 @guppy.struct
-class Box(Generic[T]):
+class Box[T]:
     value: T
 
 

--- a/tests/error/alias_errors/too_many_args.py
+++ b/tests/error/alias_errors/too_many_args.py
@@ -1,4 +1,9 @@
+from typing import Generic
+
 from guppylang import guppy
+
+
+T = guppy.type_var("T")
 
 
 @guppy.struct

--- a/tests/error/self_errors/invalid_annotation2.err
+++ b/tests/error/self_errors/invalid_annotation2.err
@@ -1,8 +1,8 @@
-Error: Invalid self annotation (at $FILE:14:21)
+Error: Invalid self annotation (at $FILE:13:21)
    | 
-12 | 
-13 |     @guppy
-14 |     def foo(my_self: int) -> None:
+11 | 
+12 |     @guppy
+13 |     def foo(my_self: int) -> None:
    |                      ^^^ `my_self` must be of type `Foo[?T]`
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/self_errors/invalid_annotation2.py
+++ b/tests/error/self_errors/invalid_annotation2.py
@@ -1,7 +1,6 @@
 from typing import Generic
 
 from guppylang.decorator import guppy
-from guppylang_internals.checker.core import V
 
 T = guppy.type_var("T")
 

--- a/tests/error/self_errors/parametrized_self2.py
+++ b/tests/error/self_errors/parametrized_self2.py
@@ -7,7 +7,7 @@ T = guppy.type_var("T")
 
 
 @guppy.enum
-class Foo(Generic[T]):
+class Foo[T]:
     Var = {}
     @guppy
     def foo(self: "Self[int]") -> None:

--- a/tests/error/test_self_errors.py
+++ b/tests/error/test_self_errors.py
@@ -12,10 +12,6 @@ files = [
     if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
 ]
 
-if sys.version_info < (3, 12):
-    # Filter out tests that require Python >= 3.12
-    files = [file for file in files if "py312" not in file.name]
-
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,7 +4,7 @@ from hugr.package import Package, PackagePointer
 from pathlib import Path
 import pytest
 from typing import Any, Literal, cast
-from typing_extensions import assert_never
+from typing import assert_never
 
 from selene_hugr_qis_compiler import check_hugr
 

--- a/tests/integration/test_self.py
+++ b/tests/integration/test_self.py
@@ -1,5 +1,5 @@
 from typing import Generic
-from typing_extensions import Self
+from typing import Self
 
 from guppylang import guppy
 


### PR DESCRIPTION
Closes #2119

Note on breakages:
1. I do not view the removal of `typing.Generic` as a superclass to be a breaking change. It just _looks_ like a breaking change. The `Generic` superclass is just a hack to achieve what we can now do with type arg syntax and not a real class. (Reviewers smash that :+1: button if you agree)
2. I can't delete the guppy type variables from the `std.collections` libs because that would be breaking 😔 