### PR TITLE
fix: correct formatting in GuppyLibrary docstring

### DIFF
--- a/guppylang/src/guppylang/library.py
+++ b/guppylang/src/guppylang/library.py
@@ -25,6 +25,7 @@ class GuppyLibrary:
     methods on this class.
 
     .. code-block:: python
+
         from guppylang.library import GuppyLibrary
 
         @guppy


### PR DESCRIPTION
Sphinx seems to need an extra line to render this docstring code snippet correctly.

Prior to this change I get the warning

```
Users/callum.macpherson/Desktop/guppy-docs/.venv/lib/python3.14/site-packages/guppylang/library.py:docstring of guppylang.library.GuppyLibrary:5: ERROR: Error in "code-block" directive:
maximum 1 argument(s) allowed, 5 supplied.

.. code-block:: python
    from guppylang.library import GuppyLibrary

    @guppy
    def foo() -> int:
        return 42
    @guppy
    def bar() -> int:
        return 7

    # Compilable collection containing `foo` and `bar`.
    lib = GuppyLibrary.from_members(foo, bar) [docutils]
```

The snippet also doesn't show up in the html pages.

I've tested the docs build with commit [ff6e5c7](https://github.com/Quantinuum/guppylang/pull/2009/commits/ff6e5c77f85ae57488d4e0ad2649b0d7f6c5cf53) and it looks better

<img width="787" height="348" alt="Screenshot 2026-07-07 at 10 39 40" src="https://github.com/user-attachments/assets/e1e3c1fa-ec60-4a17-ba06-8c3cc57bca79" />

The warning also doesn't show up anymore.

