### PR TITLE
fix!: Dagger flags cancelation inside `daggarable` functions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -78,13 +78,22 @@ class CFGBuilder(AstVisitor[BB | None]):
 
     cfg: CFG
     globals: Globals
+    # The unitary flags correspond to flags declared via the `@guppy` decorator on the
+    # function. When the builder is constructing a `with` block, this field contains the
+    # flags corresponding to the outer function. This allows us to prevent accumulated
+    # flags from nullifying the outer-function flags (e.g. an even number of daggers).
+    function_unitary_flags: UnitaryFlags
+    # The accumulated unitary flags correspond to the flags accumulated inside a
+    # function via the modifier `block`.
+    accumulated_flags: UnitaryFlags
 
     def build(
         self,
         nodes: list[ast.stmt],
         returns_none: bool,
         globals: Globals,
-        unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+        function_unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+        accumulated_flags: UnitaryFlags | None = None,
     ) -> CFG:
         """Builds a CFG from a list of ast nodes.
 
@@ -93,7 +102,17 @@ class CFGBuilder(AstVisitor[BB | None]):
         variables.
         """
         self.cfg = CFG()
-        self.cfg.unitary_flags = unitary_flags
+        self.function_unitary_flags = function_unitary_flags
+        if accumulated_flags is None:
+            # If accumulated_flags is None, we are building the CFG for a function, thus
+            # the flag declared in the decorator counts.
+            self.cfg.unitary_flags = function_unitary_flags
+            self.accumulated_flags = UnitaryFlags.NoFlags
+        else:
+            # Otherwise, we are building the CFG for with a block and the unitary flags
+            # of the cfg correspond to the accumulated flags.
+            self.cfg.unitary_flags = accumulated_flags
+            self.accumulated_flags = accumulated_flags
         self.globals = globals
 
         final_bb = self.visit_stmts(
@@ -356,7 +375,16 @@ class CFGBuilder(AstVisitor[BB | None]):
         for item in node.items:
             item.context_expr, bb = ExprBuilder.build(item.context_expr, self.cfg, bb)
             modifiers.push(self._handle_withitem(item))
-        accumulated_flags = self.cfg.unitary_flags.accumulate(modifiers.flags())
+
+        # `accumulated_flags` accumulates flags to handle nested dagger blocks (an even
+        # number of daggers cancels out).
+        accumulated_flags = self.accumulated_flags.accumulate(modifiers.flags())
+        # Preserve flags declared via the `@guppy` decorator so they cannot be cancelled
+        # out by nested modifier blocks. This ensures that a modifier block inside a
+        # `@guppy(daggerable=True)` function is treated as daggerable by the type
+        # checker.
+        accumulated_flags |= self.function_unitary_flags
+
         if UnitaryFlags.Dagger in accumulated_flags:
             # `original_ast_body` is only needed for checking invalid constructs under
             # dagger, so we only need to save it if dagger is present.
@@ -364,7 +392,13 @@ class CFGBuilder(AstVisitor[BB | None]):
         else:
             original_ast_body = None
 
-        cfg = CFGBuilder().build(node.body, True, self.globals, accumulated_flags)
+        cfg = CFGBuilder().build(
+            node.body,
+            True,
+            self.globals,
+            self.function_unitary_flags,
+            accumulated_flags,
+        )
         new_node = ModifiedBlock(
             cfg,
             modifiers,

--- a/tests/error/modifier_errors/decorator_dagger_is_preserved.err
+++ b/tests/error/modifier_errors/decorator_dagger_is_preserved.err
@@ -1,0 +1,11 @@
+Error: Dagger constraint violation (at $FILE:8:8)
+  | 
+6 | def apply_unitary(f: Controllable[[qubit], None], q: qubit) -> None:
+7 |     with dagger:
+8 |         f(q)
+  |         ^^^^ This function cannot be called in a daggerable context
+
+Help: To be able to use a Controllable function in a daggerable context, you
+have to declare it as `Daggerable`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/decorator_dagger_is_preserved.py
+++ b/tests/error/modifier_errors/decorator_dagger_is_preserved.py
@@ -1,0 +1,18 @@
+from guppylang import guppy, qubit
+from guppylang.std.builtins import dagger, Controllable
+
+
+@guppy(daggerable=True)
+def apply_unitary(f: Controllable[[qubit], None], q: qubit) -> None:
+    with dagger:
+        f(q)
+
+@guppy.declare(controllable=True)
+def foo(q: qubit) -> None:...
+
+@guppy
+def main(q1: qubit) -> None:
+    apply_unitary(foo, q1)
+
+
+main.check()


### PR DESCRIPTION
(cherry picked from commit f83c410873731aac71f1edd51bc8623638d88ecd)

Cherry picks changes from #2003

BREAKING CHANGE: guppylang-internals: remaned parameter unitary_flags CFGBuilder.build to function_unitary_flags