### PR TITLE
fix: Make auto type params for protocol bounds unique

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -247,7 +247,12 @@ def _arg_from_instantiated_defn(
                 must_be_droppable=True,
                 must_implement=[proto_inst],
             )
-            ctx.param_var_mapping[param.name] = param
+            # Create a fresh parameter to take this `Callable` protocol bound.
+            # If we see another callable in the signature, we *don't* want it to resolve
+            # to this one.
+            # Hence, the key here is assumed to be unique, which is assumed because we
+            # don't otherwise have numerals as param vars.
+            ctx.param_var_mapping[str(len(ctx.param_var_mapping))] = param
             return param.to_bound()
         # Special case for the `Unitary`, `Controllable`, and `Daggerable` protocols
         case ModifiableFunctionProtocolDef(flags=flags):
@@ -260,7 +265,8 @@ def _arg_from_instantiated_defn(
                 must_be_droppable=True,
                 must_implement=[proto_inst],
             )
-            ctx.param_var_mapping[param.name] = param
+            # See comment in the `CallableProtocolDef` above.
+            ctx.param_var_mapping[str(len(ctx.param_var_mapping))] = param
             return param.to_bound()
         # Special case for the `Self` type
         case SelfTypeDef():
@@ -314,7 +320,12 @@ def _arg_from_proto(
             must_be_droppable=True,
             must_implement=[inst],
         )
-        ctx.param_var_mapping[proto_defn.name] = param
+        # Create a fresh parameter to represent this protocol bound. If we see another
+        # instance of the bound in the type signature, we *don't* want it to resolve to
+        # this one.
+        # Hence, the key here is assumed to be unique, which is assumed because we don't
+        # otherwise have numerals as param vars.
+        ctx.param_var_mapping[str(len(ctx.param_var_mapping))] = param
     return param.to_bound()
 
 

--- a/tests/integration/test_protocol_py312.py
+++ b/tests/integration/test_protocol_py312.py
@@ -355,14 +355,14 @@ def test_run_int(validate, run_int_fn):
             return 9
 
     @guppy
-    def get_fav_num(a: Animal) -> nat:
-        return a.fav_num()
+    def sum_fav_num(a: Animal, b: Animal) -> nat:
+        x = a.fav_num()
+        x += b.fav_num()
+        return x
 
     @guppy
     def main() -> nat:
-        a = get_fav_num(Dog())
-        b = get_fav_num(Duck())
-        return a + b
+        return sum_fav_num(Dog(), Duck())
 
     validate(main.compile())
     run_int_fn(main, 13)
@@ -454,3 +454,32 @@ def test_unitary(validate):
         discard(c)
 
     validate(main.compile())
+
+
+def test_double_fn(validate):
+    from collections.abc import Callable
+    from guppylang.std.builtins import qubit
+
+    @guppy
+    def take_two(
+        a: Callable[[qubit], None], b: Callable[[qubit], None], q: qubit
+    ) -> None:
+        a(q)
+        b(q)
+
+    @guppy
+    def fn(q: qubit) -> None:
+        return
+
+    @guppy
+    def fn2(q: qubit) -> None:
+        return
+
+    @guppy
+    def call_two() -> None:
+        q = qubit()
+        take_two(fn, fn2, q)
+        take_two(fn, fn, q)
+        q.discard()
+
+    validate(call_two.compile())


### PR DESCRIPTION
(cherry picked from commit f7115120fddb498876f5138a8272836181f452d1)