### PR TITLE
chore: Omit internals from semver break CI

### DIFF
--- a/.github/workflows/semver-checks.yml
+++ b/.github/workflows/semver-checks.yml
@@ -41,5 +41,5 @@ jobs:
 
       - uses: quantinuum/hugrverse-actions/py-semver-checks@main
         with:
-          packages: guppylang/src/guppylang guppylang-internals/src/guppylang_internals
+          packages: guppylang/src/guppylang
           token: ${{ secrets.HUGRBOT_PAT || github.token }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -126,7 +126,7 @@ The general format of a contribution title should be:
 <type>(<scope>)!: <description>
 ```
 
-Where the scope is optional, and the `!` is only included if this is a semver breaking change that requires a major version bump.
+Where the scope is optional, and the `!` is only included if this is a semver breaking change that requires a major version bump *to the `guppylang` package*.
 
 We accept the following contribution types:
 


### PR DESCRIPTION
Since we now treat every version bump on internals as a breaking change, we can simply omit internals from the semver break CI and treat a lot fewer PRs as "actually breaking the user", indicated via the `!`.