### PR TITLE
fix!: Dagger flags cancelation inside `daggarable` functions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -78,6 +78,9 @@ class CFGBuilder(AstVisitor[BB | None]):
 
     cfg: CFG
     globals: Globals
+    # The accumulated unitary flags correspond to the flags accumulated inside a
+    # function via the modifier `block`.
+    accumulated_flags: UnitaryFlags
 
     def build(
         self,
@@ -85,6 +88,7 @@ class CFGBuilder(AstVisitor[BB | None]):
         returns_none: bool,
         globals: Globals,
         unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+        accumulated_flags: UnitaryFlags = UnitaryFlags.NoFlags,
     ) -> CFG:
         """Builds a CFG from a list of ast nodes.
 
@@ -95,6 +99,7 @@ class CFGBuilder(AstVisitor[BB | None]):
         self.cfg = CFG()
         self.cfg.unitary_flags = unitary_flags
         self.globals = globals
+        self.accumulated_flags = accumulated_flags
 
         final_bb = self.visit_stmts(
             nodes, self.cfg.entry_bb, Jumps(self.cfg.exit_bb, None, None)
@@ -356,7 +361,17 @@ class CFGBuilder(AstVisitor[BB | None]):
         for item in node.items:
             item.context_expr, bb = ExprBuilder.build(item.context_expr, self.cfg, bb)
             modifiers.push(self._handle_withitem(item))
-        accumulated_flags = self.cfg.unitary_flags.accumulate(modifiers.flags())
+
+        # accumulate_flags accumulates flags to handle nested dagger blocks (even dagger
+        # nullify themself).
+        accumulated_flags = self.accumulated_flags.accumulate(modifiers.flags())
+        # we overwrite the accumulate_flags with self.cfg.unitary_flags to ensure that
+        # the flags declared via the `@guppy` decorator are always preserved. This is
+        # done to ensure that a dagger block inside a @guppy(daggarable=true) function
+        # has the dagger flag (and thus the type checker can correctly handle it)
+        outer_unitary_flags = self.cfg.unitary_flags
+        accumulated_flags |= outer_unitary_flags
+
         if UnitaryFlags.Dagger in accumulated_flags:
             # `original_ast_body` is only needed for checking invalid constructs under
             # dagger, so we only need to save it if dagger is present.
@@ -364,7 +379,13 @@ class CFGBuilder(AstVisitor[BB | None]):
         else:
             original_ast_body = None
 
-        cfg = CFGBuilder().build(node.body, True, self.globals, accumulated_flags)
+        cfg = CFGBuilder().build(
+            node.body,
+            True,
+            self.globals,
+            outer_unitary_flags,
+            accumulated_flags,
+        )
         new_node = ModifiedBlock(
             cfg,
             modifiers,

--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -78,10 +78,10 @@ class CFGBuilder(AstVisitor[BB | None]):
 
     cfg: CFG
     globals: Globals
-    # The unitary flags correspond to the flags declared via the `@guppy` decorator on
-    # the function. When the builder is consider a with block this field contain the
-    # flag corresponding to outer function. This allow us to prevent the accumulated
-    # flag to nullify the outer function flag (e.g. in case of even daggers).
+    # The unitary flags correspond to flags declared via the `@guppy` decorator on the
+    # function. When the builder is constructing a `with` block, this field contains the
+    # flags corresponding to the outer function. This allows us to prevent accumulated
+    # flags from nullifying the outer-function flags (e.g. an even number of daggers).
     function_unitary_flags: UnitaryFlags
     # The accumulated unitary flags correspond to the flags accumulated inside a
     # function via the modifier `block`.
@@ -376,13 +376,13 @@ class CFGBuilder(AstVisitor[BB | None]):
             item.context_expr, bb = ExprBuilder.build(item.context_expr, self.cfg, bb)
             modifiers.push(self._handle_withitem(item))
 
-        # accumulate_flags accumulates flags to handle nested dagger blocks (even dagger
-        # nullify themself).
+        # `accumulated_flags` accumulates flags to handle nested dagger blocks (an even
+        # number of daggers cancels out).
         accumulated_flags = self.accumulated_flags.accumulate(modifiers.flags())
-        # we overwrite the accumulate_flags with self.function_unitary_flags to ensure
-        # that the flags declared via the `@guppy` decorator are always preserved.
-        # This is done to ensure that a dagger block inside a @guppy(daggarable=true)
-        # function has the dagger flag (and the type checker can correctly handle it).
+        # Preserve flags declared via the `@guppy` decorator so they cannot be cancelled
+        # out by nested modifier blocks. This ensures that a modifier block inside a
+        # `@guppy(daggerable=True)` function is treated as daggerable by the type
+        # checker.
         accumulated_flags |= self.function_unitary_flags
 
         if UnitaryFlags.Dagger in accumulated_flags:

--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -78,6 +78,11 @@ class CFGBuilder(AstVisitor[BB | None]):
 
     cfg: CFG
     globals: Globals
+    # The unitary flags correspond to the flags declared via the `@guppy` decorator on
+    # the function. When the builder is consider a with block this field contain the
+    # flag corresponding to outer function. This allow us to prevent the accumulated
+    # flag to nullify the outer function flag (e.g. in case of even daggers).
+    function_unitary_flags: UnitaryFlags
     # The accumulated unitary flags correspond to the flags accumulated inside a
     # function via the modifier `block`.
     accumulated_flags: UnitaryFlags
@@ -87,8 +92,8 @@ class CFGBuilder(AstVisitor[BB | None]):
         nodes: list[ast.stmt],
         returns_none: bool,
         globals: Globals,
-        unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
-        accumulated_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+        function_unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+        accumulated_flags: UnitaryFlags | None = None,
     ) -> CFG:
         """Builds a CFG from a list of ast nodes.
 
@@ -97,9 +102,18 @@ class CFGBuilder(AstVisitor[BB | None]):
         variables.
         """
         self.cfg = CFG()
-        self.cfg.unitary_flags = unitary_flags
+        self.function_unitary_flags = function_unitary_flags
+        if accumulated_flags is None:
+            # If accumulated_flags is None, we are building the CFG for a function, thus
+            # the flag declared in the decorator counts.
+            self.cfg.unitary_flags = function_unitary_flags
+            self.accumulated_flags = UnitaryFlags.NoFlags
+        else:
+            # Otherwise, we are building the CFG for with a block and the unitary flags
+            # of the cfg correspond to the accumulated flags.
+            self.cfg.unitary_flags = accumulated_flags
+            self.accumulated_flags = accumulated_flags
         self.globals = globals
-        self.accumulated_flags = accumulated_flags
 
         final_bb = self.visit_stmts(
             nodes, self.cfg.entry_bb, Jumps(self.cfg.exit_bb, None, None)
@@ -365,12 +379,11 @@ class CFGBuilder(AstVisitor[BB | None]):
         # accumulate_flags accumulates flags to handle nested dagger blocks (even dagger
         # nullify themself).
         accumulated_flags = self.accumulated_flags.accumulate(modifiers.flags())
-        # we overwrite the accumulate_flags with self.cfg.unitary_flags to ensure that
-        # the flags declared via the `@guppy` decorator are always preserved. This is
-        # done to ensure that a dagger block inside a @guppy(daggarable=true) function
-        # has the dagger flag (and thus the type checker can correctly handle it)
-        outer_unitary_flags = self.cfg.unitary_flags
-        accumulated_flags |= outer_unitary_flags
+        # we overwrite the accumulate_flags with self.function_unitary_flags to ensure
+        # that the flags declared via the `@guppy` decorator are always preserved.
+        # This is done to ensure that a dagger block inside a @guppy(daggarable=true)
+        # function has the dagger flag (and the type checker can correctly handle it).
+        accumulated_flags |= self.function_unitary_flags
 
         if UnitaryFlags.Dagger in accumulated_flags:
             # `original_ast_body` is only needed for checking invalid constructs under
@@ -383,7 +396,7 @@ class CFGBuilder(AstVisitor[BB | None]):
             node.body,
             True,
             self.globals,
-            outer_unitary_flags,
+            self.function_unitary_flags,
             accumulated_flags,
         )
         new_node = ModifiedBlock(

--- a/tests/error/modifier_errors/decorator_dagger_is_preserved.err
+++ b/tests/error/modifier_errors/decorator_dagger_is_preserved.err
@@ -1,6 +1,6 @@
 Error: Dagger constraint violation (at $FILE:8:8)
   | 
-6 | def apply_unitary(f: Controllable[[qubit], None], ctrl: qubit, q: qubit) -> None:
+6 | def apply_unitary(f: Controllable[[qubit], None], q: qubit) -> None:
 7 |     with dagger:
 8 |         f(q)
   |         ^^^^ This function cannot be called in a daggerable context

--- a/tests/error/modifier_errors/decorator_dagger_is_preserved.err
+++ b/tests/error/modifier_errors/decorator_dagger_is_preserved.err
@@ -1,0 +1,11 @@
+Error: Dagger constraint violation (at $FILE:8:8)
+  | 
+6 | def apply_unitary(f: Controllable[[qubit], None], ctrl: qubit, q: qubit) -> None:
+7 |     with dagger:
+8 |         f(q)
+  |         ^^^^ This function cannot be called in a daggerable context
+
+Help: To be able to use a Controllable function in a daggerable context, you
+have to declare it as `Daggerable`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/decorator_dagger_is_preserved.py
+++ b/tests/error/modifier_errors/decorator_dagger_is_preserved.py
@@ -1,0 +1,18 @@
+from guppylang import guppy, qubit
+from guppylang.std.builtins import control, dagger, Controllable
+
+
+@guppy(daggerable=True)
+def apply_unitary(f: Controllable[[qubit], None], ctrl: qubit, q: qubit) -> None:
+    with dagger:
+        f(q)
+
+@guppy.declare(controllable=True)
+def foo(q: qubit) -> None:...
+
+@guppy
+def main(q1: qubit, q2: qubit) -> None:
+    apply_unitary(foo, q1, q2)
+
+
+main.check()

--- a/tests/error/modifier_errors/decorator_dagger_is_preserved.py
+++ b/tests/error/modifier_errors/decorator_dagger_is_preserved.py
@@ -1,9 +1,9 @@
 from guppylang import guppy, qubit
-from guppylang.std.builtins import control, dagger, Controllable
+from guppylang.std.builtins import dagger, Controllable
 
 
 @guppy(daggerable=True)
-def apply_unitary(f: Controllable[[qubit], None], ctrl: qubit, q: qubit) -> None:
+def apply_unitary(f: Controllable[[qubit], None], q: qubit) -> None:
     with dagger:
         f(q)
 
@@ -11,8 +11,8 @@ def apply_unitary(f: Controllable[[qubit], None], ctrl: qubit, q: qubit) -> None
 def foo(q: qubit) -> None:...
 
 @guppy
-def main(q1: qubit, q2: qubit) -> None:
-    apply_unitary(foo, q1, q2)
+def main(q1: qubit) -> None:
+    apply_unitary(foo, q1)
 
 
 main.check()


### PR DESCRIPTION
Closes #1984.

This PR fixes an issue where `dagger` blocks incorrectly cancelled the `daggerable` property of the enclosing function:  a `daggerable` function should always enforce the `daggerable` constraint within its body. Previously, a `dagger` block inside a `daggerable` function was treated as non-`daggerable` because the block's `dagger` modifier cleared the `daggerable` flag inherited from the function decorator. However, since the context in which a function is called is not known when checking its body, the unitary constraints declared in the function signature must always be enforced.

The bug was generating a bad `cfg.unitary_flags` in the modifier blocks, affecting both the metadata and the type checking.

BREAKING CHANGE: guppylang-internals: remaned parameter `unitary_flags` `CFGBuilder.build` to `function_unitary_flags`






