### PR TITLE
fix: correct docstring indentation in EmulatorBuilder.build

### DIFF
--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -238,17 +238,24 @@ class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P
         See :py:mod:`guppylang.emulator` for more details on the emulator.
 
         Args:
-            n_qubits: The number of qubits to allocate for the function. If it is not
-            provided, the function has to declare the expected number of qubits it needs
-            with the decorator `@expected_qubits`.
-            builder: An optional `EmulatorBuilder` to use for building the emulator
-            instance. If not provided, the default `EmulatorBuilder` will be used.
-            libs: An optional list of additional HUGR packages to link with the compiled
-            function. This can be used to provide additional library functions that the
-            function being compiled depends on.
-            platform: The quantum platform to target. Defaults to ``"helios"``. Set to
-            ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
-            provided (use ``builder.with_platform()`` in that case).
+            n_qubits:
+                The number of qubits to allocate for the function. If it is not
+                provided, the function has to declare the expected number of qubits it
+                  needs with the decorator `@expected_qubits`.
+
+            builder:
+                An optional `EmulatorBuilder` to use for building the emulator
+                instance. If not provided, the default `EmulatorBuilder` will be used.
+
+            libs:
+                An optional list of additional HUGR packages to link with the compiled
+                function. This can be used to provide additional library functions that
+                  the function being compiled depends on.
+
+            platform:
+                The quantum platform to target. Defaults to ``"helios"``. Set to
+                ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
+                provided (use ``builder.with_platform()`` in that case).
 
         Returns:
             An `EmulatorInstance` that can be used to run the function in an emulator.

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -238,24 +238,17 @@ class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P
         See :py:mod:`guppylang.emulator` for more details on the emulator.
 
         Args:
-            n_qubits:
-                The number of qubits to allocate for the function. If it is not
-                provided, the function has to declare the expected number of qubits it
-                  needs with the decorator `@expected_qubits`.
-
-            builder:
-                An optional `EmulatorBuilder` to use for building the emulator
-                instance. If not provided, the default `EmulatorBuilder` will be used.
-
-            libs:
-                An optional list of additional HUGR packages to link with the compiled
-                function. This can be used to provide additional library functions that
-                  the function being compiled depends on.
-
-            platform:
-                The quantum platform to target. Defaults to ``"helios"``. Set to
-                ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
-                provided (use ``builder.with_platform()`` in that case).
+            n_qubits: The number of qubits to allocate for the function. If it is not
+            provided, the function has to declare the expected number of qubits it needs
+            with the decorator `@expected_qubits`.
+            builder: An optional `EmulatorBuilder` to use for building the emulator
+            instance. If not provided, the default `EmulatorBuilder` will be used.
+            libs: An optional list of additional HUGR packages to link with the compiled
+            function. This can be used to provide additional library functions that the
+            function being compiled depends on.
+            platform: The quantum platform to target. Defaults to ``"helios"``. Set to
+            ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
+            provided (use ``builder.with_platform()`` in that case).
 
         Returns:
             An `EmulatorInstance` that can be used to run the function in an emulator.

--- a/guppylang/src/guppylang/emulator/builder.py
+++ b/guppylang/src/guppylang/emulator/builder.py
@@ -141,10 +141,15 @@ class EmulatorBuilder:
         """Build an EmulatorInstance from a compiled package.
 
         Args:
-            package: The compiled HUGR package to build the emulator from.
-            n_qubits: The number of qubits to allocate for the emulator instance.
-            arg_specs: The runtime argument schema of the (wrapped) entrypoint, if
-            it takes arguments. Used to validate values passed to ``run``.
+            package:
+                The compiled HUGR package to build the emulator from.
+
+            n_qubits:
+                The number of qubits to allocate for the emulator instance.
+
+            arg_specs:
+                The runtime argument schema of the (wrapped) entrypoint, if
+                it takes arguments. Used to validate values passed to ``run``.
 
         Returns:
             An EmulatorInstance that can be used to run the compiled program.

--- a/guppylang/src/guppylang/emulator/builder.py
+++ b/guppylang/src/guppylang/emulator/builder.py
@@ -144,7 +144,7 @@ class EmulatorBuilder:
             package: The compiled HUGR package to build the emulator from.
             n_qubits: The number of qubits to allocate for the emulator instance.
             arg_specs: The runtime argument schema of the (wrapped) entrypoint, if
-                it takes arguments. Used to validate values passed to ``run``.
+            it takes arguments. Used to validate values passed to ``run``.
 
         Returns:
             An EmulatorInstance that can be used to run the compiled program.


### PR DESCRIPTION
Before this change
<img width="779" height="282" alt="Screenshot 2026-07-07 at 11 37 07" src="https://github.com/user-attachments/assets/004f54aa-5d35-4d50-a4bd-8c019084da20" />

Gave the corresponding Sphinx warning
```
/Users/callum.macpherson/Desktop/guppy-docs/.venv/lib/python3.14/site-packages/guppylang/emulator/builder.py:docstring of guppylang.emulator.builder.EmulatorBuilder.build:7: ERROR: Unexpected indentation. [docutils]
```

After this change (tested in local docs build with the commit [7592833](https://github.com/Quantinuum/guppylang/pull/2011/commits/7592833fea1a804cbd2dd3c4e6ed4e63770a1778))

<img width="742" height="284" alt="Screenshot 2026-07-07 at 11 40 18" src="https://github.com/user-attachments/assets/80944791-abb1-4408-8694-2dca29bcd4b3" />



We run the docs build as part of the Guppylang release process now. Hopefully once the strict build (fail on warnings) is reenabled then we can catch this sort of thing prior to release.