### PR TITLE
feat: Emit hint when branch type mismatch can be fixed via coercions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
@@ -22,12 +22,16 @@ from guppylang_internals.checker.core import (
     V,
     Variable,
 )
-from guppylang_internals.checker.expr_checker import ExprSynthesizer, to_bool
+from guppylang_internals.checker.expr_checker import (
+    ExprSynthesizer,
+    coerces_to,
+    to_bool,
+)
 from guppylang_internals.checker.stmt_checker import StmtChecker
 from guppylang_internals.diagnostic import Error, Help, Note
 from guppylang_internals.error import GuppyError
 from guppylang_internals.tys.arg import Argument
-from guppylang_internals.tys.ty import InputFlags, Type
+from guppylang_internals.tys.ty import FunctionDefType, InputFlags, Type
 
 Row = Sequence[V]
 
@@ -233,6 +237,23 @@ class BranchTypeError(Error):
         span_label: ClassVar[str] = "This is of type `{ty}`"
         ty: Type
 
+    @dataclass(frozen=True)
+    class CoerceOneHint(Help):
+        span_label: ClassVar[str] = (
+            "Consider adding a type annotation: `{var}: {ty} = ...`"
+        )
+        var: str
+        ty: Type
+
+    @dataclass(frozen=True)
+    class CoerceBothHint(Help):
+        message: ClassVar[str] = (
+            "Consider adding type annotations{extra}: `{var}: {ty} = ...`"
+        )
+        var: str
+        ty: str
+        extra: str = ""
+
 
 @dataclass(frozen=True)
 class AssignedInModifierError(Error):
@@ -396,7 +417,32 @@ def check_rows_match(row1: Row[Variable], row2: Row[Variable], bb: BB) -> None:
             # supported) or refer to long function definitions.
             err.add_sub_diagnostic(BranchTypeError.TypeHint(v1.defined_at, v1.ty))
             err.add_sub_diagnostic(BranchTypeError.TypeHint(v2.defined_at, v2.ty))
+            if hint := maybe_coerce_hint(v1, v2):
+                err.add_sub_diagnostic(hint)
             raise GuppyError(err)
+
+
+def maybe_coerce_hint(v1: Variable, v2: Variable) -> Help | None:
+    """Generates a help message telling the user to add type annotations to trigger
+    coercions that fix a type mismatch across different control-flow paths."""
+    assert v1.name == v2.name
+    assert v1.ty != v2.ty
+    if coerces_to(v1.ty, v2.ty):
+        return BranchTypeError.CoerceOneHint(v1.defined_at, v1.name, v2.ty)
+    if coerces_to(v2.ty, v1.ty):
+        return BranchTypeError.CoerceOneHint(v2.defined_at, v2.name, v1.ty)
+    # Suggest to coerce function definition types into opaque function types
+    if (
+        isinstance(v1.ty, FunctionDefType)
+        and isinstance(v2.ty, FunctionDefType)
+        and v1.ty.sig == v2.ty.sig
+    ):
+        unquantified, _ = v1.ty.sig.unquantified()
+        args = ", ".join(str(inp.ty) for inp in unquantified.inputs)
+        fn_str = f"Function[[{args}], {unquantified.output}]"
+        extra = " to coerce them into opaque function values"
+        return BranchTypeError.CoerceBothHint(None, v1.name, fn_str, extra)
+    return None
 
 
 def diagnose_maybe_undefined(

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1247,6 +1247,25 @@ def try_coerce_to(
     return None
 
 
+def coerces_to(act: Type, exp: Type) -> bool:
+    """Checks whether `act` implicitly coerces to `exp`.
+
+    Unlike `try_coerce_to`, this function just performs the check but does not emit any
+    code to actually perform the coercion.
+    """
+    function_coercion = (
+        isinstance(act, FunctionDefType)
+        and isinstance(exp, FunctionType)
+        and act.sig == exp
+    )
+    numeric_coercion = (
+        isinstance(act, NumericType)
+        and isinstance(exp, NumericType)
+        and act.kind < exp.kind
+    )
+    return function_coercion or numeric_coercion
+
+
 def function_def_value_to_global_name(expr: AstNode, ty: FunctionDefType) -> GlobalName:
     """Turns an expressions with a `FunctionDefType` into the corresponding
     `GlobalName`.

--- a/tests/error/errors_on_usage/if_different_types_coerce1.err
+++ b/tests/error/errors_on_usage/if_different_types_coerce1.err
@@ -1,0 +1,23 @@
+Error: Different types (at $FILE:10:11)
+   | 
+ 8 |     else:
+ 9 |         y = 1.0
+10 |     return y
+   |            ^ Variable `y` may refer to different types
+
+Notes:
+   | 
+ 6 |     if x:
+ 7 |         y = 1
+   |         - This is of type `int`
+ 8 |     else:
+ 9 |         y = 1.0
+   |         - This is of type `float`
+
+Help:
+   | 
+ 6 |     if x:
+ 7 |         y = 1
+   |         - Consider adding a type annotation: `y: float = ...`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/if_different_types_coerce1.py
+++ b/tests/error/errors_on_usage/if_different_types_coerce1.py
@@ -1,0 +1,10 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def foo(x: bool) -> float:
+    if x:
+        y = 1
+    else:
+        y = 1.0
+    return y

--- a/tests/error/errors_on_usage/if_different_types_coerce2.err
+++ b/tests/error/errors_on_usage/if_different_types_coerce2.err
@@ -1,0 +1,23 @@
+Error: Different types (at $FILE:10:11)
+   | 
+ 8 |     else:
+ 9 |         y = 1
+10 |     return y
+   |            ^ Variable `y` may refer to different types
+
+Notes:
+   | 
+ 6 |     if x:
+ 7 |         y = 1.0
+   |         - This is of type `float`
+ 8 |     else:
+ 9 |         y = 1
+   |         - This is of type `int`
+
+Help:
+   | 
+ 8 |     else:
+ 9 |         y = 1
+   |         - Consider adding a type annotation: `y: float = ...`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/if_different_types_coerce2.py
+++ b/tests/error/errors_on_usage/if_different_types_coerce2.py
@@ -1,0 +1,10 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def foo(x: bool) -> float:
+    if x:
+        y = 1.0
+    else:
+        y = 1
+    return y

--- a/tests/error/type_errors/fun_item_ty_mismatch.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch.err
@@ -14,4 +14,7 @@ Notes:
 17 |         baz = bar
    |         --- This is of type `def bar() -> int`
 
+Help: Consider adding type annotations to coerce them into opaque function
+values: `baz: Function[[], int] = ...`
+
 Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_generic.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch_generic.err
@@ -1,0 +1,20 @@
+Error: Different types (at $FILE:21:11)
+   | 
+19 |     else:
+20 |         baz = bar
+21 |     return baz(42)
+   |            ^^^ Variable `baz` may refer to different types
+
+Notes:
+   | 
+17 |     if b:
+18 |         baz = foo
+   |         --- This is of type `def foo(x: T) -> T`
+19 |     else:
+20 |         baz = bar
+   |         --- This is of type `def bar(x: T) -> T`
+
+Help: Consider adding type annotations to coerce them into opaque function
+values: `baz: Function[[?T], ?T] = ...`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_generic.py
+++ b/tests/error/type_errors/fun_item_ty_mismatch_generic.py
@@ -1,0 +1,24 @@
+from guppylang import guppy
+
+
+T = guppy.type_var("T")
+
+
+@guppy.declare
+def foo(x: T) -> T: ...
+
+
+@guppy.declare
+def bar(x: T) -> T: ...
+
+
+@guppy
+def main(b: bool) -> int:
+    if b:
+        baz = foo
+    else:
+        baz = bar
+    return baz(42)
+
+
+main.compile_function()


### PR DESCRIPTION
I started writing the docs section about function types and think this would be a useful hint

Even better would be to apply the coercion automatically, but that would require repeated type-checking of basic blocks until we reach a fixed point. For now, the hint seems like a good solution imo