### PR TITLE
fix: Make auto type params for protocol bounds unique

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -246,7 +246,12 @@ def _arg_from_instantiated_defn(
                 must_be_droppable=True,
                 must_implement=[proto_inst],
             )
-            ctx.param_var_mapping[param.name] = param
+            # Create a fresh parameter to take this `Callable` protocol bound.
+            # If we see another callable in the signature, we *don't* want it to resolve
+            # to this one.
+            # Hence, the key here is assumed to be unique, which is assumed because we
+            # don't otherwise have numerals as param vars.
+            ctx.param_var_mapping[str(len(ctx.param_var_mapping))] = param
             return param.to_bound()
         # Special case for the `Unitary`, `Controllable`, and `Daggerable` protocols
         case ModifiableFunctionProtocolDef(flags=flags):
@@ -259,7 +264,8 @@ def _arg_from_instantiated_defn(
                 must_be_droppable=True,
                 must_implement=[proto_inst],
             )
-            ctx.param_var_mapping[param.name] = param
+            # See comment in the `CallableProtocolDef` above.
+            ctx.param_var_mapping[str(len(ctx.param_var_mapping))] = param
             return param.to_bound()
         # Special case for the `Self` type
         case SelfTypeDef():
@@ -313,7 +319,12 @@ def _arg_from_proto(
             must_be_droppable=True,
             must_implement=[inst],
         )
-        ctx.param_var_mapping[proto_defn.name] = param
+        # Create a fresh parameter to represent this protocol bound. If we see another
+        # instance of the bound in the type signature, we *don't* want it to resolve to
+        # this one.
+        # Hence, the key here is assumed to be unique, which is assumed because we don't
+        # otherwise have numerals as param vars.
+        ctx.param_var_mapping[str(len(ctx.param_var_mapping))] = param
     return param.to_bound()
 
 

--- a/tests/integration/test_protocol_py312.py
+++ b/tests/integration/test_protocol_py312.py
@@ -355,14 +355,14 @@ def test_run_int(validate, run_int_fn):
             return 9
 
     @guppy
-    def get_fav_num(a: Animal) -> nat:
-        return a.fav_num()
+    def sum_fav_num(a: Animal, b: Animal) -> nat:
+        x = a.fav_num()
+        x += b.fav_num()
+        return x
 
     @guppy
     def main() -> nat:
-        a = get_fav_num(Dog())
-        b = get_fav_num(Duck())
-        return a + b
+        return sum_fav_num(Dog(), Duck())
 
     validate(main.compile())
     run_int_fn(main, 13)
@@ -454,3 +454,32 @@ def test_unitary(validate):
         discard(c)
 
     validate(main.compile())
+
+
+def test_double_fn(validate):
+    from collections.abc import Callable
+    from guppylang.std.builtins import qubit
+
+    @guppy
+    def take_two(
+        a: Callable[[qubit], None], b: Callable[[qubit], None], q: qubit
+    ) -> None:
+        a(q)
+        b(q)
+
+    @guppy
+    def fn(q: qubit) -> None:
+        return
+
+    @guppy
+    def fn2(q: qubit) -> None:
+        return
+
+    @guppy
+    def call_two() -> None:
+        q = qubit()
+        take_two(fn, fn2, q)
+        take_two(fn, fn, q)
+        q.discard()
+
+    validate(call_two.compile())


### PR DESCRIPTION
Closes #1989

The `param_var_mapping` in our `TypeParsingContext` is usually populated by the explicit type args to a function (or type vars inherited from another scope), i.e., in
```python
def foo[A, B: Proto, C: nat](...)
```
we would parse the `(...)` with a context containing 
```python
param_var_mapping = {'A': BoundVar(...), 'B': BoundVar(...implements=[Proto]), 'C': BoundConst(ty=nat...)`
```
which is all well and good. When we see any of `A`, `B`, `C` in the function signature, we want to substitute the var for it's value in the `param_var_mapping`.

But we also allow users to write protocols in place of types, as in
```python
def foo(b: Proto)
```
which is desugared to 
```python
def foo[B: Proto](b: B)
```
the key difference here that went unnoticed before is that if we see _another_ `Proto` type
```python
def foo(b: Proto, d: Proto)
```
we DON'T want it to desugar to
```python
def foo[B: Proto](b: B, d: B)
```
but rather
```python
def foo[B: Proto, D: Proto](b: B, d: D)
```
Unfortunately, the case we don't want is what comes from naïvely adding `{'B': BoundVar(impl=[Proto])}` to the `param_var_mapping`. We actually want the parameter to be unique to the specific type that introduced it, and not be visible to be looked up to the rest.