### PR TITLE
refactor: Remove deprecated qsystem extension usage

### DIFF
--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/tket_exts.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/tket_exts.py
@@ -8,7 +8,6 @@ from tket_exts import (
     guppy,
     measurement,
     modifier,
-    qsystem,
     qsystem_helios,
     qsystem_random,
     qsystem_sol,
@@ -25,7 +24,6 @@ GLOBAL_PHASE_EXTENSION = global_phase()
 GUPPY_EXTENSION = guppy()
 MEASUREMENT_EXTENSION = measurement()
 MODIFIER_EXTENSION = modifier()
-QSYSTEM_EXTENSION = qsystem()
 QSYSTEM_HELIOS_EXTENSION = qsystem_helios()
 QSYSTEM_SOL_EXTENSION = qsystem_sol()
 QSYSTEM_RANDOM_EXTENSION = qsystem_random()
@@ -42,7 +40,6 @@ TKET_EXTENSIONS = [
     GUPPY_EXTENSION,
     MEASUREMENT_EXTENSION,
     MODIFIER_EXTENSION,
-    QSYSTEM_EXTENSION,
     QSYSTEM_HELIOS_EXTENSION,
     QSYSTEM_SOL_EXTENSION,
     QSYSTEM_RANDOM_EXTENSION,


### PR DESCRIPTION
We do not seem to use it anymore. This only impacts the "extensions with which used extensions are resolved following compilation", but since there are no more op bindings, we should not be able to produce HUGRs using this extension anyway...

This should prevent a bunch of warnings during compilation, so I will nominate it for backport.

Closes #1999