### PR TITLE
docs: Correct formatting in docstrings for GuppyLibrary and EmulatorBuilder

### DIFF
--- a/guppylang/src/guppylang/emulator/builder.py
+++ b/guppylang/src/guppylang/emulator/builder.py
@@ -141,9 +141,14 @@ class EmulatorBuilder:
         """Build an EmulatorInstance from a compiled package.
 
         Args:
-            package: The compiled HUGR package to build the emulator from.
-            n_qubits: The number of qubits to allocate for the emulator instance.
-            arg_specs: The runtime argument schema of the (wrapped) entrypoint, if
+            package:
+                The compiled HUGR package to build the emulator from.
+
+            n_qubits:
+                The number of qubits to allocate for the emulator instance.
+
+            arg_specs:
+                The runtime argument schema of the (wrapped) entrypoint, if
                 it takes arguments. Used to validate values passed to ``run``.
 
         Returns:

--- a/guppylang/src/guppylang/library.py
+++ b/guppylang/src/guppylang/library.py
@@ -25,6 +25,7 @@ class GuppyLibrary:
     methods on this class.
 
     .. code-block:: python
+
         from guppylang.library import GuppyLibrary
 
         @guppy


### PR DESCRIPTION
Cherry picks changes from #2009 and #2011