### PR TITLE
refactor: remove EXTENSION_OPS_WITH_SIDE_EFFECTS, pass effects alongside DataflowOp

### DIFF
--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -11,7 +11,7 @@ from hugr.build import Block, Case, Cfg, Conditional, TailLoop
 from hugr.build import function as hf
 from hugr.hugr.node_port import ToNode
 from hugr.metadata import HugrDebugInfo
-from hugr.ops import CallIndirect, DataflowOp, Output
+from hugr.ops import DataflowOp, Output
 from typing_extensions import Self, override
 
 from guppylang_internals.ast_util import AstNode
@@ -98,13 +98,7 @@ class DFBuilder(ABC, ToNode):
         """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
         avoid automatic debug information attachment.
         """
-        from guppylang_internals.compiler.core import may_have_side_effect
-
         op, effects = op
-
-        assert frozenset(effects) == frozenset(
-            [Effect.ANY] if may_have_side_effect(op) else []
-        )
         op_node = self._raw.add_op(op, *args)
         self._handle_side_effects(op_node, effects)
 

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -21,13 +21,11 @@ from guppylang_internals.metadata.debug_info_util import (
 )
 from guppylang_internals.tys import Effect
 
-
-@dataclass(frozen=True)
-class Pure:
-    op: DataflowOp
+OpWithEffects: TypeAlias = tuple[DataflowOp, Iterable[Effect]]
 
 
-OpWithEffects: TypeAlias = Pure | tuple[DataflowOp, Iterable[Effect]]
+def pure(op: DataflowOp) -> OpWithEffects:
+    return (op, [])
 
 
 @dataclass
@@ -100,7 +98,7 @@ class DFBuilder(ABC, ToNode):
         """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
         avoid automatic debug information attachment.
         """
-        op, effects = (op.op, []) if isinstance(op, Pure) else op
+        op, effects = op
         op_node = self._raw.add_op(op, *args)
         self._handle_side_effects(op_node, effects)
 

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -115,7 +115,11 @@ class DFBuilder(ABC, ToNode):
         node = op_node.to_node()
         to_propagate = set()  # Effects newly added to our container
 
-        def get_last_node(e: Effect) -> Node:
+        def get_prev_node(e: Effect) -> Node:
+            """Gets the previous node that had the given effect,
+            or Input (marking this container as having that effect) if none.
+            Then records the current `node` as the last node, for any later call."""
+
             last = self._last_side_effect.get(e)
             if last is None:
                 to_propagate.add(e)
@@ -125,9 +129,9 @@ class DFBuilder(ABC, ToNode):
             self._last_side_effect[e] = node
             return last
 
-        prev_nodes = {get_last_node(e) for e in effects}
-        # Avoid cycles and duplicate edges:
-        prev_nodes.discard(node)
+        prev_nodes = {get_prev_node(e) for e in effects}
+        prev_nodes.discard(node)  # Avoid cycles
+        # Avoid duplicate Order edges when two nodes share multiple effects:
         for prev in self._raw.hugr.incoming_order_links(node):
             prev_nodes.discard(prev)
 
@@ -140,7 +144,7 @@ class DFBuilder(ABC, ToNode):
     @abstractmethod
     def _propagate_side_effects(self, effects: Iterable[Effect]) -> None:
         """Subclasses must implement to mark the container node
-        as side-effecting within any parent/ancestor builder"""
+        as having the given Effects within any parent/ancestor builder."""
 
     def call(
         self,

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -11,7 +11,7 @@ from hugr.build import Block, Case, Cfg, Conditional, TailLoop
 from hugr.build import function as hf
 from hugr.hugr.node_port import ToNode
 from hugr.metadata import HugrDebugInfo
-from hugr.ops import DataflowOp, Output
+from hugr.ops import CallIndirect, DataflowOp, Output
 from typing_extensions import Self, override
 
 from guppylang_internals.ast_util import AstNode
@@ -98,7 +98,13 @@ class DFBuilder(ABC, ToNode):
         """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
         avoid automatic debug information attachment.
         """
+        from guppylang_internals.compiler.core import may_have_side_effect
+
         op, effects = op
+
+        assert frozenset(effects) == frozenset(
+            [Effect.ANY] if may_have_side_effect(op) else []
+        )
         op_node = self._raw.add_op(op, *args)
         self._handle_side_effects(op_node, effects)
 

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/__init__.py
@@ -1,24 +1,33 @@
 from abc import ABC, abstractmethod, abstractproperty
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from types import TracebackType
-from typing import Generic, TypeVar
+from typing import Generic, NamedTuple, TypeAlias, TypeVar
 
-from hugr import Node, Wire, ops, val
+from hugr import Node, Wire, val
 from hugr import tys as ht
 from hugr.build import Block, Case, Cfg, Conditional, TailLoop
 from hugr.build import function as hf
 from hugr.hugr.node_port import ToNode
 from hugr.metadata import HugrDebugInfo
+from hugr.ops import DataflowOp, Output
 from typing_extensions import Self, override
 
 from guppylang_internals.ast_util import AstNode
-from guppylang_internals.compiler.core import may_have_side_effect
 from guppylang_internals.metadata.debug_info_util import (
     debug_conditions_fulfilled,
     make_location_record,
 )
+from guppylang_internals.tys import Effect
+
+
+@dataclass(frozen=True)
+class Pure:
+    op: DataflowOp
+
+
+OpWithEffects: TypeAlias = Pure | tuple[DataflowOp, Iterable[Effect]]
 
 
 @dataclass
@@ -33,7 +42,7 @@ class DFBuilder(ABC, ToNode):
     """
 
     current_ast_node: AstNode | None = field(default=None, kw_only=True)
-    _last_side_effect: Node | None = field(default=None, init=False)
+    _last_side_effect: dict[Effect, Node] = field(default_factory=dict, init=False)
 
     @abstractproperty
     def _raw(self) -> hf.Function | Case | TailLoop | Block:
@@ -76,13 +85,14 @@ class DFBuilder(ABC, ToNode):
 
     def set_outputs(self, *outputs: Wire) -> hf.Function | Case | TailLoop | Block:
         self._raw.set_outputs(*outputs)
-        if self._last_side_effect is not None:
-            self._handle_side_effects(self._raw.output_node)
+        self._handle_side_effects(
+            self._raw.output_node, list(self._last_side_effect.keys())
+        )
         return self._raw
 
     def add_op(
         self,
-        op: ops.DataflowOp,
+        op: OpWithEffects,
         /,
         *args: Wire,
         set_debug_info: bool = True,
@@ -90,9 +100,9 @@ class DFBuilder(ABC, ToNode):
         """Adds an op to the dataflow graph builder. Set `set_debug_info=False` to
         avoid automatic debug information attachment.
         """
+        op, effects = (op.op, []) if isinstance(op, Pure) else op
         op_node = self._raw.add_op(op, *args)
-        if may_have_side_effect(op):
-            self._handle_side_effects(op_node)
+        self._handle_side_effects(op_node, effects)
 
         if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
             assert self.current_ast_node is not None  # for type-checker
@@ -101,19 +111,36 @@ class DFBuilder(ABC, ToNode):
             )
         return op_node
 
-    def _handle_side_effects(self, op_node: ToNode) -> None:
-        if self._last_side_effect is None:
-            self._propagate_side_effects()
-            self._last_side_effect = self.input_node
-        else:
-            assert not isinstance(self._raw.hugr[self._last_side_effect].op, ops.Output)
+    def _handle_side_effects(self, op_node: ToNode, effects: Iterable[Effect]) -> None:
+        """Updates Hugr to reflect `op_node` having effects `effects`.
+        Does nothing if effects is empty (or the node already has those effects)."""
         node = op_node.to_node()
-        if self._last_side_effect != node:  # avoid self-loops when propagating
-            self._raw.add_state_order(self._last_side_effect, node)
-            self._last_side_effect = node
+        to_propagate = set()  # Effects newly added to our container
+
+        def get_last_node(e: Effect) -> Node:
+            last = self._last_side_effect.get(e)
+            if last is None:
+                to_propagate.add(e)
+                last = self.input_node
+            else:
+                assert not isinstance(self._raw.hugr[last].op, Output)
+            self._last_side_effect[e] = node
+            return last
+
+        prev_nodes = {get_last_node(e) for e in effects}
+        # Avoid cycles and duplicate edges:
+        prev_nodes.discard(node)
+        for prev in self._raw.hugr.incoming_order_links(node):
+            prev_nodes.discard(prev)
+
+        for prev in prev_nodes:
+            self._raw.add_state_order(prev, node)
+
+        if to_propagate:
+            self._propagate_side_effects(to_propagate)
 
     @abstractmethod
-    def _propagate_side_effects(self) -> None:
+    def _propagate_side_effects(self, effects: Iterable[Effect]) -> None:
         """Subclasses must implement to mark the container node
         as side-effecting within any parent/ancestor builder"""
 
@@ -121,6 +148,7 @@ class DFBuilder(ABC, ToNode):
         self,
         func: ToNode,
         *args: Wire,
+        effects: Iterable[Effect],
         instantiation: ht.FunctionType | None = None,
         type_args: Sequence[ht.TypeArg] | None = None,
         set_debug_info: bool = True,
@@ -131,7 +159,7 @@ class DFBuilder(ABC, ToNode):
         call = self._raw.call(
             func, *args, instantiation=instantiation, type_args=type_args
         )
-        self._handle_side_effects(call)
+        self._handle_side_effects(call, effects)
         if set_debug_info and debug_conditions_fulfilled(self.current_ast_node):
             assert self.current_ast_node is not None  # for type-checker
             self._raw.hugr[call].metadata[HugrDebugInfo] = make_location_record(
@@ -192,16 +220,17 @@ class TailLoopBuilder(_DFBuilderRaw[TailLoop]):
 
     def set_loop_outputs(self, predicate: Wire, *outputs: Wire) -> None:
         self._raw.set_loop_outputs(predicate, *outputs)
-        if self._last_side_effect is not None:
-            self._handle_side_effects(self._raw.output_node)
+        self._handle_side_effects(
+            self._raw.output_node, list(self._last_side_effect.keys())
+        )
 
-    def _propagate_side_effects(self) -> None:
-        self.parent._handle_side_effects(self._raw)
+    def _propagate_side_effects(self, effects: Iterable[Effect]) -> None:
+        self.parent._handle_side_effects(self._raw, effects)
 
 
 @dataclass
 class FunctionBuilder(_DFBuilderRaw[hf.Function]):
-    def _propagate_side_effects(self) -> None:
+    def _propagate_side_effects(self, effects: Iterable[Effect]) -> None:
         pass  # No parent
 
     @override
@@ -215,10 +244,10 @@ class CaseBuilder(_DFBuilderRaw[Case]):
     parent: Conditional
     grandparent: DFBuilder
 
-    def _propagate_side_effects(self) -> None:
+    def _propagate_side_effects(self, effects: Iterable[Effect]) -> None:
         # No need to do anything in the Conditional,
         # but the Conditional itself needs to be ordered inside its parent
-        self.grandparent._handle_side_effects(self.parent)
+        self.grandparent._handle_side_effects(self.parent, effects)
 
 
 @dataclass
@@ -253,12 +282,13 @@ class BlockBuilder(_DFBuilderRaw[Block]):
     parent: Cfg
     grandparent: DFBuilder
 
-    def _propagate_side_effects(self) -> None:
+    def _propagate_side_effects(self, effects: Iterable[Effect]) -> None:
         # No need to do anything in the CFG, but the CFG itself
         # needs to be ordered inside its parent,
-        self.grandparent._handle_side_effects(self.parent)
+        self.grandparent._handle_side_effects(self.parent, effects)
 
     def set_block_outputs(self, branching: Wire, *other_outputs: Wire) -> None:
         self._raw.set_outputs(branching, *other_outputs)
-        if self._last_side_effect is not None:
-            self._handle_side_effects(self._raw.output_node)
+        self._handle_side_effects(
+            self._raw.output_node, list(self._last_side_effect.keys())
+        )

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/ops.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/ops.py
@@ -1,20 +1,20 @@
 from hugr import ops as hops
 from hugr.tys import Sum, Type, TypeRow
 
-from guppylang_internals.compiler.builder import OpWithEffects, Pure
+from guppylang_internals.compiler.builder import OpWithEffects, pure
 
 
 def make_tuple(tys: TypeRow | None = None) -> OpWithEffects:
-    return Pure(hops.MakeTuple(tys))
+    return pure(hops.MakeTuple(tys))
 
 
 def unpack_tuple(tys: TypeRow | None = None) -> OpWithEffects:
-    return Pure(hops.UnpackTuple(tys))
+    return pure(hops.UnpackTuple(tys))
 
 
 def tag(tag: int, rows: Sum) -> OpWithEffects:
-    return Pure(hops.Tag(tag, rows))
+    return pure(hops.Tag(tag, rows))
 
 
 def some(ty: Type) -> OpWithEffects:
-    return Pure(hops.Some(ty))
+    return pure(hops.Some(ty))

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/ops.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/ops.py
@@ -1,20 +1,20 @@
-from hugr import ops
+from hugr import ops as hops
 from hugr.tys import Sum, Type, TypeRow
 
 from guppylang_internals.compiler.builder import OpWithEffects, Pure
 
 
 def make_tuple(tys: TypeRow | None = None) -> OpWithEffects:
-    return Pure(ops.MakeTuple(tys))
+    return Pure(hops.MakeTuple(tys))
 
 
 def unpack_tuple(tys: TypeRow | None = None) -> OpWithEffects:
-    return Pure(ops.UnpackTuple(tys))
+    return Pure(hops.UnpackTuple(tys))
 
 
 def tag(tag: int, rows: Sum) -> OpWithEffects:
-    return Pure(ops.Tag(tag, rows))
+    return Pure(hops.Tag(tag, rows))
 
 
 def some(ty: Type) -> OpWithEffects:
-    return Pure(ops.Some(ty))
+    return Pure(hops.Some(ty))

--- a/guppylang-internals/src/guppylang_internals/compiler/builder/ops.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/builder/ops.py
@@ -1,0 +1,20 @@
+from hugr import ops
+from hugr.tys import Sum, Type, TypeRow
+
+from guppylang_internals.compiler.builder import OpWithEffects, Pure
+
+
+def make_tuple(tys: TypeRow | None = None) -> OpWithEffects:
+    return Pure(ops.MakeTuple(tys))
+
+
+def unpack_tuple(tys: TypeRow | None = None) -> OpWithEffects:
+    return Pure(ops.UnpackTuple(tys))
+
+
+def tag(tag: int, rows: Sum) -> OpWithEffects:
+    return Pure(ops.Tag(tag, rows))
+
+
+def some(ty: Type) -> OpWithEffects:
+    return Pure(ops.Some(ty))

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -1,7 +1,7 @@
 import functools
 from collections.abc import Sequence
 
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
 from hugr.build import cfg as hc
 from hugr.hugr.node_port import ToNode
@@ -13,7 +13,7 @@ from guppylang_internals.checker.cfg_checker import (
     Signature,
 )
 from guppylang_internals.checker.core import Place, Variable
-from guppylang_internals.compiler.builder import BlockBuilder, DFBuilder
+from guppylang_internals.compiler.builder import BlockBuilder, DFBuilder, ops
 from guppylang_internals.compiler.core import (
     CompilerContext,
     DFContainer,
@@ -109,7 +109,7 @@ def compile_bb(
     else:
         # Even if we don't branch, we still have to add a `Sum(())` predicates
         branch_port = dfg.builder.add_op(
-            ops.Tag(0, ht.UnitSum(1)), set_debug_info=False
+            ops.tag(0, ht.UnitSum(1)), set_debug_info=False
         )
 
     # Finally, we have to add the block output.
@@ -206,7 +206,7 @@ def choose_vars_for_tuple_sum(
         for i, var_row in enumerate(output_vars):
             case = conditional.add_case(i)
             outputs = [case.inputs()[all_vars_idxs[v.id]] for v in var_row]
-            tag = case.add_op(ops.Tag(i, sum_type), *outputs)
+            tag = case.add_op(ops.tag(i, sum_type), *outputs)
             case.set_outputs(tag)
         return conditional
 

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -4,12 +4,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from hugr import Hugr, Wire
-from hugr import ops as hops
 from hugr import tys as ht
 from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder
 from hugr.hugr.base import OpVarCov
-from hugr.std import PRELUDE
+from hugr.ops import Module
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
 
@@ -87,7 +86,7 @@ class CompilerContext(ToHugrContext):
     themselves (i.e. `compile_inner` has not yet been called).
     """
 
-    module: DefinitionBuilder[hops.Module]
+    module: DefinitionBuilder[Module]
 
     #: The definitions compiled so far. For generic definitions, their id can occur
     #: multiple times here with respectively different monomorphizations. See
@@ -109,7 +108,7 @@ class CompilerContext(ToHugrContext):
 
     def __init__(
         self,
-        module: DefinitionBuilder[hops.Module],
+        module: DefinitionBuilder[Module],
         exported_defs: set[DefId],
         file_table: StringTable | None = None,
     ) -> None:
@@ -305,44 +304,6 @@ def get_parent_type(defn: Definition) -> "RawDef | None":
 QUANTUM_EXTENSION = TKET_QUANTUM_EXTENSION
 RESULT_EXTENSION = TKET_RESULT_EXTENSION
 DEBUG_EXTENSION = TKET_DEBUG_EXTENSION
-
-#: List of extension ops that have side-effects, identified by their qualified name
-EXTENSION_OPS_WITH_SIDE_EFFECTS: list[str] = [
-    # Outputs should be ordered w.r.t. each other but also w.r.t. panics
-    *(op_def.qualified_name() for op_def in RESULT_EXTENSION.operations.values()),
-    PRELUDE.get_op("panic").qualified_name(),
-    PRELUDE.get_op("exit").qualified_name(),
-    DEBUG_EXTENSION.get_op("StateResult").qualified_name(),
-    # Qubit allocation and deallocation have the side-effect of changing the number of
-    # available free qubits
-    QUANTUM_EXTENSION.get_op("QAlloc").qualified_name(),
-    QUANTUM_EXTENSION.get_op("QFree").qualified_name(),
-    QUANTUM_EXTENSION.get_op("MeasureFree").qualified_name(),
-]
-
-
-def may_have_side_effect(op: hops.Op) -> bool:
-    """Checks whether an operation could have a side-effect.
-
-    We need to insert implicit state order edges between these kinds of nodes to ensure
-    they are executed in the correct order, even if there is no data dependency.
-    """
-    match op:
-        case hops.ExtOp() as ext_op:
-            return ext_op.op_def().qualified_name() in EXTENSION_OPS_WITH_SIDE_EFFECTS
-        case hops.Custom(op_name=op_name, extension=extension):
-            qualified_name = f"{extension}.{op_name}" if extension else op_name
-            return qualified_name in EXTENSION_OPS_WITH_SIDE_EFFECTS
-        case hops.Call() | hops.CallIndirect():
-            # Conservative choice is to assume that all calls could have side effects.
-            # In the future we could inspect the call graph to figure out a more
-            # precise answer
-            return True
-        case _:
-            # There is no need to handle TailLoop (in case of non-termination) since
-            # TailLoops are only generated for array comprehensions which must have
-            # statically-guaranteed (finite) size. TODO revisit this for lists.
-            return False
 
 
 #: List of linear extension types that correspond to affine Guppy types and thus require

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -4,11 +4,11 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from hugr import Hugr, Wire
+from hugr import ops as hops
 from hugr import tys as ht
 from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder
 from hugr.hugr.base import OpVarCov
-from hugr.ops import Module
 from hugr.std import PRELUDE
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
@@ -87,7 +87,7 @@ class CompilerContext(ToHugrContext):
     themselves (i.e. `compile_inner` has not yet been called).
     """
 
-    module: DefinitionBuilder[Module]
+    module: DefinitionBuilder[hops.Module]
 
     #: The definitions compiled so far. For generic definitions, their id can occur
     #: multiple times here with respectively different monomorphizations. See
@@ -109,7 +109,7 @@ class CompilerContext(ToHugrContext):
 
     def __init__(
         self,
-        module: DefinitionBuilder[Module],
+        module: DefinitionBuilder[hops.Module],
         exported_defs: set[DefId],
         file_table: StringTable | None = None,
     ) -> None:
@@ -319,6 +319,30 @@ EXTENSION_OPS_WITH_SIDE_EFFECTS: list[str] = [
     QUANTUM_EXTENSION.get_op("QFree").qualified_name(),
     QUANTUM_EXTENSION.get_op("MeasureFree").qualified_name(),
 ]
+
+
+def may_have_side_effect(op: hops.Op) -> bool:
+    """Checks whether an operation could have a side-effect.
+
+    We need to insert implicit state order edges between these kinds of nodes to ensure
+    they are executed in the correct order, even if there is no data dependency.
+    """
+    match op:
+        case hops.ExtOp() as ext_op:
+            return ext_op.op_def().qualified_name() in EXTENSION_OPS_WITH_SIDE_EFFECTS
+        case hops.Custom(op_name=op_name, extension=extension):
+            qualified_name = f"{extension}.{op_name}" if extension else op_name
+            return qualified_name in EXTENSION_OPS_WITH_SIDE_EFFECTS
+        case hops.Call() | hops.CallIndirect():
+            # Conservative choice is to assume that all calls could have side effects.
+            # In the future we could inspect the call graph to figure out a more
+            # precise answer
+            return True
+        case _:
+            # There is no need to handle TailLoop (in case of non-termination) since
+            # TailLoops are only generated for array comprehensions which must have
+            # statically-guaranteed (finite) size. TODO revisit this for lists.
+            return False
 
 
 #: List of linear extension types that correspond to affine Guppy types and thus require

--- a/guppylang-internals/src/guppylang_internals/compiler/core.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/core.py
@@ -3,11 +3,12 @@ from abc import ABC
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from hugr import Hugr, Wire, ops
+from hugr import Hugr, Wire
 from hugr import tys as ht
 from hugr.build import function as hf
 from hugr.build.dfg import DefinitionBuilder
 from hugr.hugr.base import OpVarCov
+from hugr.ops import Module
 from hugr.std import PRELUDE
 from hugr.std.collections.array import EXTENSION as ARRAY_EXTENSION
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
@@ -19,6 +20,7 @@ from guppylang_internals.checker.core import (
     TupleAccess,
     Variable,
 )
+from guppylang_internals.compiler.builder import ops
 from guppylang_internals.definition.common import (
     CompilableDef,
     CompiledDef,
@@ -85,7 +87,7 @@ class CompilerContext(ToHugrContext):
     themselves (i.e. `compile_inner` has not yet been called).
     """
 
-    module: DefinitionBuilder[ops.Module]
+    module: DefinitionBuilder[Module]
 
     #: The definitions compiled so far. For generic definitions, their id can occur
     #: multiple times here with respectively different monomorphizations. See
@@ -107,7 +109,7 @@ class CompilerContext(ToHugrContext):
 
     def __init__(
         self,
-        module: DefinitionBuilder[ops.Module],
+        module: DefinitionBuilder[Module],
         exported_defs: set[DefId],
         file_table: StringTable | None = None,
     ) -> None:
@@ -227,7 +229,7 @@ class DFContainer:
             raise InternalGuppyError(f"Couldn't obtain a port for `{place}`")
         child_types = [child.ty.to_hugr(self.ctx) for child in children]
         child_wires = [self[child] for child in children]
-        wire = self.builder.add_op(ops.MakeTuple(child_types), *child_wires)[0]
+        wire = self.builder.add_op(ops.make_tuple(child_types), *child_wires)[0]
         for child in children:
             if child.ty.linear:
                 self.locals.pop(child.id)
@@ -240,7 +242,7 @@ class DFContainer:
         is_return = isinstance(place, Variable) and is_return_var(place.name)
         if isinstance(place.ty, StructType) and not is_return:
             hugr_fields_ty = [t.ty.to_hugr(self.ctx) for t in place.ty.fields]
-            unpack = self.builder.add_op(ops.UnpackTuple(hugr_fields_ty), port)
+            unpack = self.builder.add_op(ops.unpack_tuple(hugr_fields_ty), port)
             for field, field_port in zip(place.ty.fields, unpack, strict=True):
                 self[FieldAccess(place, field, None)] = field_port
             # If we had a previous wire assigned to this place, we need forget about it.
@@ -249,7 +251,7 @@ class DFContainer:
         # Same for tuples.
         elif isinstance(place.ty, TupleType) and not is_return:
             hugr_elem_tys = [ty.to_hugr(self.ctx) for ty in place.ty.element_types]
-            unpack = self.builder.add_op(ops.UnpackTuple(hugr_elem_tys), port)
+            unpack = self.builder.add_op(ops.unpack_tuple(hugr_elem_tys), port)
             for idx, (elem, elem_port) in enumerate(
                 zip(place.ty.element_types, unpack, strict=True)
             ):
@@ -319,30 +321,6 @@ EXTENSION_OPS_WITH_SIDE_EFFECTS: list[str] = [
 ]
 
 
-def may_have_side_effect(op: ops.Op) -> bool:
-    """Checks whether an operation could have a side-effect.
-
-    We need to insert implicit state order edges between these kinds of nodes to ensure
-    they are executed in the correct order, even if there is no data dependency.
-    """
-    match op:
-        case ops.ExtOp() as ext_op:
-            return ext_op.op_def().qualified_name() in EXTENSION_OPS_WITH_SIDE_EFFECTS
-        case ops.Custom(op_name=op_name, extension=extension):
-            qualified_name = f"{extension}.{op_name}" if extension else op_name
-            return qualified_name in EXTENSION_OPS_WITH_SIDE_EFFECTS
-        case ops.Call() | ops.CallIndirect():
-            # Conservative choice is to assume that all calls could have side effects.
-            # In the future we could inspect the call graph to figure out a more
-            # precise answer
-            return True
-        case _:
-            # There is no need to handle TailLoop (in case of non-termination) since
-            # TailLoops are only generated for array comprehensions which must have
-            # statically-guaranteed (finite) size. TODO revisit this for lists.
-            return False
-
-
 #: List of linear extension types that correspond to affine Guppy types and thus require
 #: insertion of an explicit drop operation.
 AFFINE_EXTENSION_TYS: list[str] = [
@@ -378,13 +356,6 @@ def requires_drop(ty: ht.Type) -> bool:
             return False
 
 
-def drop_op(ty: ht.Type) -> ops.ExtOp:
-    """Returns the operation to drop affine values."""
-    return GUPPY_EXTENSION.get_op("drop").instantiate(
-        [ht.TypeTypeArg(ty)], ht.FunctionType([ty], [])
-    )
-
-
 def insert_drops(hugr: Hugr[OpVarCov]) -> None:
     """Inserts explicit drop ops for unconnected ports into the Hugr.
     TODO: This is a quick workaround until we can properly insert these drops during
@@ -403,5 +374,8 @@ def insert_drops(hugr: Hugr[OpVarCov]) -> None:
                 and isinstance(kind, ht.ValueKind)
                 and requires_drop(kind.ty)
             ):
-                drop = hugr.add_node(drop_op(kind.ty), parent=data.parent)
+                drop_op = GUPPY_EXTENSION.get_op("drop").instantiate(
+                    [ht.TypeTypeArg(kind.ty)], ht.FunctionType([kind.ty], [])
+                )
+                drop = hugr.add_node(drop_op, parent=data.parent)
                 hugr.add_link(port, drop.inp(0))

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -425,12 +425,11 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             num_returns = len(type_to_row(func_ty.output))
             consumed_args, other_args = args[0:input_len], args[input_len:]
             consumed_wires = self._compile_call_args(consumed_args, func_ty)
+            # This is terrible - we'll need to do better if tensored functions
+            # become non-experimental:
+            effects = [Effect.ANY]
             call = self.builder.add_op(
-                (
-                    hops.CallIndirect(func_ty.to_hugr(self.ctx)),
-                    # ALAN need something here, this will fail at runtime
-                    func_ty.effects,  # type: ignore[attr-defined]
-                ),
+                (hops.CallIndirect(func_ty.to_hugr(self.ctx)), effects),
                 func,
                 *consumed_wires,
             )

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -1,5 +1,5 @@
 import ast
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from contextlib import AbstractContextManager, ExitStack, contextmanager
 from typing import Any, TypeGuard, TypeVar
 
@@ -8,7 +8,8 @@ import hugr.std.float
 import hugr.std.int
 import hugr.std.logic
 import hugr.std.prelude
-from hugr import Node, Wire, ops
+from hugr import Node, Wire
+from hugr import ops as hops
 from hugr import tys as ht
 from hugr import val as hv
 
@@ -16,7 +17,12 @@ from guppylang_internals.ast_util import AstNode, AstVisitor, get_type
 from guppylang_internals.cfg.builder import tmp_vars
 from guppylang_internals.checker.core import Variable, contains_subscript
 from guppylang_internals.checker.errors.generic import UnsupportedError
-from guppylang_internals.compiler.builder import CondBuilder, DFBuilder
+from guppylang_internals.compiler.builder import (
+    CondBuilder,
+    DFBuilder,
+    Pure,
+    ops,
+)
 from guppylang_internals.compiler.core import (
     DEBUG_EXTENSION,
     CompilerBase,
@@ -24,7 +30,7 @@ from guppylang_internals.compiler.core import (
     DFContainer,
 )
 from guppylang_internals.compiler.hugr_extension import PartialOp
-from guppylang_internals.definition.common import CheckableGenericDef
+from guppylang_internals.definition.common import CheckableGenericDef, CompiledDef
 from guppylang_internals.definition.custom import CustomFunctionDef
 from guppylang_internals.definition.value import (
     CallReturnWires,
@@ -71,10 +77,12 @@ from guppylang_internals.std._internal.compiler.list import (
     list_new,
 )
 from guppylang_internals.std._internal.compiler.prelude import (
+    barrier_op,
     build_panic,
     make_error,
     panic,
 )
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import (
     bool_type,
     get_element_type,
@@ -263,7 +271,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         if isinstance(get_type(node), FunctionDefType):
             # Function items don't need an actual runtime representation so we just
             # lower them to a unit value (see `FunctionItemType.to_hugr`)
-            return self.builder.add_op(ops.MakeTuple())
+            return self.builder.add_op(ops.make_tuple())
         defn = self.ctx.build_compiled_def(node.def_id, type_args=())
         assert isinstance(defn, CompiledValueDef)
         return defn.load(self.dfg, self.ctx, node)
@@ -291,12 +299,12 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
     def _unpack_tuple(self, wire: Wire, types: Sequence[Type]) -> Sequence[Wire]:
         """Add a tuple unpack operation to the graph"""
         types = [t.to_hugr(self.ctx) for t in types]
-        return list(self.builder.add_op(ops.UnpackTuple(types), wire))
+        return list(self.builder.add_op(ops.unpack_tuple(types), wire))
 
     def _pack_tuple(self, wires: Sequence[Wire], types: Sequence[Type]) -> Wire:
         """Add a tuple pack operation to the graph"""
         types = [t.to_hugr(self.ctx) for t in types]
-        return self.builder.add_op(ops.MakeTuple(types), *wires)
+        return self.builder.add_op(ops.make_tuple(types), *wires)
 
     def _pack_returns(self, returns: Sequence[Wire], return_ty: Type) -> Wire:
         """Groups function return values into a tuple"""
@@ -337,9 +345,34 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         assert isinstance(func_ty, FunctionType)
         num_returns = len(type_to_row(func_ty.output))
 
+        def get_def_effects(defn: CompiledDef) -> Iterable[Effect]:
+            assert isinstance(defn, CompiledCallableDef)
+            return defn.call_effects
+
+        def get_effects(func: ast.expr) -> Iterable[Effect]:
+            """Get the effects of a function call."""
+            func_ty = get_type(func)
+            if isinstance(func_ty, FunctionDefType):
+                defn = self.ctx.build_compiled_def(func_ty.def_id, func_ty.args)
+                return get_def_effects(defn)
+            # if isinstance(func, GlobalName):
+            #    defn = ENGINE.get_checked(func.def_id, ())
+            #    return get_def_effects(defn)
+            if isinstance(func, TypeApply) and isinstance(func.value, GlobalName):
+                defn = self.ctx.build_compiled_def(func.value.def_id, func.inst)
+                return get_def_effects(defn)
+            # if isinstance(func, TypeApply):
+            # Type applications cannot change effects as there are no effect variables.
+            # (ALAN unless we can TypeApply with a Protocol instance?)
+            # return get_effects(func.value)
+            raise InternalGuppyError(
+                f"Function {func} does not have effects information"
+            )
+
         args = self._compile_call_args(node.args, func_ty)
+        effects = get_effects(node.func)
         call = self.builder.add_op(
-            ops.CallIndirect(func_ty.to_hugr(self.ctx)),
+            (hops.CallIndirect(func_ty.to_hugr(self.ctx)), effects),
             func,
             *args,
         )
@@ -398,7 +431,11 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             consumed_args, other_args = args[0:input_len], args[input_len:]
             consumed_wires = self._compile_call_args(consumed_args, func_ty)
             call = self.builder.add_op(
-                ops.CallIndirect(func_ty.to_hugr(self.ctx)),
+                (
+                    hops.CallIndirect(func_ty.to_hugr(self.ctx)),
+                    # ALAN need something here, this will fail at runtime
+                    func_ty.effects,  # type: ignore[attr-defined]
+                ),
                 func,
                 *consumed_wires,
             )
@@ -472,7 +509,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         if isinstance(get_type(node), FunctionDefType):
             # Function items don't need an actual runtime representation so we just
             # lower them to a unit value (see `FunctionItemType.to_hugr`)
-            return self.builder.add_op(ops.MakeTuple())
+            return self.builder.add_op(ops.make_tuple())
         defn = self.ctx.build_compiled_def(node.value.def_id, node.inst)
         assert isinstance(defn, CompiledCallableDef)
         return defn.load(self.dfg, self.ctx, node)
@@ -482,7 +519,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         # since it is not implemented via a dunder method
         if isinstance(node.op, ast.Not):
             arg = self.visit(node.operand)
-            return self.builder.add_op(hugr.std.logic.Not, arg)
+            return self.builder.add_op(Pure(hugr.std.logic.Not), arg)
 
         raise InternalGuppyError("Node should have been removed during type checking.")
 
@@ -545,12 +582,10 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
 
     def visit_BarrierExpr(self, node: BarrierExpr) -> Wire:
         hugr_tys = [get_type(e).to_hugr(self.ctx) for e in node.args]
-        op = hugr.std.prelude.PRELUDE_EXTENSION.get_op("Barrier").instantiate(
-            [ht.ListArg([ht.TypeTypeArg(ty) for ty in hugr_tys])],
-            ht.FunctionType.endo(hugr_tys),
-        )
 
-        barrier_n = self.builder.add_op(op, *(self.visit(e) for e in node.args))
+        barrier_n = self.builder.add_op(
+            barrier_op(hugr_tys), *(self.visit(e) for e in node.args)
+        )
 
         self._update_inout_ports(node.args, iter(barrier_n), node.func_ty)
         return self._pack_returns([], NoneType())
@@ -568,7 +603,10 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             [standard_array_type(ht.Qubit, num_qubits_arg)],
         )
 
-        op = ops.ExtOp(DEBUG_EXTENSION.get_op("StateResult"), signature=sig, args=args)
+        op = (
+            hops.ExtOp(DEBUG_EXTENSION.get_op("StateResult"), signature=sig, args=args),
+            [Effect.ANY],
+        )
 
         qubit_arr_in: Wire
         if not node.array_len:
@@ -694,17 +732,17 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
                 break_pred_hugr_ty = ht.Either([iter_ty.to_hugr(self.ctx)], [])
                 with stop_case:
                     self.dfg[break_pred.place] = self.builder.add_op(
-                        ops.Tag(1, break_pred_hugr_ty)
+                        ops.tag(1, break_pred_hugr_ty)
                     )
                 # Otherwise, we continue, set the break predicate to false, and insert
                 # the iterator for the next loop iteration
                 stack.enter_context(hasnext_case)
                 next_wire = self.dfg[next_var.place]
-                elt, it = self.builder.add_op(ops.UnpackTuple(), next_wire)
+                elt, it = self.builder.add_op(ops.unpack_tuple(), next_wire)
                 compiler.dfg = self.dfg
                 compiler._assign(gen.target, elt)
                 self.dfg[break_pred.place] = self.builder.add_op(
-                    ops.Tag(0, break_pred_hugr_ty), it
+                    ops.tag(0, break_pred_hugr_ty), it
                 )
                 # Enter nested conditionals for each if guard on the generator
                 for if_expr in gen.ifs:
@@ -735,7 +773,7 @@ def pack_returns(
         types = type_to_row(return_ty)
         assert len(returns) == len(types)
         hugr_tys = [t.to_hugr(ctx) for t in types]
-        return builder.add_op(ops.MakeTuple(hugr_tys), *returns)
+        return builder.add_op(ops.make_tuple(hugr_tys), *returns)
     assert len(returns) == 1, (
         f"Expected a single return value. Got {returns}. return type {return_ty}"
     )
@@ -753,7 +791,7 @@ def unpack_wire(
     if isinstance(return_ty, TupleType | NoneType):
         types = type_to_row(return_ty)
         hugr_tys = [t.to_hugr(ctx) for t in types]
-        return list(builder.add_op(ops.UnpackTuple(hugr_tys), wire).outputs())
+        return list(builder.add_op(ops.unpack_tuple(hugr_tys), wire).outputs())
     return [wire]
 
 

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -30,7 +30,10 @@ from guppylang_internals.compiler.core import (
     DFContainer,
 )
 from guppylang_internals.compiler.hugr_extension import PartialOp
-from guppylang_internals.definition.common import CheckableGenericDef, CompiledDef
+from guppylang_internals.definition.common import (
+    CheckableGenericDef,
+    DefId,
+)
 from guppylang_internals.definition.custom import CustomFunctionDef
 from guppylang_internals.definition.value import (
     CallReturnWires,
@@ -345,7 +348,8 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         assert isinstance(func_ty, FunctionType)
         num_returns = len(type_to_row(func_ty.output))
 
-        def get_def_effects(defn: CompiledDef) -> Iterable[Effect]:
+        def get_def_effects(def_id: DefId, args: Inst) -> Iterable[Effect]:
+            defn = self.ctx.build_compiled_def(def_id, args)
             assert isinstance(defn, CompiledCallableDef)
             return defn.call_effects
 
@@ -353,14 +357,12 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             """Get the effects of a function call."""
             func_ty = get_type(func)
             if isinstance(func_ty, FunctionDefType):
-                defn = self.ctx.build_compiled_def(func_ty.def_id, func_ty.args)
-                return get_def_effects(defn)
-            # if isinstance(func, GlobalName):
-            #    defn = ENGINE.get_checked(func.def_id, ())
-            #    return get_def_effects(defn)
+                return get_def_effects(func_ty.def_id, func_ty.args)
             if isinstance(func, TypeApply) and isinstance(func.value, GlobalName):
-                defn = self.ctx.build_compiled_def(func.value.def_id, func.inst)
-                return get_def_effects(defn)
+                return get_def_effects(func.value.def_id, func.inst)
+            if isinstance(func, PlaceNode):
+                # A conservative approximation. We may need to improve this...somehow.
+                return [Effect.ANY]
             # if isinstance(func, TypeApply):
             # Type applications cannot change effects as there are no effect variables.
             # (ALAN unless we can TypeApply with a Protocol instance?)

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -20,8 +20,8 @@ from guppylang_internals.checker.errors.generic import UnsupportedError
 from guppylang_internals.compiler.builder import (
     CondBuilder,
     DFBuilder,
-    Pure,
     ops,
+    pure,
 )
 from guppylang_internals.compiler.core import (
     DEBUG_EXTENSION,
@@ -513,7 +513,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         # since it is not implemented via a dunder method
         if isinstance(node.op, ast.Not):
             arg = self.visit(node.operand)
-            return self.builder.add_op(Pure(hugr.std.logic.Not), arg)
+            return self.builder.add_op(pure(hugr.std.logic.Not), arg)
 
         raise InternalGuppyError("Node should have been removed during type checking.")
 

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -358,18 +358,11 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             func_ty = get_type(func)
             if isinstance(func_ty, FunctionDefType):
                 return get_def_effects(func_ty.def_id, func_ty.args)
-            if isinstance(func, TypeApply) and isinstance(func.value, GlobalName):
+            if isinstance(func, TypeApply):
+                assert isinstance(func.value, GlobalName)
                 return get_def_effects(func.value.def_id, func.inst)
-            if isinstance(func, PlaceNode):
-                # A conservative approximation. We may need to improve this...somehow.
-                return [Effect.ANY]
-            # if isinstance(func, TypeApply):
-            # Type applications cannot change effects as there are no effect variables.
-            # (ALAN unless we can TypeApply with a Protocol instance?)
-            # return get_effects(func.value)
-            raise InternalGuppyError(
-                f"Function {func} does not have effects information"
-            )
+            # A conservative approximation. We may need to improve this...somehow.
+            return [Effect.ANY]
 
         args = self._compile_call_args(node.args, func_ty)
         effects = get_effects(node.func)

--- a/guppylang-internals/src/guppylang_internals/compiler/hugr_extension.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/hugr_extension.py
@@ -9,6 +9,8 @@ import hugr.ext as he
 import hugr.tys as ht
 from hugr import ops
 
+from guppylang_internals.compiler.builder import OpWithEffects, Pure
+
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
 
@@ -77,7 +79,7 @@ class PartialOp(ops.AsExtOp):
     @classmethod
     def from_closure(
         cls, closure_ty: ht.FunctionType, captured_tys: Sequence[ht.Type]
-    ) -> PartialOp:
+    ) -> OpWithEffects:
         """An operation that partially evaluates a function.
 
         args:
@@ -93,10 +95,12 @@ class PartialOp(ops.AsExtOp):
         assert captured_tys == closure_ty.input[: len(captured_tys)]
 
         other_inputs = closure_ty.input[len(captured_tys) :]
-        return cls(
-            captured_inputs=list(captured_tys),
-            other_inputs=list(other_inputs),
-            outputs=list(closure_ty.output),
+        return Pure(
+            cls(
+                captured_inputs=list(captured_tys),
+                other_inputs=list(other_inputs),
+                outputs=list(closure_ty.output),
+            )
         )
 
     def op_def(self) -> he.OpDef:

--- a/guppylang-internals/src/guppylang_internals/compiler/hugr_extension.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/hugr_extension.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 import hugr.ext as he
 import hugr.tys as ht
-from hugr import ops
+from hugr.ops import AsExtOp, ExtOp
 
 from guppylang_internals.compiler.builder import OpWithEffects, Pure
 
@@ -58,7 +58,7 @@ PARTIAL_OP_DEF: he.OpDef = EXTENSION.add_op_def(
 
 
 @dataclass
-class PartialOp(ops.AsExtOp):
+class PartialOp(AsExtOp):
     """An operation that partially evaluates a function.
 
     args:
@@ -127,11 +127,9 @@ class PartialOp(ops.AsExtOp):
         return ht.FunctionType([closure_ty, *self.captured_inputs], [partial_fn_ty])
 
     @classmethod
-    def from_ext(cls, custom: ops.ExtOp) -> PartialOp:
+    def from_ext(cls, custom: ExtOp) -> PartialOp:
         match custom:
-            case ops.ExtOp(
-                _op_def=op_def, args=[captured_args, other_args, output_args]
-            ):
+            case ExtOp(_op_def=op_def, args=[captured_args, other_args, output_args]):
                 if op_def.qualified_name() == PARTIAL_OP_DEF.qualified_name():
                     return cls(
                         captured_inputs=[*_arg_seq_to_types(captured_args)],
@@ -139,7 +137,7 @@ class PartialOp(ops.AsExtOp):
                         outputs=[*_arg_seq_to_types(output_args)],
                     )
         msg = f"Invalid custom op: {custom}"
-        raise ops.AsExtOp.InvalidExtOp(msg)
+        raise AsExtOp.InvalidExtOp(msg)
 
     @property
     def num_out(self) -> int:
@@ -171,7 +169,7 @@ UNSUPPORTED_OP_DEF: he.OpDef = EXTENSION.add_op_def(
 
 
 @dataclass
-class UnsupportedOp(ops.AsExtOp):
+class UnsupportedOp(AsExtOp):
     """An unsupported operation stub emitted by Guppy.
 
     args:
@@ -197,9 +195,9 @@ class UnsupportedOp(ops.AsExtOp):
         return ht.FunctionType(self.inputs, self.outputs)
 
     @classmethod
-    def from_ext(cls, custom: ops.ExtOp) -> UnsupportedOp:
+    def from_ext(cls, custom: ExtOp) -> UnsupportedOp:
         match custom:
-            case ops.ExtOp(_op_def=op_def, args=args):
+            case ExtOp(_op_def=op_def, args=args):
                 if op_def.qualified_name() == UNSUPPORTED_OP_DEF.qualified_name():
                     [op_name, input_args, output_args] = args
                     assert isinstance(op_name, ht.StringArg), (
@@ -213,7 +211,7 @@ class UnsupportedOp(ops.AsExtOp):
                         outputs=[*_arg_seq_to_types(output_args)],
                     )
         msg = f"Invalid custom op: {custom}"
-        raise ops.AsExtOp.InvalidExtOp(msg)
+        raise AsExtOp.InvalidExtOp(msg)
 
     @property
     def num_out(self) -> int:

--- a/guppylang-internals/src/guppylang_internals/compiler/hugr_extension.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/hugr_extension.py
@@ -9,7 +9,7 @@ import hugr.ext as he
 import hugr.tys as ht
 from hugr.ops import AsExtOp, ExtOp
 
-from guppylang_internals.compiler.builder import OpWithEffects, Pure
+from guppylang_internals.compiler.builder import OpWithEffects, pure
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -95,7 +95,7 @@ class PartialOp(AsExtOp):
         assert captured_tys == closure_ty.input[: len(captured_tys)]
 
         other_inputs = closure_ty.input[len(captured_tys) :]
-        return Pure(
+        return pure(
             cls(
                 captured_inputs=list(captured_tys),
                 other_inputs=list(other_inputs),

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -7,7 +7,7 @@ from hugr.ops import CallIndirect, ExtOp
 from guppylang_internals.ast_util import get_type
 from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
 from guppylang_internals.checker.modifier_checker import non_copyable_front_others_back
-from guppylang_internals.compiler.builder import Pure
+from guppylang_internals.compiler.builder import pure
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
@@ -81,7 +81,7 @@ def compile_modified_block(
     if modified_block.has_dagger():
         dagger_ty = ht.FunctionType([hugr_ty], [hugr_ty])
         call = dfg.builder.add_op(
-            Pure(  # This is generation of the daggered version, not calling it (below)
+            pure(  # This is generation of the daggered version, not calling it (below)
                 ExtOp(
                     dagger_op_def,
                     dagger_ty,
@@ -96,7 +96,7 @@ def compile_modified_block(
             num = expr_compiler.compile(power.iter, dfg)
             call = dfg.builder.add_op(
                 # This is generation of the powered version, not calling it (below)
-                Pure(
+                pure(
                     ExtOp(
                         power_op_def,
                         power_ty,
@@ -124,7 +124,7 @@ def compile_modified_block(
                 [std_array, *hugr_ty.input], [std_array, *hugr_ty.output]
             )
             # Compilation of the controlled version is pure, not calling it (below)
-            op = Pure(
+            op = pure(
                 ExtOp(
                     control_op_def,
                     ht.FunctionType([input_fn_ty], [output_fn_ty]),

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -1,7 +1,8 @@
 """Hugr generation for modifiers."""
 
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
+from hugr.ops import CallIndirect, ExtOp
 
 from guppylang_internals.ast_util import get_type
 from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
@@ -81,7 +82,7 @@ def compile_modified_block(
         dagger_ty = ht.FunctionType([hugr_ty], [hugr_ty])
         call = dfg.builder.add_op(
             Pure(  # This is generation of the daggered version, not calling it (below)
-                ops.ExtOp(
+                ExtOp(
                     dagger_op_def,
                     dagger_ty,
                     [in_out_arg, other_in_arg],
@@ -96,7 +97,7 @@ def compile_modified_block(
             call = dfg.builder.add_op(
                 # This is generation of the powered version, not calling it (below)
                 Pure(
-                    ops.ExtOp(
+                    ExtOp(
                         power_op_def,
                         power_ty,
                         [in_out_arg, other_in_arg],
@@ -124,7 +125,7 @@ def compile_modified_block(
             )
             # Compilation of the controlled version is pure, not calling it (below)
             op = Pure(
-                ops.ExtOp(
+                ExtOp(
                     control_op_def,
                     ht.FunctionType([input_fn_ty], [output_fn_ty]),
                     [qubit_num, in_out_arg, other_in_arg],
@@ -159,7 +160,7 @@ def compile_modified_block(
 
     # Call the modified block.
     call = dfg.builder.add_op(
-        (ops.CallIndirect(), effects),
+        (CallIndirect(), effects),
         call,
         *ctrl_args,
         *args,

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -6,6 +6,7 @@ from hugr import tys as ht
 from guppylang_internals.ast_util import get_type
 from guppylang_internals.checker.core import SubscriptAccess, contains_subscript
 from guppylang_internals.checker.modifier_checker import non_copyable_front_others_back
+from guppylang_internals.compiler.builder import Pure
 from guppylang_internals.compiler.cfg_compiler import compile_cfg
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
@@ -66,6 +67,7 @@ def compile_modified_block(
     # compile body
     cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
     func_builder.set_outputs(*cfg)
+    effects = func_builder._last_side_effect.keys()
 
     # Add the LoadFunc node
     call = dfg.builder.load_function(func_builder, hugr_ty)
@@ -78,10 +80,12 @@ def compile_modified_block(
     if modified_block.has_dagger():
         dagger_ty = ht.FunctionType([hugr_ty], [hugr_ty])
         call = dfg.builder.add_op(
-            ops.ExtOp(
-                dagger_op_def,
-                dagger_ty,
-                [in_out_arg, other_in_arg],
+            Pure(  # This is generation of the daggered version, not calling it (below)
+                ops.ExtOp(
+                    dagger_op_def,
+                    dagger_ty,
+                    [in_out_arg, other_in_arg],
+                )
             ),
             call,
         )
@@ -90,10 +94,13 @@ def compile_modified_block(
         for power in modified_block.power:
             num = expr_compiler.compile(power.iter, dfg)
             call = dfg.builder.add_op(
-                ops.ExtOp(
-                    power_op_def,
-                    power_ty,
-                    [in_out_arg, other_in_arg],
+                # This is generation of the powered version, not calling it (below)
+                Pure(
+                    ops.ExtOp(
+                        power_op_def,
+                        power_ty,
+                        [in_out_arg, other_in_arg],
+                    )
                 ),
                 call,
                 num,
@@ -115,10 +122,13 @@ def compile_modified_block(
             output_fn_ty = ht.FunctionType(
                 [std_array, *hugr_ty.input], [std_array, *hugr_ty.output]
             )
-            op = ops.ExtOp(
-                control_op_def,
-                ht.FunctionType([input_fn_ty], [output_fn_ty]),
-                [qubit_num, in_out_arg, other_in_arg],
+            # Compilation of the controlled version is pure, not calling it (below)
+            op = Pure(
+                ops.ExtOp(
+                    control_op_def,
+                    ht.FunctionType([input_fn_ty], [output_fn_ty]),
+                    [qubit_num, in_out_arg, other_in_arg],
+                )
             )
             call = dfg.builder.add_op(op, call)
             # Update types: later modifiers see the newly wrapped function type
@@ -149,7 +159,7 @@ def compile_modified_block(
 
     # Call the modified block.
     call = dfg.builder.add_op(
-        ops.CallIndirect(),
+        (ops.CallIndirect(), effects),
         call,
         *ctrl_args,
         *args,

--- a/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/modifier_compiler.py
@@ -21,6 +21,7 @@ from guppylang_internals.std._internal.compiler.array import (
     unpack_array,
 )
 from guppylang_internals.std._internal.compiler.tket_exts import MODIFIER_EXTENSION
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import int_type, is_array_type
 from guppylang_internals.tys.ty import InputFlags
 
@@ -68,7 +69,9 @@ def compile_modified_block(
     # compile body
     cfg = compile_cfg(modified_block.cfg, func_builder, func_builder.inputs(), ctx)
     func_builder.set_outputs(*cfg)
-    effects = func_builder._last_side_effect.keys()
+    # EFFECTS we should pull out the actual effects from func_builder,
+    # e.g. func_builder._last_side_effect.keys(), but preserving previous behaviour
+    effects = [Effect.ANY]
 
     # Add the LoadFunc node
     call = dfg.builder.load_function(func_builder, hugr_ty)

--- a/guppylang-internals/src/guppylang_internals/compiler/stmt_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/stmt_compiler.py
@@ -2,11 +2,12 @@ import ast
 import functools
 from collections.abc import Sequence
 
-from hugr import Wire, ops
+from hugr import Wire
 
 from guppylang_internals.ast_util import AstVisitor, get_type
 from guppylang_internals.checker.core import Variable, contains_subscript
 from guppylang_internals.compiler.builder import DFBuilder
+from guppylang_internals.compiler.builder.ops import unpack_tuple
 from guppylang_internals.compiler.core import (
     CompilerBase,
     CompilerContext,
@@ -103,7 +104,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
         # Unpack the RHS tuple
         left, starred, right = lhs.pattern.left, lhs.pattern.starred, lhs.pattern.right
         types = [ty.to_hugr(self.ctx) for ty in type_to_row(get_type(lhs))]
-        unpack = self.builder.add_op(ops.UnpackTuple(types), port)
+        unpack = self.builder.add_op(unpack_tuple(types), port)
         ports = list(unpack)
 
         # Assign left and right
@@ -206,7 +207,7 @@ class StmtCompiler(CompilerBase, AstVisitor[None]):
             row: list[tuple[Wire, Type]]
             if isinstance(return_ty, TupleType):
                 types = [e.to_hugr(self.ctx) for e in return_ty.element_types]
-                unpack = self.builder.add_op(ops.UnpackTuple(types), port)
+                unpack = self.builder.add_op(unpack_tuple(types), port)
                 row = list(zip(unpack, return_ty.element_types, strict=True))
             else:
                 row = [(port, return_ty)]

--- a/guppylang-internals/src/guppylang_internals/decorator/custom.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/custom.py
@@ -42,7 +42,7 @@ def custom_function(
     name: str = "",
     signature: FunctionType | None = None,
     unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
-    effects: Iterable[Effect] = (),  # ALAN TODO remove default?
+    effects: Iterable[Effect] = (),
     has_var_args: bool = False,
 ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
     """Decorator to add custom typing or compilation behaviour to function decls.
@@ -131,7 +131,7 @@ def hugr_op(
     name: str = "",
     signature: FunctionType | None = None,
     unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
-    effects: Iterable[Effect] = (),  # ALAN TODO remove default?
+    effects: Iterable[Effect] = (),
 ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
     """Decorator to annotate function declarations as HUGR ops.
 

--- a/guppylang-internals/src/guppylang_internals/decorator/custom.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/custom.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, ParamSpec, TypeVar
 
-from hugr import ops
 from hugr import tys as ht
 
 from guppylang_internals.definition.common import DefId
@@ -24,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Sequence
 
     from guppylang.defs import GuppyFunctionDefinition
+    from hugr.ops import DataflowOp
 
     from guppylang_internals.compiler.core import CompilerContext
     from guppylang_internals.tys import Effect
@@ -125,7 +125,7 @@ def custom_type(
 
 
 def hugr_op(
-    op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp],
+    op: Callable[[ht.FunctionType, Inst, CompilerContext], DataflowOp],
     checker: CustomCallChecker | None = None,
     higher_order_value: bool = True,
     name: str = "",

--- a/guppylang-internals/src/guppylang_internals/decorator/custom.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/custom.py
@@ -21,11 +21,12 @@ from guppylang_internals.frame_util import get_calling_frame
 from guppylang_internals.tys.ty import FunctionType, UnitaryFlags
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Sequence
+    from collections.abc import Callable, Iterable, Sequence
 
     from guppylang.defs import GuppyFunctionDefinition
 
     from guppylang_internals.compiler.core import CompilerContext
+    from guppylang_internals.tys import Effect
     from guppylang_internals.tys.arg import Argument
     from guppylang_internals.tys.param import Parameter
     from guppylang_internals.tys.subst import Inst
@@ -41,6 +42,7 @@ def custom_function(
     name: str = "",
     signature: FunctionType | None = None,
     unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+    effects: Iterable[Effect] = (),  # ALAN TODO remove default?
     has_var_args: bool = False,
 ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
     """Decorator to add custom typing or compilation behaviour to function decls.
@@ -64,6 +66,7 @@ def custom_function(
             compiler or NotImplementedCallCompiler(),
             higher_order_value,
             signature,
+            effects,
             unitary_flags,
             has_var_args,
         )
@@ -128,6 +131,7 @@ def hugr_op(
     name: str = "",
     signature: FunctionType | None = None,
     unitary_flags: UnitaryFlags = UnitaryFlags.NoFlags,
+    effects: Iterable[Effect] = (),  # ALAN TODO remove default?
 ) -> Callable[[Callable[P, T]], GuppyFunctionDefinition[P, T]]:
     """Decorator to annotate function declarations as HUGR ops.
 
@@ -146,6 +150,7 @@ def hugr_op(
         name,
         signature,
         unitary_flags=unitary_flags,
+        effects=effects,
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/decorator/wasm.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/wasm.py
@@ -112,6 +112,7 @@ def _wasm_helper(fn_id: int | None, f: Callable[P, T]) -> GuppyFunctionDefinitio
         WasmCallChecker(),
         WasmModuleCallCompiler(f.__name__, fn_id),
         True,
+        effects=[],  # No effects as all state in explicit Context
         signature=None,
         wasm_index=fn_id,
     )

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -1,6 +1,6 @@
 import ast
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
@@ -20,7 +20,10 @@ from guppylang_internals.ast_util import (
 from guppylang_internals.checker.core import Context, Globals
 from guppylang_internals.checker.expr_checker import check_call, synthesize_call
 from guppylang_internals.checker.func_checker import check_signature
-from guppylang_internals.compiler.builder import DFBuilder, FunctionBuilder
+from guppylang_internals.compiler.builder import (
+    DFBuilder,
+    FunctionBuilder,
+)
 from guppylang_internals.compiler.core import (
     CompilerContext,
     DFContainer,
@@ -36,6 +39,7 @@ from guppylang_internals.diagnostic import Error, Help
 from guppylang_internals.error import GuppyError, InternalGuppyError
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.subst import Inst, Subst
 from guppylang_internals.tys.ty import (
@@ -114,6 +118,7 @@ class RawCustomFunctionDef(ParsableDef):
     higher_order_value: bool
 
     signature: FunctionType | None
+    effects: Iterable[Effect]
 
     unitary_flags: UnitaryFlags = field(default=UnitaryFlags.NoFlags)
 
@@ -156,6 +161,7 @@ class RawCustomFunctionDef(ParsableDef):
             GlobalConstId.fresh(self.name),
             sig is not None,
             self.has_var_args,
+            self.effects,
         )
 
     def _get_signature(
@@ -213,6 +219,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
     higher_order_func_id: GlobalConstId
     has_signature: bool
     has_var_args: bool
+    effects: Iterable[Effect]
 
     description: str = field(default="function", init=False)
 
@@ -234,6 +241,7 @@ class CustomFunctionDef(CallableDef, CheckableGenericDef):
             self.higher_order_func_id,
             self.has_signature,
             self.has_var_args,
+            self.effects,
             type_args,
         )
 
@@ -283,6 +291,11 @@ class CustomMonoFunctionDef(CustomFunctionDef, CompiledCallableDef):
     """
 
     type_args: Inst
+
+    @override
+    @property
+    def call_effects(self) -> Iterable[Effect]:
+        return self.effects
 
     @override
     def check(self, type_args: Inst, globals: Globals) -> "CustomMonoFunctionDef":
@@ -410,7 +423,7 @@ class CustomInoutCallCompiler(ABC):
     ctx: CompilerContext
     node: AstNode
     ty: ht.FunctionType
-    func: CustomMonoFunctionDef | None
+    func: CustomMonoFunctionDef
 
     _depth = 0
 
@@ -422,7 +435,7 @@ class CustomInoutCallCompiler(ABC):
         ctx: CompilerContext,
         node: AstNode,
         hugr_ty: ht.FunctionType,
-        func: CustomMonoFunctionDef | None,
+        func: CustomMonoFunctionDef,
     ) -> Generator["CustomInoutCallCompiler", None, None]:
         """
         A context manager to temporarily set up the compiler with required arguments,
@@ -529,7 +542,7 @@ class OpCompiler(CustomInoutCallCompiler):
     @override
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         op = self.op(self.ty, self.type_args, self.ctx)
-        node = self.builder.add_op(op, *args)
+        node = self.builder.add_op((op, self.func.call_effects), *args)
         num_returns = (
             len(type_to_row(self.func.ty.output)) if self.func else len(self.ty.output)
         )
@@ -579,6 +592,8 @@ class CopyInoutCompiler(CustomInoutCallCompiler):
                         type_args,
                         ht.FunctionType(self.ty.input, self.ty.output),
                     )
+                    # ALAN assume panics if any borrowed?
+                    clone_op = (clone_op, [Effect.ANY])
                     return list(self.builder.add_op(clone_op, arg))
             case _:
                 pass

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -5,8 +5,9 @@ from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
 
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
+from hugr.ops import DataflowOp
 from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXTENSION
 from typing_extensions import override
 
@@ -533,10 +534,10 @@ class OpCompiler(CustomInoutCallCompiler):
             the monomorphic function type, and returns a concrete HUGR op.
     """
 
-    op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+    op: Callable[[ht.FunctionType, Inst, CompilerContext], DataflowOp]
 
     def __init__(
-        self, op: Callable[[ht.FunctionType, Inst, CompilerContext], ops.DataflowOp]
+        self, op: Callable[[ht.FunctionType, Inst, CompilerContext], DataflowOp]
     ) -> None:
         self.op = op
 

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -24,7 +24,7 @@ from guppylang_internals.checker.func_checker import check_signature
 from guppylang_internals.compiler.builder import (
     DFBuilder,
     FunctionBuilder,
-    Pure,
+    pure,
 )
 from guppylang_internals.compiler.core import (
     CompilerContext,
@@ -595,7 +595,7 @@ class CopyInoutCompiler(CustomInoutCallCompiler):
                         ht.FunctionType(self.ty.input, self.ty.output),
                     )
                     # We never borrow copyable elements, so this never panics
-                    return list(self.builder.add_op(Pure(clone_op), arg))
+                    return list(self.builder.add_op(pure(clone_op), arg))
             case _:
                 pass
         raise InternalGuppyError(

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -23,6 +23,7 @@ from guppylang_internals.checker.func_checker import check_signature
 from guppylang_internals.compiler.builder import (
     DFBuilder,
     FunctionBuilder,
+    Pure,
 )
 from guppylang_internals.compiler.core import (
     CompilerContext,
@@ -592,9 +593,8 @@ class CopyInoutCompiler(CustomInoutCallCompiler):
                         type_args,
                         ht.FunctionType(self.ty.input, self.ty.output),
                     )
-                    # ALAN assume panics if any borrowed?
-                    clone_op = (clone_op, [Effect.ANY])
-                    return list(self.builder.add_op(clone_op, arg))
+                    # We never borrow copyable elements, so this never panics
+                    return list(self.builder.add_op(Pure(clone_op), arg))
             case _:
                 pass
         raise InternalGuppyError(

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -47,6 +47,7 @@ from guppylang_internals.error import GuppyError
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.subst import Inst, Subst
 from guppylang_internals.tys.ty import Type, UnitaryFlags
@@ -247,6 +248,13 @@ class CompiledFunctionDecl(
 
     declaration: Node
 
+    @override
+    @property
+    def call_effects(self) -> frozenset[Effect]:
+        # Assume all external function calls are side-effecting; we could improve
+        # by allowing explicit annotation on declarations, but this is a safe default.
+        return frozenset([Effect.ANY])
+
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
@@ -268,4 +276,6 @@ class CompiledFunctionDecl(
     ) -> CallReturnWires:
         """Compiles a call to the function."""
         # Use implementation from function definition.
-        return compile_call(args, dfg, self.ty, self.declaration, node)
+        return compile_call(
+            args, dfg, self.ty, self.declaration, node, effects=self.call_effects
+        )

--- a/guppylang-internals/src/guppylang_internals/definition/enum.py
+++ b/guppylang-internals/src/guppylang_internals/definition/enum.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import ClassVar, Generic, TypeVar
 
-from hugr import Wire, ops
+from hugr import Wire
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import Globals
@@ -12,6 +12,7 @@ from guppylang_internals.checker.errors.generic import (
     UnexpectedError,
     UnsupportedError,
 )
+from guppylang_internals.compiler.builder.ops import tag
 from guppylang_internals.compiler.core import GlobalConstId
 from guppylang_internals.definition.common import (
     CheckableDef,
@@ -285,7 +286,7 @@ class CheckedEnumDef(TypeDef, CompiledDef):
                 assert isinstance(inst_enum_type, EnumType)  # for mypy
                 return list(
                     self.builder.add_op(
-                        ops.Tag(self.variant_idx, inst_enum_type.to_hugr(self.ctx)),
+                        tag(self.variant_idx, inst_enum_type.to_hugr(self.ctx)),
                         *wires,
                     )
                 )
@@ -319,6 +320,7 @@ class CheckedEnumDef(TypeDef, CompiledDef):
                 higher_order_func_id=GlobalConstId.fresh(f"{self.name}.{variant_name}"),
                 has_signature=True,
                 has_var_args=False,
+                effects=[],
             )
             variants_constructors.append(constructor_def)
 

--- a/guppylang-internals/src/guppylang_internals/definition/enum.py
+++ b/guppylang-internals/src/guppylang_internals/definition/enum.py
@@ -40,6 +40,7 @@ from guppylang_internals.diagnostic import Error, Help
 from guppylang_internals.engine import DEF_STORE
 from guppylang_internals.error import GuppyError, InternalGuppyError
 from guppylang_internals.span import SourceMap
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import Argument
 from guppylang_internals.tys.param import Parameter, check_all_args
 from guppylang_internals.tys.parsing import TypeParsingCtx, type_from_ast
@@ -320,7 +321,7 @@ class CheckedEnumDef(TypeDef, CompiledDef):
                 higher_order_func_id=GlobalConstId.fresh(f"{self.name}.{variant_name}"),
                 has_signature=True,
                 has_var_args=False,
-                effects=[],
+                effects=[Effect.ANY],
             )
             variants_constructors.append(constructor_def)
 

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -1,6 +1,6 @@
 import ast
 import inspect
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -54,6 +54,7 @@ from guppylang_internals.error import GuppyError
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap, to_span
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import ConstArg, TypeArg
 from guppylang_internals.tys.const import ConstValue
 from guppylang_internals.tys.subst import Inst, Subst
@@ -297,6 +298,13 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
 
     _func_bldr: FunctionBuilder
 
+    @override
+    @property
+    def call_effects(self) -> frozenset[Effect]:
+        # For now, an approximation. (We said, may occur.)
+        # TODO refine via callgraph: https://github.com/Quantinuum/guppylang/issues/1748
+        return frozenset([Effect.ANY])
+
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
@@ -316,7 +324,9 @@ class CompiledFunctionDef(CheckedFunctionDef, CompiledCallableDef, CompiledHugrN
         node: AstNode,
     ) -> CallReturnWires:
         """Compiles a call to the function."""
-        return compile_call(args, dfg, self.ty, self.hugr_node, node)
+        return compile_call(
+            args, dfg, self.ty, self.hugr_node, node, effects=self.call_effects
+        )
 
     @override
     def compile_inner(self, globals: CompilerContext) -> None:
@@ -335,11 +345,13 @@ def compile_call(
     ty: FunctionType,
     func: ToNode,
     call_ast: AstNode,
+    *,
+    effects: Iterable[Effect],
 ) -> CallReturnWires:
     """Compiles a call to the function."""
     num_returns = len(type_to_row(ty.output))
     with dfg.builder.set_ast_context(call_ast):
-        call = dfg.builder.call(func, *args)
+        call = dfg.builder.call(func, *args, effects=effects)
     return CallReturnWires(
         regular_returns=list(call[:num_returns]),
         inout_returns=list(call[num_returns:]),

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -1,5 +1,6 @@
 import ast
 import copy
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, NamedTuple, NoReturn
 
@@ -26,6 +27,7 @@ from guppylang_internals.error import (
     InternalGuppyError,
 )
 from guppylang_internals.span import Span, to_span
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.printing import signature_to_str
 from guppylang_internals.tys.subst import Subst
 from guppylang_internals.tys.ty import FunctionType, Type
@@ -93,6 +95,11 @@ class InternalExpectOverloadError(Error):
 class OverloadedFunctionDef(CompiledCallableDef, CallableDef):
     func_ids: list[DefId]
     description: str = field(default="overloaded function", init=False)
+
+    @property
+    def call_effects(self) -> Iterable[Effect]:
+        # ALAN
+        raise InternalGuppyError("Not yet implemented")
 
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         raise GuppyError(OverloadHigherOrderError(node, self.name))

--- a/guppylang-internals/src/guppylang_internals/definition/overloaded.py
+++ b/guppylang-internals/src/guppylang_internals/definition/overloaded.py
@@ -98,8 +98,7 @@ class OverloadedFunctionDef(CompiledCallableDef, CallableDef):
 
     @property
     def call_effects(self) -> Iterable[Effect]:
-        # ALAN
-        raise InternalGuppyError("Not yet implemented")
+        raise InternalGuppyError("Should have been resolved to one overload")
 
     def load(self, dfg: DFContainer, ctx: CompilerContext, node: AstNode) -> Wire:
         raise GuppyError(OverloadHigherOrderError(node, self.name))

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -295,10 +295,11 @@ class ParsedPytketDef(CallableDef, CompilableDef):
                 rotation = outer_func.add_op(from_halfturns_unchecked(), halfturns)
                 param_wires.append(rotation)
 
-        # Pass all arguments to call node. We assume that the target function has no
-        # side-effects, since it came from a circuit.
+        # Pass all arguments to call node.
+        # Pytket circuits can contain `unwrap` operations which can panic.
+        # (This should match `def call_effects` in `CompiledPytketDef` below.)
         call_node = outer_func.call(
-            hugr_func, *(input_list + bool_wires + param_wires), effects=[]
+            hugr_func, *(input_list + bool_wires + param_wires), effects=[Effect.ANY]
         )
         # Add debug info metadata to the call node inside the outer function definition.
         if debug_mode_enabled():
@@ -399,9 +400,8 @@ class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef, CompiledHugrNodeDe
 
     @property
     def call_effects(self) -> Iterable[Effect]:
-        # Pytket circuits never have side-effects as they contain only pure quantum
-        # gates (no qalloc, no panic).
-        return []
+        # Pytket circuits may contain borrow-array unpacks, which can panic.
+        return [Effect.ANY]
 
     @property
     def hugr_node(self) -> Node:

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -1,10 +1,11 @@
 import ast
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, cast
 
 import hugr.build.function as hf
 from guppylang.defs import GuppyDefinition
-from hugr import Node, Wire, envelope, ops, val
+from hugr import Node, Wire, envelope, val
 from hugr import tys as ht
 from hugr.build.dfg import DefinitionBuilder, OpVar
 from hugr.debug_info import DILocation, DISubprogram
@@ -21,6 +22,7 @@ from guppylang_internals.checker.func_checker import (
     check_signature,
 )
 from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.builder.ops import unpack_tuple
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.debug_mode import debug_mode_enabled
 from guppylang_internals.definition.common import (
@@ -53,6 +55,7 @@ from guppylang_internals.std._internal.compiler.array import (
     array_unpack,
 )
 from guppylang_internals.std._internal.compiler.quantum import from_halfturns_unchecked
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import array_type, bool_type, float_type
 from guppylang_internals.tys.subst import Subst
 from guppylang_internals.tys.ty import (
@@ -288,14 +291,15 @@ class ParsedPytketDef(CallableDef, CompilableDef):
             angle_wires = [name_to_param[name] for name in param_order]
             # Need to convert all angles to rotations.
             for angle in angle_wires:
-                [halfturns] = outer_func.add_op(ops.UnpackTuple([FLOAT_T]), angle)
+                [halfturns] = outer_func.add_op(unpack_tuple([FLOAT_T]), angle)
                 rotation = outer_func.add_op(from_halfturns_unchecked(), halfturns)
                 param_wires.append(rotation)
 
-        # Pass all arguments to call node. Note that since we are using a
-        # FunctionBuilder, this will default to assuming that the target function
-        # is side-effecting, so may produce more order edges than necessary.
-        call_node = outer_func.call(hugr_func, *(input_list + bool_wires + param_wires))
+        # Pass all arguments to call node. We assume that the target function has no
+        # side-effects, since it came from a circuit.
+        call_node = outer_func.call(
+            hugr_func, *(input_list + bool_wires + param_wires), effects=[]
+        )
         # Add debug info metadata to the call node inside the outer function definition.
         if debug_mode_enabled():
             call_metadata = outer_func._raw.hugr[call_node].metadata
@@ -394,6 +398,12 @@ class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef, CompiledHugrNodeDe
     func_def: hf.Function
 
     @property
+    def call_effects(self) -> Iterable[Effect]:
+        # Pytket circuits never have side-effects as they contain only pure quantum
+        # gates (no qalloc, no panic).
+        return []
+
+    @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
         return self.func_def.parent_node
@@ -414,7 +424,9 @@ class CompiledPytketDef(ParsedPytketDef, CompiledCallableDef, CompiledHugrNodeDe
     ) -> CallReturnWires:
         """Compiles a call to the function."""
         # Use implementation from function definition.
-        return compile_call(args, dfg, self.ty, self.func_def, node)
+        return compile_call(
+            args, dfg, self.ty, self.func_def, node, effects=self.call_effects
+        )
 
 
 def _signature_from_circuit(

--- a/guppylang-internals/src/guppylang_internals/definition/struct.py
+++ b/guppylang-internals/src/guppylang_internals/definition/struct.py
@@ -3,7 +3,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import ClassVar
 
-from hugr import Wire, ops
+from hugr import Wire
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import Globals
@@ -12,6 +12,7 @@ from guppylang_internals.checker.errors.generic import (
     UnexpectedError,
     UnsupportedError,
 )
+from guppylang_internals.compiler.builder.ops import make_tuple
 from guppylang_internals.compiler.core import GlobalConstId
 from guppylang_internals.definition.common import (
     CheckableDef,
@@ -215,7 +216,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
             """Compiler for the `__new__` constructor method of a struct."""
 
             def compile(self, args: list[Wire]) -> list[Wire]:
-                return list(self.builder.add_op(ops.MakeTuple(), *args))
+                return list(self.builder.add_op(make_tuple(), *args))
 
         constructor_sig = FunctionType(
             inputs=[
@@ -242,6 +243,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
             higher_order_func_id=GlobalConstId.fresh(f"{self.name}.__new__"),
             has_signature=True,
             has_var_args=False,
+            effects=[],
         )
         return [constructor_def]
 

--- a/guppylang-internals/src/guppylang_internals/definition/struct.py
+++ b/guppylang-internals/src/guppylang_internals/definition/struct.py
@@ -41,6 +41,7 @@ from guppylang_internals.diagnostic import Error, Help
 from guppylang_internals.engine import DEF_STORE
 from guppylang_internals.error import GuppyError, InternalGuppyError
 from guppylang_internals.span import SourceMap
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import Argument
 from guppylang_internals.tys.param import Parameter, check_all_args
 from guppylang_internals.tys.parsing import TypeParsingCtx, type_from_ast
@@ -243,7 +244,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
             higher_order_func_id=GlobalConstId.fresh(f"{self.name}.__new__"),
             has_signature=True,
             has_var_args=False,
-            effects=[],
+            effects=[Effect.ANY],
         )
         return [constructor_def]
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -40,6 +40,7 @@ from guppylang_internals.definition.value import (
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import Argument
 from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.subst import Inst, Subst
@@ -171,6 +172,14 @@ class CompiledTracedFunctionDef(
 ):
     func_def: hf.Function
 
+    @override
+    @property
+    def call_effects(self) -> frozenset[Effect]:
+        """The maximum set of effects that may occur when calling the function."""
+        # For now, an approximation. (We said, may occur.)
+        # TODO refine via callgraph: https://github.com/Quantinuum/guppylang/issues/1748
+        return frozenset([Effect.ANY])
+
     @property
     def hugr_node(self) -> Node:
         """The Hugr node this definition was compiled into."""
@@ -195,7 +204,7 @@ class CompiledTracedFunctionDef(
         """Compiles a call to the function."""
         num_returns = len(type_to_row(self.ty.output))
         with dfg.builder.set_ast_context(node):
-            call = dfg.builder.call(self.func_def, *args)
+            call = dfg.builder.call(self.func_def, *args, effects=self.call_effects)
         return CallReturnWires(
             regular_returns=list(call[:num_returns]),
             inout_returns=list(call[num_returns:]),

--- a/guppylang-internals/src/guppylang_internals/definition/value.py
+++ b/guppylang-internals/src/guppylang_internals/definition/value.py
@@ -1,5 +1,6 @@
 import ast
-from abc import abstractmethod
+from abc import abstractmethod, abstractproperty
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, NamedTuple
 
@@ -13,6 +14,7 @@ from guppylang_internals.tys.ty import FunctionType, Type
 if TYPE_CHECKING:
     from guppylang_internals.checker.core import Context
     from guppylang_internals.compiler.core import CompilerContext, DFContainer
+    from guppylang_internals.tys import Effect
 
 
 @dataclass(frozen=True)
@@ -57,6 +59,10 @@ class CallableDef(ValueDef):
 
 class CompiledCallableDef(CallableDef, CompiledValueDef):  # type: ignore[misc, unused-ignore]
     """Abstract base class a global module-level function."""
+
+    @abstractproperty
+    def call_effects(self) -> Iterable["Effect"]:
+        """The maximum set of effects that may occur when calling the function."""
 
     @abstractmethod
     def compile_call(

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -8,11 +8,11 @@ from typing import ClassVar, cast
 
 import hugr
 import hugr.build.function as hf
-from hugr import ops
 from hugr.debug_info import DICompileUnit
 from hugr.envelope import ExtensionDesc, GeneratorDesc
 from hugr.ext import Extension, ExtensionRegistry
 from hugr.metadata import HugrDebugInfo, HugrGenerator, HugrUsedExtensions
+from hugr.ops import FuncDecl
 from hugr.package import ModulePointer, Package
 from semver import Version
 from typing_extensions import assert_never
@@ -461,7 +461,7 @@ class CompilationEngine:
         if (
             isinstance(compiled_def, CompiledHugrNodeDef)
             and isinstance(compiled_def, CompiledCallableDef)
-            and not isinstance(pointer.module[compiled_def.hugr_node].op, ops.FuncDecl)
+            and not isinstance(pointer.module[compiled_def.hugr_node].op, FuncDecl)
         ):
             # if compiling a region set it as the HUGR entrypoint can be
             # loosened after https://github.com/quantinuum/hugr/issues/2501 is fixed

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/arithmetic.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/arithmetic.py
@@ -8,6 +8,7 @@ from hugr import model, ops, val
 from hugr import tys as ht
 from hugr.std.int import int_t
 
+from guppylang_internals.compiler.builder import OpWithEffects, Pure
 from guppylang_internals.std._internal.compiler.prelude import error_type
 from guppylang_internals.tys.ty import NumericType
 
@@ -47,41 +48,43 @@ def _instantiate_int_op(
     int_width: int | Sequence[int],
     inp: list[ht.Type],
     out: list[ht.Type],
-) -> ops.ExtOp:
+) -> OpWithEffects:
     op_def = hugr.std.int.INT_OPS_EXTENSION.get_op(name)
     int_width = [int_width] if isinstance(int_width, int) else int_width
-    return ops.ExtOp(
-        op_def,
-        ht.FunctionType(inp, out),
-        [ht.BoundedNatArg(w) for w in int_width],
+    return Pure(
+        ops.ExtOp(
+            op_def,
+            ht.FunctionType(inp, out),
+            [ht.BoundedNatArg(w) for w in int_width],
+        )
     )
 
 
-def ieq(width: int) -> ops.ExtOp:
+def ieq(width: int) -> OpWithEffects:
     """Returns a `std.arithmetic.int.ieq` operation."""
     return _instantiate_int_op("ieq", width, [int_t(width), int_t(width)], [ht.Bool])
 
 
-def ine(width: int) -> ops.ExtOp:
+def ine(width: int) -> OpWithEffects:
     """Returns a `std.arithmetic.int.ine` operation."""
     return _instantiate_int_op("ine", width, [int_t(width), int_t(width)], [ht.Bool])
 
 
-def iwiden_u(from_width: int, to_width: int) -> ops.ExtOp:
+def iwiden_u(from_width: int, to_width: int) -> OpWithEffects:
     """Returns an unsigned `std.arithmetic.int.widen_u` operation."""
     return _instantiate_int_op(
         "iwiden_u", [from_width, to_width], [int_t(from_width)], [int_t(to_width)]
     )
 
 
-def iwiden_s(from_width: int, to_width: int) -> ops.ExtOp:
+def iwiden_s(from_width: int, to_width: int) -> OpWithEffects:
     """Returns a signed `std.arithmetic.int.widen_s` operation."""
     return _instantiate_int_op(
         "iwiden_s", [from_width, to_width], [int_t(from_width)], [int_t(to_width)]
     )
 
 
-def inarrow_u(from_width: int, to_width: int) -> ops.ExtOp:
+def inarrow_u(from_width: int, to_width: int) -> OpWithEffects:
     """Returns an unsigned `std.arithmetic.int.narrow_u` operation."""
     return _instantiate_int_op(
         "inarrow_u",
@@ -91,7 +94,7 @@ def inarrow_u(from_width: int, to_width: int) -> ops.ExtOp:
     )
 
 
-def inarrow_s(from_width: int, to_width: int) -> ops.ExtOp:
+def inarrow_s(from_width: int, to_width: int) -> OpWithEffects:
     """Returns a signed `std.arithmetic.int.narrow_s` operation."""
     return _instantiate_int_op(
         "inarrow_s",
@@ -111,26 +114,26 @@ def _instantiate_convert_op(
     inp: list[ht.Type],
     out: list[ht.Type],
     args: list[ht.TypeArg] | None = None,
-) -> ops.ExtOp:
+) -> OpWithEffects:
     op_def = hugr.std.int.CONVERSIONS_EXTENSION.get_op(name)
-    return ops.ExtOp(op_def, ht.FunctionType(inp, out), args or [])
+    return Pure(ops.ExtOp(op_def, ht.FunctionType(inp, out), args or []))
 
 
-def convert_ifromusize() -> ops.ExtOp:
+def convert_ifromusize() -> OpWithEffects:
     """Returns a `std.arithmetic.conversions.ifromusize` operation."""
     return _instantiate_convert_op("ifromusize", [ht.USize()], [INT_T])
 
 
-def convert_itousize() -> ops.ExtOp:
+def convert_itousize() -> OpWithEffects:
     """Returns a `std.arithmetic.conversions.itousize` operation."""
     return _instantiate_convert_op("itousize", [INT_T], [ht.USize()])
 
 
-def convert_ifrombool() -> ops.ExtOp:
+def convert_ifrombool() -> OpWithEffects:
     """Returns a `std.arithmetic.conversions.ifrombool` operation."""
     return _instantiate_convert_op("ifrombool", [ht.Bool], [int_t(0)])
 
 
-def convert_itobool() -> ops.ExtOp:
+def convert_itobool() -> OpWithEffects:
     """Returns a `std.arithmetic.conversions.itobool` operation."""
     return _instantiate_convert_op("itobool", [int_t(0)], [ht.Bool])

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/arithmetic.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/arithmetic.py
@@ -8,7 +8,7 @@ from hugr import model, ops, val
 from hugr import tys as ht
 from hugr.std.int import int_t
 
-from guppylang_internals.compiler.builder import OpWithEffects, Pure
+from guppylang_internals.compiler.builder import OpWithEffects, pure
 from guppylang_internals.std._internal.compiler.prelude import error_type
 from guppylang_internals.tys.ty import NumericType
 
@@ -51,7 +51,7 @@ def _instantiate_int_op(
 ) -> OpWithEffects:
     op_def = hugr.std.int.INT_OPS_EXTENSION.get_op(name)
     int_width = [int_width] if isinstance(int_width, int) else int_width
-    return Pure(
+    return pure(
         ops.ExtOp(
             op_def,
             ht.FunctionType(inp, out),
@@ -116,7 +116,7 @@ def _instantiate_convert_op(
     args: list[ht.TypeArg] | None = None,
 ) -> OpWithEffects:
     op_def = hugr.std.int.CONVERSIONS_EXTENSION.get_op(name)
-    return Pure(ops.ExtOp(op_def, ht.FunctionType(inp, out), args or []))
+    return pure(ops.ExtOp(op_def, ht.FunctionType(inp, out), args or []))
 
 
 def convert_ifromusize() -> OpWithEffects:

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -9,14 +9,18 @@ from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.collections.borrow_array import EXTENSION
 
+from guppylang_internals.compiler.builder import OpWithEffects, Pure
 from guppylang_internals.definition.custom import CustomCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
 from guppylang_internals.std._internal.compiler.arithmetic import convert_itousize
 from guppylang_internals.std._internal.compiler.prelude import build_unwrap_right
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import ConstArg, TypeArg
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
     from guppylang_internals.ast_util import AstNode
     from guppylang_internals.compiler.builder import DFBuilder
 
@@ -32,9 +36,16 @@ def _instantiate_array_op(
     length: ht.TypeArg,
     inp: list[ht.Type],
     out: list[ht.Type],
-) -> ops.ExtOp:
-    return EXTENSION.get_op(name).instantiate(
-        [length, ht.TypeTypeArg(elem_ty)], ht.FunctionType(inp, out)
+    # Almost all (borrow-)array operations can panic if relevant element(s) are
+    # borrowed. Allow overriding for the minority that do not.
+    # Usual warning about mutable default arguments applies, but Sequence is read-only.
+    effects: Sequence[Effect] = [Effect.ANY],
+) -> OpWithEffects:
+    return (
+        EXTENSION.get_op(name).instantiate(
+            [length, ht.TypeTypeArg(elem_ty)], ht.FunctionType(inp, out)
+        ),
+        effects,
     )
 
 
@@ -57,16 +68,16 @@ def standard_array_type(elem_ty: ht.Type, length: ht.TypeArg) -> ht.ExtType:
     return defn.instantiate([length, elem_arg])
 
 
-def array_new(elem_ty: ht.Type, length: int) -> ops.ExtOp:
+def array_new(elem_ty: ht.Type, length: int) -> OpWithEffects:
     """Returns an operation that creates a new fixed length array."""
     length_arg = ht.BoundedNatArg(length)
     arr_ty = array_type(elem_ty, length_arg)
     return _instantiate_array_op(
-        "new_array", elem_ty, length_arg, [elem_ty] * length, [arr_ty]
-    )
+        "new_array", elem_ty, length_arg, [elem_ty] * length, [arr_ty], effects=[]
+    )  # never panics
 
 
-def array_unpack(elem_ty: ht.Type, length: int) -> ops.ExtOp:
+def array_unpack(elem_ty: ht.Type, length: int) -> OpWithEffects:
     """Returns an operation that unpacks a fixed length array."""
     length_arg = ht.BoundedNatArg(length)
     arr_ty = array_type(elem_ty, length_arg)
@@ -75,7 +86,7 @@ def array_unpack(elem_ty: ht.Type, length: int) -> ops.ExtOp:
     )
 
 
-def array_get(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def array_get(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `get` operation."""
     assert elem_ty.type_bound() == ht.TypeBound.Copyable
     arr_ty = array_type(elem_ty, length)
@@ -84,7 +95,7 @@ def array_get(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
     )
 
 
-def array_set(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def array_set(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `set` operation."""
     arr_ty = array_type(elem_ty, length)
     return _instantiate_array_op(
@@ -96,7 +107,7 @@ def array_set(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
     )
 
 
-def array_pop(elem_ty: ht.Type, length: int, from_left: bool) -> ops.ExtOp:
+def array_pop(elem_ty: ht.Type, length: int, from_left: bool) -> OpWithEffects:
     """Returns an operation that pops an element from the left of an array."""
     assert length > 0
     length_arg = ht.BoundedNatArg(length)
@@ -108,11 +119,13 @@ def array_pop(elem_ty: ht.Type, length: int, from_left: bool) -> ops.ExtOp:
     )
 
 
-def array_discard_empty(elem_ty: ht.Type) -> ops.ExtOp:
+def array_discard_empty(elem_ty: ht.Type) -> OpWithEffects:
     """Returns an operation that discards an array of length zero."""
     arr_ty = array_type(elem_ty, ht.BoundedNatArg(0))
-    return EXTENSION.get_op("discard_empty").instantiate(
-        [ht.TypeTypeArg(elem_ty)], ht.FunctionType([arr_ty], [])
+    return Pure(
+        EXTENSION.get_op("discard_empty").instantiate(
+            [ht.TypeTypeArg(elem_ty)], ht.FunctionType([arr_ty], [])
+        )
     )
 
 
@@ -121,7 +134,7 @@ def array_scan(
     length: ht.TypeArg,
     new_elem_ty: ht.Type,
     accumulators: list[ht.Type],
-) -> ops.ExtOp:
+) -> OpWithEffects:
     """Returns an operation that maps and folds a function across an array."""
     ty_args = [
         length,
@@ -135,49 +148,65 @@ def array_scan(
         *accumulators,
     ]
     outs = [array_type(new_elem_ty, length), *accumulators]
-    return EXTENSION.get_op("scan").instantiate(ty_args, ht.FunctionType(ins, outs))
+    return (
+        EXTENSION.get_op("scan").instantiate(ty_args, ht.FunctionType(ins, outs)),
+        [Effect.ANY],  # can panic if any element is borrowed
+    )
 
 
-def array_map(elem_ty: ht.Type, length: ht.TypeArg, new_elem_ty: ht.Type) -> ops.ExtOp:
+def array_map(
+    elem_ty: ht.Type, length: ht.TypeArg, new_elem_ty: ht.Type
+) -> OpWithEffects:
     """Returns an operation that maps a function across an array."""
     return array_scan(elem_ty, length, new_elem_ty, accumulators=[])
 
 
-def array_repeat(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
-    """Returns an array `repeat` operation."""
-    return EXTENSION.get_op("repeat").instantiate(
-        [length, ht.TypeTypeArg(elem_ty)],
-        ht.FunctionType(
-            [ht.FunctionType([], [elem_ty])], [array_type(elem_ty, length)]
-        ),
+def array_repeat(
+    elem_ty: ht.Type, length: ht.TypeArg, effects: Iterable[Effect]
+) -> OpWithEffects:
+    """Returns an array `repeat` operation for a function, of no arguments
+    to one element, with the specified effects."""
+    func_ty = ht.FunctionType([], [elem_ty])
+    return _instantiate_array_op(
+        "repeat",
+        elem_ty,
+        length,
+        [func_ty],
+        [array_type(elem_ty, length)],
+        effects=list(
+            set(effects)
+        ),  # As the function, as it'll invoke the function many times
     )
 
 
-def array_to_std_array(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def array_to_std_array(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array operation to convert a value of the `borrow_array` type
     used by Guppy into a standard `array`.
     """
-    return EXTENSION.get_op("to_array").instantiate(
-        [length, ht.TypeTypeArg(elem_ty)],
-        ht.FunctionType(
-            [array_type(elem_ty, length)], [standard_array_type(elem_ty, length)]
-        ),
+    return _instantiate_array_op(
+        "to_array",
+        elem_ty,
+        length,
+        [array_type(elem_ty, length)],
+        [standard_array_type(elem_ty, length)],
     )
 
 
-def std_array_to_array(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def std_array_to_array(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array operation to convert the standard `array` type into the
     `borrow_array` type used by Guppy.
     """
-    return EXTENSION.get_op("from_array").instantiate(
-        [length, ht.TypeTypeArg(elem_ty)],
-        ht.FunctionType(
-            [standard_array_type(elem_ty, length)], [array_type(elem_ty, length)]
-        ),
+    return _instantiate_array_op(
+        "from_array",
+        elem_ty,
+        length,
+        [standard_array_type(elem_ty, length)],
+        [array_type(elem_ty, length)],
+        effects=[],  # Cannot panic: a standard array always has every element
     )
 
 
-def barray_borrow(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def barray_borrow(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `borrow` operation."""
     arr_ty = array_type(elem_ty, length)
     return _instantiate_array_op(
@@ -185,7 +214,7 @@ def barray_borrow(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
     )
 
 
-def barray_return(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def barray_return(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `return` operation."""
     arr_ty = array_type(elem_ty, length)
     return _instantiate_array_op(
@@ -193,27 +222,34 @@ def barray_return(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
     )
 
 
-def barray_discard_all_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def barray_discard_all_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `discard_all_borrowed` operation."""
     arr_ty = array_type(elem_ty, length)
     return _instantiate_array_op("discard_all_borrowed", elem_ty, length, [arr_ty], [])
 
 
-def barray_new_all_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def barray_new_all_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `new_all_borrowed` operation."""
     arr_ty = array_type(elem_ty, length)
-    return _instantiate_array_op("new_all_borrowed", elem_ty, length, [], [arr_ty])
-
-
-def barray_is_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
-    """Returns an array `is_borrowed` operation."""
-    arr_ty = array_type(elem_ty, length)
     return _instantiate_array_op(
-        "is_borrowed", elem_ty, length, [arr_ty, ht.USize()], [arr_ty, ht.Bool]
+        "new_all_borrowed", elem_ty, length, [], [arr_ty], effects=[]
     )
 
 
-def array_clone(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def barray_is_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
+    """Returns an array `is_borrowed` operation."""
+    arr_ty = array_type(elem_ty, length)
+    return _instantiate_array_op(
+        "is_borrowed",
+        elem_ty,
+        length,
+        [arr_ty, ht.USize()],
+        [arr_ty, ht.Bool],
+        effects=[],
+    )
+
+
+def array_clone(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `clone` operation for arrays none of whose elements are
     borrowed."""
     assert elem_ty.type_bound() == ht.TypeBound.Copyable
@@ -221,7 +257,7 @@ def array_clone(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
     return _instantiate_array_op("clone", elem_ty, length, [arr_ty], [arr_ty, arr_ty])
 
 
-def array_swap(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
+def array_swap(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `swap` operation.
 
     Swaps two elements at given indices in-place.
@@ -235,6 +271,7 @@ def array_swap(elem_ty: ht.Type, length: ht.TypeArg) -> ops.ExtOp:
         length,
         [arr_ty, ht.USize(), ht.USize()],
         [ht.Either([arr_ty], [arr_ty])],
+        effects=[],  # ALAN TODO CHECK: Do we swap borrowedness?
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -271,7 +271,6 @@ def array_swap(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
         length,
         [arr_ty, ht.USize(), ht.USize()],
         [ht.Either([arr_ty], [arr_ty])],
-        effects=[],  # ALAN TODO CHECK: Do we swap borrowedness?
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -134,7 +134,7 @@ def array_scan(
     length: ht.TypeArg,
     new_elem_ty: ht.Type,
     accumulators: list[ht.Type],
-) -> OpWithEffects:
+) -> ops.ExtOp:
     """Returns an operation that maps and folds a function across an array."""
     ty_args = [
         length,
@@ -148,15 +148,12 @@ def array_scan(
         *accumulators,
     ]
     outs = [array_type(new_elem_ty, length), *accumulators]
-    return (
-        EXTENSION.get_op("scan").instantiate(ty_args, ht.FunctionType(ins, outs)),
-        [Effect.ANY],  # can panic if any element is borrowed
-    )
+    # EFFECTS: this can panic if any element is borrowed, so we should mark that here.
+    # (We also need to allow for callee effects.) Preserving behaviour for now.
+    return EXTENSION.get_op("scan").instantiate(ty_args, ht.FunctionType(ins, outs))
 
 
-def array_map(
-    elem_ty: ht.Type, length: ht.TypeArg, new_elem_ty: ht.Type
-) -> OpWithEffects:
+def array_map(elem_ty: ht.Type, length: ht.TypeArg, new_elem_ty: ht.Type) -> ops.ExtOp:
     """Returns an operation that maps a function across an array."""
     return array_scan(elem_ty, length, new_elem_ty, accumulators=[])
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -9,7 +9,7 @@ from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.std.collections.borrow_array import EXTENSION
 
-from guppylang_internals.compiler.builder import OpWithEffects, Pure
+from guppylang_internals.compiler.builder import OpWithEffects, pure
 from guppylang_internals.definition.custom import CustomCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
@@ -122,7 +122,7 @@ def array_pop(elem_ty: ht.Type, length: int, from_left: bool) -> OpWithEffects:
 def array_discard_empty(elem_ty: ht.Type) -> OpWithEffects:
     """Returns an operation that discards an array of length zero."""
     arr_ty = array_type(elem_ty, ht.BoundedNatArg(0))
-    return Pure(
+    return pure(
         EXTENSION.get_op("discard_empty").instantiate(
             [ht.TypeTypeArg(elem_ty)], ht.FunctionType([arr_ty], [])
         )

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/array.py
@@ -15,7 +15,6 @@ from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
 from guppylang_internals.std._internal.compiler.arithmetic import convert_itousize
 from guppylang_internals.std._internal.compiler.prelude import build_unwrap_right
-from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import ConstArg, TypeArg
 
 if TYPE_CHECKING:
@@ -23,6 +22,7 @@ if TYPE_CHECKING:
 
     from guppylang_internals.ast_util import AstNode
     from guppylang_internals.compiler.builder import DFBuilder
+    from guppylang_internals.tys import Effect
 
 
 # ------------------------------------------------------
@@ -36,10 +36,8 @@ def _instantiate_array_op(
     length: ht.TypeArg,
     inp: list[ht.Type],
     out: list[ht.Type],
-    # Almost all (borrow-)array operations can panic if relevant element(s) are
-    # borrowed. Allow overriding for the minority that do not.
     # Usual warning about mutable default arguments applies, but Sequence is read-only.
-    effects: Sequence[Effect] = [Effect.ANY],
+    effects: Sequence[Effect] = [],
 ) -> OpWithEffects:
     return (
         EXTENSION.get_op(name).instantiate(
@@ -73,7 +71,7 @@ def array_new(elem_ty: ht.Type, length: int) -> OpWithEffects:
     length_arg = ht.BoundedNatArg(length)
     arr_ty = array_type(elem_ty, length_arg)
     return _instantiate_array_op(
-        "new_array", elem_ty, length_arg, [elem_ty] * length, [arr_ty], effects=[]
+        "new_array", elem_ty, length_arg, [elem_ty] * length, [arr_ty]
     )  # never panics
 
 
@@ -199,7 +197,6 @@ def std_array_to_array(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
         length,
         [standard_array_type(elem_ty, length)],
         [array_type(elem_ty, length)],
-        effects=[],  # Cannot panic: a standard array always has every element
     )
 
 
@@ -228,9 +225,7 @@ def barray_discard_all_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithE
 def barray_new_all_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
     """Returns an array `new_all_borrowed` operation."""
     arr_ty = array_type(elem_ty, length)
-    return _instantiate_array_op(
-        "new_all_borrowed", elem_ty, length, [], [arr_ty], effects=[]
-    )
+    return _instantiate_array_op("new_all_borrowed", elem_ty, length, [], [arr_ty])
 
 
 def barray_is_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
@@ -242,7 +237,6 @@ def barray_is_borrowed(elem_ty: ht.Type, length: ht.TypeArg) -> OpWithEffects:
         length,
         [arr_ty, ht.USize()],
         [arr_ty, ht.Bool],
-        effects=[],
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
@@ -1,10 +1,11 @@
 from abc import ABC
 from collections.abc import Sequence
 
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
 from hugr import val as hv
 
+from guppylang_internals.compiler.builder.ops import tag
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -71,7 +72,7 @@ class EitherConstructor(EitherCompiler, CustomCallCompiler):
         [inp] = args
         # Unpack the single input into a row
         inp_row = unpack_wire(inp, inp_arg.ty, self.builder, self.ctx, self.node)
-        return [self.builder.add_op(ops.Tag(self.tag, ty), *inp_row)]
+        return [self.builder.add_op(tag(self.tag, ty), *inp_row)]
 
 
 class EitherTestCompiler(EitherCompiler):
@@ -86,7 +87,7 @@ class EitherTestCompiler(EitherCompiler):
         for i in [0, 1]:
             case = cond.add_case(i)
             val = hv.TRUE if i == self.tag else hv.FALSE
-            either = case.add_op(ops.Tag(i, self.either_ty), *case.inputs())
+            either = case.add_op(tag(i, self.either_ty), *case.inputs())
             case.set_outputs(case.load(val), either)
         [res, either] = cond.outputs()
         return CallReturnWires(regular_returns=[res], inout_returns=[either])
@@ -105,9 +106,9 @@ class EitherToOptionCompiler(EitherCompiler, CustomCallCompiler):
         for i in [0, 1]:
             case = cond.add_case(i)
             if i == self.tag:
-                out = case.add_op(ops.Tag(1, ht.Option(*target_tys)), *case.inputs())
+                out = case.add_op(tag(1, ht.Option(*target_tys)), *case.inputs())
             else:
-                out = case.add_op(ops.Tag(0, ht.Option(*target_tys)))
+                out = case.add_op(tag(0, ht.Option(*target_tys)))
             case.set_outputs(out)
         return list(cond.outputs())
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
 from hugr.std.collections.static_array import EXTENSION, StaticArray
 
-from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.builder import FunctionBuilder, OpWithEffects, Pure
 from guppylang_internals.compiler.core import GlobalConstId
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import CustomCallCompiler
@@ -25,13 +25,15 @@ if TYPE_CHECKING:
     from hugr.build import function as hf
 
 
-def static_array_get(elem_ty: ht.Type) -> ops.ExtOp:
+def static_array_get(elem_ty: ht.Type) -> OpWithEffects:
     """Returns the static array `get` operation."""
     assert elem_ty.type_bound() == ht.TypeBound.Copyable
     arr_ty = StaticArray(elem_ty)
-    return EXTENSION.get_op("get").instantiate(
-        [ht.TypeTypeArg(elem_ty)],
-        ht.FunctionType([arr_ty, ht.USize()], [ht.Option(elem_ty)]),
+    return Pure(
+        EXTENSION.get_op("get").instantiate(
+            [ht.TypeTypeArg(elem_ty)],
+            ht.FunctionType([arr_ty, ht.USize()], [ht.Option(elem_ty)]),
+        )
     )
 
 
@@ -65,6 +67,10 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
         type_args = [ht.TypeTypeArg(elem_ty)]
         with self.builder.set_ast_context(self.node):
             out = self.builder.call(
-                self.getitem_func(), *args, instantiation=inst, type_args=type_args
+                self.getitem_func(),
+                *args,
+                instantiation=inst,
+                type_args=type_args,
+                effects=[],
             )
         return unpack_wire(out, ty_arg.ty, self.builder, self.ctx)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -71,6 +71,6 @@ class FrozenarrayGetitemCompiler(CustomCallCompiler):
                 *args,
                 instantiation=inst,
                 type_args=type_args,
-                effects=[],
+                effects=self.func.effects,
             )
         return unpack_wire(out, ty_arg.ty, self.builder, self.ctx)

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/frozenarray.py
@@ -8,7 +8,7 @@ from hugr import Wire
 from hugr import tys as ht
 from hugr.std.collections.static_array import EXTENSION, StaticArray
 
-from guppylang_internals.compiler.builder import FunctionBuilder, OpWithEffects, Pure
+from guppylang_internals.compiler.builder import FunctionBuilder, OpWithEffects, pure
 from guppylang_internals.compiler.core import GlobalConstId
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import CustomCallCompiler
@@ -29,7 +29,7 @@ def static_array_get(elem_ty: ht.Type) -> OpWithEffects:
     """Returns the static array `get` operation."""
     assert elem_ty.type_bound() == ht.TypeBound.Copyable
     arr_ty = StaticArray(elem_ty)
-    return Pure(
+    return pure(
         EXTENSION.get_op("get").instantiate(
             [ht.TypeTypeArg(elem_ty)],
             ht.FunctionType([arr_ty, ht.USize()], [ht.Option(elem_ty)]),

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, TypeVar
 
 import hugr.std.collections.list
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
+from hugr.ops import DfParentOp, ExtOp
 from hugr.std.collections.list import List, ListVal
 
+from guppylang_internals.compiler.builder import OpWithEffects, Pure, ops
 from guppylang_internals.definition.custom import CustomCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
@@ -36,16 +38,18 @@ if TYPE_CHECKING:
 
 def _instantiate_list_op(
     name: str, elem_type: ht.Type, inp: list[ht.Type], out: list[ht.Type]
-) -> ops.ExtOp:
+) -> OpWithEffects:
     op_def = hugr.std.collections.list.EXTENSION.get_op(name)
-    return ops.ExtOp(
-        op_def,
-        ht.FunctionType(inp, out),
-        [ht.TypeTypeArg(elem_type)],
+    return Pure(
+        ExtOp(
+            op_def,
+            ht.FunctionType(inp, out),
+            [ht.TypeTypeArg(elem_type)],
+        )
     )
 
 
-def list_pop(elem_type: ht.Type) -> ops.ExtOp:
+def list_pop(elem_type: ht.Type) -> OpWithEffects:
     """Returns a list `pop` operation."""
     list_type = List(elem_type)
     return _instantiate_list_op(
@@ -53,13 +57,13 @@ def list_pop(elem_type: ht.Type) -> ops.ExtOp:
     )
 
 
-def list_push(elem_type: ht.Type) -> ops.ExtOp:
+def list_push(elem_type: ht.Type) -> OpWithEffects:
     """Returns a list `push` operation."""
     list_type = List(elem_type)
     return _instantiate_list_op("push", elem_type, [list_type, elem_type], [list_type])
 
 
-def list_get(elem_type: ht.Type) -> ops.ExtOp:
+def list_get(elem_type: ht.Type) -> OpWithEffects:
     """Returns a list `get` operation."""
     list_type = List(elem_type)
     return _instantiate_list_op(
@@ -67,29 +71,31 @@ def list_get(elem_type: ht.Type) -> ops.ExtOp:
     )
 
 
-def list_set(elem_type: ht.Type) -> ops.ExtOp:
+def list_set(elem_type: ht.Type) -> OpWithEffects:
     """Returns a list `set` operation."""
     list_type = List(elem_type)
     return _instantiate_list_op(
         "set",
         elem_type,
         [list_type, ht.USize(), elem_type],
+        # Return supplied element if out of range else element removed from list
         [list_type, ht.Either([elem_type], [elem_type])],
     )
 
 
-def list_insert(elem_type: ht.Type) -> ops.ExtOp:
+def list_insert(elem_type: ht.Type) -> OpWithEffects:
     """Returns a list `insert` operation."""
     list_type = List(elem_type)
     return _instantiate_list_op(
         "insert",
         elem_type,
         [list_type, ht.USize(), elem_type],
+        # Return supplied element if out of range else unit
         [list_type, ht.Either([elem_type], [ht.Unit])],
     )
 
 
-def list_length(elem_type: ht.Type) -> ops.ExtOp:
+def list_length(elem_type: ht.Type) -> OpWithEffects:
     """Returns a list `length` operation."""
     list_type = List(elem_type)
     return _instantiate_list_op(
@@ -128,7 +134,7 @@ class ListGetitemCompiler(CustomCallCompiler):
         # implementation of the list type ensures that linear element types are turned
         # into optionals.
         elem_opt_ty = ht.Option(elem_ty)
-        none = self.builder.add_op(ops.Tag(0, elem_opt_ty))
+        none = self.builder.add_op(ops.tag(0, elem_opt_ty))
         idx = self.builder.add_op(convert_itousize(), idx)
         list_wire, result = self.builder.add_op(
             list_set(elem_opt_ty), list_wire, idx, none
@@ -183,7 +189,7 @@ class ListSetitemCompiler(CustomCallCompiler):
         """Lowers a call to `array.__setitem__` for linear arrays."""
         # Embed the element into an optional
         elem_opt_ty = ht.Option(elem_ty)
-        elem = self.builder.add_op(ops.Some(elem_ty), elem)
+        elem = self.builder.add_op(ops.some(elem_ty), elem)
         idx = self.builder.add_op(convert_itousize(), idx)
         list_wire, result = self.builder.add_op(
             list_set(elem_opt_ty), list_wire, idx, elem
@@ -276,7 +282,7 @@ class ListPushCompiler(CustomCallCompiler):
         """Lowers a call to `list.push` for linear lists."""
         # Wrap element into an optional
         elem_opt_ty = ht.Option(elem_ty)
-        elem_opt = self.builder.add_op(ops.Some(elem_ty), elem)
+        elem_opt = self.builder.add_op(ops.some(elem_ty), elem)
         list_wire = self.builder.add_op(list_push(elem_opt_ty), list_wire, elem_opt)
         return CallReturnWires(regular_returns=[], inout_returns=[list_wire])
 
@@ -315,7 +321,7 @@ class ListLengthCompiler(CustomCallCompiler):
         raise InternalGuppyError("Call compile_with_inouts instead")
 
 
-P = TypeVar("P", bound=ops.DfParentOp)
+P = TypeVar("P", bound=DfParentOp)
 
 
 def list_new(builder: DFBuilder, elem_type: ht.Type, args: list[Wire]) -> Wire:
@@ -342,6 +348,6 @@ def _list_new_linear(builder: DFBuilder, elem_type: ht.Type, args: list[Wire]) -
     lst = builder.load(ListVal([], elem_ty=elem_opt_ty))
     push_op = list_push(elem_opt_ty)
     for elem in args:
-        elem_opt = builder.add_op(ops.Some(elem_type), elem)
+        elem_opt = builder.add_op(ops.some(elem_type), elem)
         lst = builder.add_op(push_op, lst, elem_opt)
     return lst

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/list.py
@@ -12,7 +12,7 @@ from hugr import tys as ht
 from hugr.ops import DfParentOp, ExtOp
 from hugr.std.collections.list import List, ListVal
 
-from guppylang_internals.compiler.builder import OpWithEffects, Pure, ops
+from guppylang_internals.compiler.builder import OpWithEffects, ops, pure
 from guppylang_internals.definition.custom import CustomCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
@@ -40,7 +40,7 @@ def _instantiate_list_op(
     name: str, elem_type: ht.Type, inp: list[ht.Type], out: list[ht.Type]
 ) -> OpWithEffects:
     op_def = hugr.std.collections.list.EXTENSION.get_op(name)
-    return Pure(
+    return pure(
         ExtOp(
             op_def,
             ht.FunctionType(inp, out),

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/mem.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/mem.py
@@ -11,6 +11,8 @@ class WithOwnedCompiler(CustomInoutCallCompiler):
 
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         [val, func] = args
-        [out, val] = self.builder.add_op(ops.CallIndirect(), func, val)
+        [out, val] = self.builder.add_op(
+            (ops.CallIndirect(), self.func.call_effects), func, val
+        )
         outs = unpack_wire(out, get_type(self.node), self.builder, self.ctx)
         return CallReturnWires(regular_returns=outs, inout_returns=[val])

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/option.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/option.py
@@ -1,9 +1,10 @@
 from abc import ABC
 
-from hugr import Wire, ops
+from hugr import Wire
 from hugr import tys as ht
 from hugr import val as hv
 
+from guppylang_internals.compiler.builder.ops import tag
 from guppylang_internals.compiler.expr_compiler import unpack_wire
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -37,7 +38,7 @@ class OptionConstructor(OptionCompiler, CustomCallCompiler):
         self.tag = tag
 
     def compile(self, args: list[Wire]) -> list[Wire]:
-        return [self.builder.add_op(ops.Tag(self.tag, self.option_ty), *args)]
+        return [self.builder.add_op(tag(self.tag, self.option_ty), *args)]
 
 
 class OptionTestCompiler(OptionCompiler):
@@ -52,7 +53,7 @@ class OptionTestCompiler(OptionCompiler):
         for i in [0, 1]:
             case = cond.add_case(i)
             val = hv.TRUE if i == self.tag else hv.FALSE
-            opt = case.add_op(ops.Tag(i, self.option_ty), *case.inputs())
+            opt = case.add_op(tag(i, self.option_ty), *case.inputs())
             case.set_outputs(case.load(val), opt)
         [res, opt] = cond.outputs()
         return CallReturnWires(regular_returns=[res], inout_returns=[opt])

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/platform.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/platform.py
@@ -28,6 +28,7 @@ from guppylang_internals.std._internal.compiler.array import (
     array_to_std_array,
 )
 from guppylang_internals.std._internal.compiler.tket_exts import RESULT_EXTENSION
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import Argument, ConstArg
 from guppylang_internals.tys.builtin import get_element_type, is_array_type
 from guppylang_internals.tys.const import BoundConstVar, ConstValue
@@ -67,7 +68,7 @@ class OutputCompiler(CustomCallCompiler):
             args.append(tys.BoundedNatArg(NumericType.INT_WIDTH))
         op = RESULT_EXTENSION.get_op(self.op_name)
         sig = tys.FunctionType(input=[hugr_ty], output=[])
-        self.builder.add_op(op.instantiate(args, sig), value)
+        self.builder.add_op((op.instantiate(args, sig), [Effect.ANY]), value)
         return []
 
 
@@ -106,7 +107,7 @@ class ArrayOutputCompiler(CustomInoutCallCompiler):
         if self.with_int_width:
             args.append(tys.BoundedNatArg(NumericType.INT_WIDTH))
         op = ops.ExtOp(RESULT_EXTENSION.get_op(self.op_name), signature=sig, args=args)
-        self.builder.add_op(op, arr)
+        self.builder.add_op((op, [Effect.ANY]), arr)
         return CallReturnWires([], [out_arr])
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -12,7 +12,12 @@ from hugr import Node, Wire, ops
 from hugr import tys as ht
 from hugr import val as hv
 
-from guppylang_internals.compiler.builder import DFBuilder, FunctionBuilder
+from guppylang_internals.compiler.builder import (
+    DFBuilder,
+    FunctionBuilder,
+    OpWithEffects,
+    Pure,
+)
 from guppylang_internals.compiler.core import CompilerContext, GlobalConstId
 from guppylang_internals.definition.custom import (
     CustomCallCompiler,
@@ -21,6 +26,7 @@ from guppylang_internals.definition.custom import (
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
 from guppylang_internals.nodes import AbortKind
+from guppylang_internals.tys import Effect
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -57,7 +63,7 @@ class ErrorVal(hv.ExtensionValue):
 
 def panic(
     inputs: list[ht.Type], outputs: list[ht.Type], kind: AbortKind = AbortKind.Panic
-) -> ops.ExtOp:
+) -> OpWithEffects:
     """Returns an operation that panics."""
     name = "panic" if kind == AbortKind.Panic else "exit"
     op_def = hugr.std.PRELUDE.get_op(name)
@@ -66,15 +72,16 @@ def panic(
         ht.ListArg([ht.TypeTypeArg(ty) for ty in outputs]),
     ]
     sig = ht.FunctionType([error_type(), *inputs], outputs)
-    return ops.ExtOp(op_def, sig, args)
+    return (ops.ExtOp(op_def, sig, args), [Effect.ANY])
 
 
-def make_error() -> ops.ExtOp:
-    """Returns an operation that makes an error."""
+def make_error() -> OpWithEffects:
+    """Returns an operation that makes an error (and returns the error as a value,
+    does nothing to raise it)."""
     op_def = hugr.std.PRELUDE.get_op("MakeError")
     args: list[ht.TypeArg] = []
     sig = ht.FunctionType([ht.USize(), hugr.std.prelude.STRING_T], [error_type()])
-    return ops.ExtOp(op_def, sig, args)
+    return Pure(ops.ExtOp(op_def, sig, args))
 
 
 # ------------------------------------------------------
@@ -272,6 +279,7 @@ def unwrap_result(
     func_call = builder.call(
         func,
         either,
+        effects=[Effect.ANY],  # panics
         instantiation=concrete_ty,
         type_args=type_args,
     )
@@ -303,9 +311,16 @@ class UnwrapOpCompiler(CustomInoutCallCompiler):
             output=[ht.Either([error_type()], self.ty.output)],
         )
         op = self.op(opt_func_type, self.type_args, self.ctx)
-        either = self.builder.add_op(op, *args)
+        either = self.builder.add_op((op, self.func.call_effects), *args)
         result = unwrap_result(self.builder, self.ctx, either)
         return CallReturnWires(regular_returns=[result], inout_returns=[])
+
+
+def barrier_op(tys: ht.TypeRow) -> OpWithEffects:
+    """Returns an operation that represents a barrier on the given types."""
+    op_def = hugr.std.prelude.PRELUDE_EXTENSION.get_op("Barrier")
+    args = [ht.ListArg([ht.TypeTypeArg(ty) for ty in tys])]
+    return Pure(op_def.instantiate(args, ht.FunctionType.endo(tys)))
 
 
 class BarrierCompiler(CustomCallCompiler):
@@ -314,11 +329,7 @@ class BarrierCompiler(CustomCallCompiler):
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         tys = [t for arg in args if (t := self.builder.get_wire_type(arg))]
 
-        op = hugr.std.prelude.PRELUDE_EXTENSION.get_op("Barrier").instantiate(
-            [ht.ListArg([ht.TypeTypeArg(ty) for ty in tys])]
-        )
-
-        barrier_n = self.builder.add_op(op, *args)
+        barrier_n = self.builder.add_op(barrier_op(tys), *args)
 
         return CallReturnWires(
             regular_returns=[], inout_returns=[barrier_n[i] for i in range(len(tys))]

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/prelude.py
@@ -16,7 +16,7 @@ from guppylang_internals.compiler.builder import (
     DFBuilder,
     FunctionBuilder,
     OpWithEffects,
-    Pure,
+    pure,
 )
 from guppylang_internals.compiler.core import CompilerContext, GlobalConstId
 from guppylang_internals.definition.custom import (
@@ -81,7 +81,7 @@ def make_error() -> OpWithEffects:
     op_def = hugr.std.PRELUDE.get_op("MakeError")
     args: list[ht.TypeArg] = []
     sig = ht.FunctionType([ht.USize(), hugr.std.prelude.STRING_T], [error_type()])
-    return Pure(ops.ExtOp(op_def, sig, args))
+    return pure(ops.ExtOp(op_def, sig, args))
 
 
 # ------------------------------------------------------
@@ -320,7 +320,7 @@ def barrier_op(tys: ht.TypeRow) -> OpWithEffects:
     """Returns an operation that represents a barrier on the given types."""
     op_def = hugr.std.prelude.PRELUDE_EXTENSION.get_op("Barrier")
     args = [ht.ListArg([ht.TypeTypeArg(ty) for ty in tys])]
-    return Pure(op_def.instantiate(args, ht.FunctionType.endo(tys)))
+    return pure(op_def.instantiate(args, ht.FunctionType.endo(tys)))
 
 
 class BarrierCompiler(CustomCallCompiler):

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/qsystem.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/qsystem.py
@@ -2,6 +2,7 @@ from hugr import Wire
 from hugr import tys as ht
 from hugr.std.int import int_t
 
+from guppylang_internals.compiler.builder import Pure
 from guppylang_internals.definition.custom import CustomInoutCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.std._internal.compiler.arithmetic import inarrow_s, iwiden_s
@@ -19,8 +20,12 @@ class RandomIntCompiler(CustomInoutCallCompiler):
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         [ctx] = args
         [rnd, ctx] = self.builder.add_op(
-            external_op("RandomInt", [], ext=QSYSTEM_RANDOM_EXTENSION)(
-                ht.FunctionType([RNGCONTEXT_T], [int_t(5), RNGCONTEXT_T]), (), self.ctx
+            Pure(
+                external_op("RandomInt", [], ext=QSYSTEM_RANDOM_EXTENSION)(
+                    ht.FunctionType([RNGCONTEXT_T], [int_t(5), RNGCONTEXT_T]),
+                    (),
+                    self.ctx,
+                )
             ),
             ctx,
         )
@@ -36,10 +41,12 @@ class RandomIntBoundedCompiler(CustomInoutCallCompiler):
             self.builder, bound_sum, "bound must be a 32-bit integer"
         )
         [rnd, ctx] = self.builder.add_op(
-            external_op("RandomIntBounded", [], ext=QSYSTEM_RANDOM_EXTENSION)(
-                ht.FunctionType([RNGCONTEXT_T, int_t(5)], [int_t(5), RNGCONTEXT_T]),
-                (),
-                self.ctx,
+            Pure(
+                external_op("RandomIntBounded", [], ext=QSYSTEM_RANDOM_EXTENSION)(
+                    ht.FunctionType([RNGCONTEXT_T, int_t(5)], [int_t(5), RNGCONTEXT_T]),
+                    (),
+                    self.ctx,
+                )
             ),
             ctx,
             bound,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/qsystem.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/qsystem.py
@@ -2,7 +2,7 @@ from hugr import Wire
 from hugr import tys as ht
 from hugr.std.int import int_t
 
-from guppylang_internals.compiler.builder import Pure
+from guppylang_internals.compiler.builder import pure
 from guppylang_internals.definition.custom import CustomInoutCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.std._internal.compiler.arithmetic import inarrow_s, iwiden_s
@@ -20,7 +20,7 @@ class RandomIntCompiler(CustomInoutCallCompiler):
     def compile_with_inouts(self, args: list[Wire]) -> CallReturnWires:
         [ctx] = args
         [rnd, ctx] = self.builder.add_op(
-            Pure(
+            pure(
                 external_op("RandomInt", [], ext=QSYSTEM_RANDOM_EXTENSION)(
                     ht.FunctionType([RNGCONTEXT_T], [int_t(5), RNGCONTEXT_T]),
                     (),
@@ -41,7 +41,7 @@ class RandomIntBoundedCompiler(CustomInoutCallCompiler):
             self.builder, bound_sum, "bound must be a 32-bit integer"
         )
         [rnd, ctx] = self.builder.add_op(
-            Pure(
+            pure(
                 external_op("RandomIntBounded", [], ext=QSYSTEM_RANDOM_EXTENSION)(
                     ht.FunctionType([RNGCONTEXT_T, int_t(5)], [int_t(5), RNGCONTEXT_T]),
                     (),

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/quantum.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/quantum.py
@@ -9,7 +9,7 @@ from hugr import ext as he
 from hugr import tys as ht
 from hugr.std.float import FLOAT_T
 
-from guppylang_internals.compiler.builder import OpWithEffects, Pure
+from guppylang_internals.compiler.builder import OpWithEffects, pure
 from guppylang_internals.compiler.builder.ops import unpack_tuple
 from guppylang_internals.definition.custom import CustomInoutCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
@@ -87,7 +87,7 @@ class InoutMeasureCompiler(CustomInoutCallCompiler):
         )
         [q] = args
         [q, bit] = self.builder.add_op(
-            Pure(
+            pure(
                 quantum_op(self.opname, ext=self.ext)(
                     ht.FunctionType([ht.Qubit], [ht.Qubit, return_ty]), (), self.ctx
                 )
@@ -111,7 +111,7 @@ class RotationCompiler(CustomInoutCallCompiler):
         [rotation] = self.builder.add_op(from_halfturns_unchecked(), halfturns)
 
         qs = self.builder.add_op(
-            Pure(
+            pure(
                 quantum_op(self.opname)(
                     ht.FunctionType(
                         [ht.Qubit for _ in qs] + [ROTATION_T], [ht.Qubit for _ in qs]

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/quantum.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/quantum.py
@@ -9,6 +9,8 @@ from hugr import ext as he
 from hugr import tys as ht
 from hugr.std.float import FLOAT_T
 
+from guppylang_internals.compiler.builder import OpWithEffects, Pure
+from guppylang_internals.compiler.builder.ops import unpack_tuple
 from guppylang_internals.definition.custom import CustomInoutCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.std._internal.compiler.tket_exts import (
@@ -17,6 +19,7 @@ from guppylang_internals.std._internal.compiler.tket_exts import (
     QUANTUM_EXTENSION,
     ROTATION_EXTENSION,
 )
+from guppylang_internals.tys import Effect
 
 # ----------------------------------------------
 # --------- tket.* extensions -----------------
@@ -30,10 +33,15 @@ ROTATION_T_DEF = ROTATION_EXTENSION.get_type("rotation")
 ROTATION_T = ht.ExtType(ROTATION_T_DEF)
 
 
-def from_halfturns_unchecked() -> ops.ExtOp:
-    return ops.ExtOp(
-        ROTATION_EXTENSION.get_op("from_halfturns_unchecked"),
-        ht.FunctionType([FLOAT_T], [ROTATION_T]),
+def from_halfturns_unchecked() -> OpWithEffects:
+    """Return an operation that converts a float to a rotation,
+    panicking if the angle is not finite."""
+    return (
+        ops.ExtOp(
+            ROTATION_EXTENSION.get_op("from_halfturns_unchecked"),
+            ht.FunctionType([FLOAT_T], [ROTATION_T]),
+        ),
+        [Effect.ANY],
     )
 
 
@@ -79,8 +87,10 @@ class InoutMeasureCompiler(CustomInoutCallCompiler):
         )
         [q] = args
         [q, bit] = self.builder.add_op(
-            quantum_op(self.opname, ext=self.ext)(
-                ht.FunctionType([ht.Qubit], [ht.Qubit, return_ty]), (), self.ctx
+            Pure(
+                quantum_op(self.opname, ext=self.ext)(
+                    ht.FunctionType([ht.Qubit], [ht.Qubit, return_ty]), (), self.ctx
+                )
             ),
             q,
         )
@@ -97,16 +107,18 @@ class RotationCompiler(CustomInoutCallCompiler):
         from guppylang_internals.std._internal.util import quantum_op
 
         [*qs, angle] = args
-        [halfturns] = self.builder.add_op(ops.UnpackTuple([FLOAT_T]), angle)
+        [halfturns] = self.builder.add_op(unpack_tuple([FLOAT_T]), angle)
         [rotation] = self.builder.add_op(from_halfturns_unchecked(), halfturns)
 
         qs = self.builder.add_op(
-            quantum_op(self.opname)(
-                ht.FunctionType(
-                    [ht.Qubit for _ in qs] + [ROTATION_T], [ht.Qubit for _ in qs]
-                ),
-                (),
-                self.ctx,
+            Pure(
+                quantum_op(self.opname)(
+                    ht.FunctionType(
+                        [ht.Qubit for _ in qs] + [ROTATION_T], [ht.Qubit for _ in qs]
+                    ),
+                    (),
+                    self.ctx,
+                )
             ),
             *qs,
             rotation,

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/quantum.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/quantum.py
@@ -19,7 +19,6 @@ from guppylang_internals.std._internal.compiler.tket_exts import (
     QUANTUM_EXTENSION,
     ROTATION_EXTENSION,
 )
-from guppylang_internals.tys import Effect
 
 # ----------------------------------------------
 # --------- tket.* extensions -----------------
@@ -34,14 +33,11 @@ ROTATION_T = ht.ExtType(ROTATION_T_DEF)
 
 
 def from_halfturns_unchecked() -> OpWithEffects:
-    """Return an operation that converts a float to a rotation,
-    panicking if the angle is not finite."""
-    return (
+    return pure(
         ops.ExtOp(
             ROTATION_EXTENSION.get_op("from_halfturns_unchecked"),
             ht.FunctionType([FLOAT_T], [ROTATION_T]),
         ),
-        [Effect.ANY],
     )
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/wasm.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/wasm.py
@@ -1,6 +1,7 @@
 from hugr import Wire, ops
 from hugr import tys as ht
 
+from guppylang_internals.compiler.builder import Pure
 from guppylang_internals.definition.custom import CustomInoutCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
@@ -11,6 +12,7 @@ from guppylang_internals.std._internal.compiler.tket_exts import (
     WASM_EXTENSION,
     ConstWasmModule,
 )
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import (
     wasm_module_name,
 )
@@ -36,7 +38,7 @@ class WasmModuleInitCompiler(CustomInoutCallCompiler):
             WASM_EXTENSION.get_op("get_context"),
             ht.FunctionType([ht.USize()], [ht.Option(ctx_ty)]),
         )
-        node = self.builder.add_op(get_ctx_op, ctx_wire)
+        node = self.builder.add_op((get_ctx_op, [Effect.ANY]), ctx_wire)
         opt_w: Wire = node[0]
         err = "Failed to spawn WASM context"
         out_node = build_unwrap(self.builder, opt_w, err)
@@ -50,7 +52,7 @@ class WasmModuleDiscardCompiler(CustomInoutCallCompiler):
         assert len(args) == 1
         ctx = args[0]
         op = WASM_EXTENSION.get_op("dispose_context").instantiate([])
-        self.builder.add_op(op, ctx)
+        self.builder.add_op((op, [Effect.ANY]), ctx)
         return CallReturnWires(regular_returns=[], inout_returns=[])
 
 
@@ -122,7 +124,7 @@ class WasmModuleCallCompiler(CustomInoutCallCompiler):
                 ht.FunctionType([module_ty], [func_ty]),
             )
 
-        wasm_func = self.builder.add_op(wasm_opdef, wasm_module)
+        wasm_func = self.builder.add_op(Pure(wasm_opdef), wasm_module)
 
         # Call the function
         call_op = WASM_EXTENSION.get_op("call").instantiate(
@@ -130,13 +132,13 @@ class WasmModuleCallCompiler(CustomInoutCallCompiler):
             ht.FunctionType([ctx_ty, func_ty, *wasm_sig.input], [result_ty]),
         )
 
-        result = self.builder.add_op(call_op, args[0], wasm_func, *args[1:])
+        result = self.builder.add_op(Pure(call_op), args[0], wasm_func, *args[1:])
 
         read_opdef = WASM_EXTENSION.get_op("read_result").instantiate(
             [output_row_arg],
             ht.FunctionType([result_ty], [ctx_ty, *wasm_sig.output]),
         )
-        data = self.builder.add_op(read_opdef, result)
+        data = self.builder.add_op(Pure(read_opdef), result)
         match list(data[:]):
             case [ctx]:
                 return CallReturnWires(regular_returns=[], inout_returns=[ctx])

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/wasm.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/wasm.py
@@ -1,7 +1,7 @@
 from hugr import Wire, ops
 from hugr import tys as ht
 
-from guppylang_internals.compiler.builder import Pure
+from guppylang_internals.compiler.builder import pure
 from guppylang_internals.definition.custom import CustomInoutCallCompiler
 from guppylang_internals.definition.value import CallReturnWires
 from guppylang_internals.error import InternalGuppyError
@@ -124,7 +124,7 @@ class WasmModuleCallCompiler(CustomInoutCallCompiler):
                 ht.FunctionType([module_ty], [func_ty]),
             )
 
-        wasm_func = self.builder.add_op(Pure(wasm_opdef), wasm_module)
+        wasm_func = self.builder.add_op(pure(wasm_opdef), wasm_module)
 
         # Call the function
         call_op = WASM_EXTENSION.get_op("call").instantiate(
@@ -132,13 +132,13 @@ class WasmModuleCallCompiler(CustomInoutCallCompiler):
             ht.FunctionType([ctx_ty, func_ty, *wasm_sig.input], [result_ty]),
         )
 
-        result = self.builder.add_op(Pure(call_op), args[0], wasm_func, *args[1:])
+        result = self.builder.add_op(pure(call_op), args[0], wasm_func, *args[1:])
 
         read_opdef = WASM_EXTENSION.get_op("read_result").instantiate(
             [output_row_arg],
             ht.FunctionType([result_ty], [ctx_ty, *wasm_sig.output]),
         )
-        data = self.builder.add_op(Pure(read_opdef), result)
+        data = self.builder.add_op(pure(read_opdef), result)
         match list(data[:]):
             case [ctx]:
                 return CallReturnWires(regular_returns=[], inout_returns=[ctx])

--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/wasm.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/wasm.py
@@ -12,7 +12,6 @@ from guppylang_internals.std._internal.compiler.tket_exts import (
     WASM_EXTENSION,
     ConstWasmModule,
 )
-from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import (
     wasm_module_name,
 )
@@ -38,7 +37,8 @@ class WasmModuleInitCompiler(CustomInoutCallCompiler):
             WASM_EXTENSION.get_op("get_context"),
             ht.FunctionType([ht.USize()], [ht.Option(ctx_ty)]),
         )
-        node = self.builder.add_op((get_ctx_op, [Effect.ANY]), ctx_wire)
+        # Should get_context / dispose_context have effects here?
+        node = self.builder.add_op(pure(get_ctx_op), ctx_wire)
         opt_w: Wire = node[0]
         err = "Failed to spawn WASM context"
         out_node = build_unwrap(self.builder, opt_w, err)
@@ -52,7 +52,8 @@ class WasmModuleDiscardCompiler(CustomInoutCallCompiler):
         assert len(args) == 1
         ctx = args[0]
         op = WASM_EXTENSION.get_op("dispose_context").instantiate([])
-        self.builder.add_op((op, [Effect.ANY]), ctx)
+        # Should get_context / dispose_context have effects here?
+        self.builder.add_op(pure(op), ctx)
         return CallReturnWires(regular_returns=[], inout_returns=[])
 
 

--- a/guppylang-internals/src/guppylang_internals/std/_internal/decorator.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/decorator.py
@@ -25,6 +25,7 @@ from guppylang_internals.std._internal.wasm import (
     WasmPlatform,
     WasmSignatureError,
 )
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.ty import (
     FuncInput,
     FunctionType,
@@ -135,6 +136,7 @@ def ext_module_decorator(
                 init_compiler,
                 True,
                 GlobalConstId.fresh(f"{cls.__name__}.__new__"),
+                effects=[Effect.ANY],  # ALAN does DefaultCallChecker even use this?
                 has_signature=True,
                 has_var_args=False,
             )
@@ -147,6 +149,7 @@ def ext_module_decorator(
                 discard_compiler,
                 False,
                 GlobalConstId.fresh(f"{cls.__name__}.__discard__"),
+                effects=[Effect.ANY],  # ALAN does DefaultCallChecker even use this?
                 has_signature=True,
                 has_var_args=False,
             )

--- a/guppylang-internals/src/guppylang_internals/std/_internal/decorator.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/decorator.py
@@ -136,7 +136,7 @@ def ext_module_decorator(
                 init_compiler,
                 True,
                 GlobalConstId.fresh(f"{cls.__name__}.__new__"),
-                effects=[Effect.ANY],  # ALAN does DefaultCallChecker even use this?
+                effects=[Effect.ANY],
                 has_signature=True,
                 has_var_args=False,
             )
@@ -149,7 +149,7 @@ def ext_module_decorator(
                 discard_compiler,
                 False,
                 GlobalConstId.fresh(f"{cls.__name__}.__discard__"),
-                effects=[Effect.ANY],  # ALAN does DefaultCallChecker even use this?
+                effects=[Effect.ANY],
                 has_signature=True,
                 has_var_args=False,
             )

--- a/guppylang-internals/src/guppylang_internals/std/_internal/util.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/util.py
@@ -12,8 +12,8 @@ import hugr.std.float
 import hugr.std.int
 import hugr.std.logic
 from hugr import ext as he
-from hugr import ops
 from hugr import tys as ht
+from hugr.ops import DataflowOp, ExtOp
 
 from guppylang_internals.compiler.hugr_extension import UnsupportedOp
 from guppylang_internals.std._internal.compiler.tket_exts import QUANTUM_EXTENSION
@@ -64,7 +64,7 @@ def external_op(
     ext: he.Extension,
     *,
     variable_remap: dict[int, int] | None = None,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Custom hugr operation
 
     Args:
@@ -80,7 +80,7 @@ def external_op(
     """
     op_def = ext.get_op(name)
 
-    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> ops.DataflowOp:
+    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> DataflowOp:
         concrete_args = [
             make_concrete_arg(arg, inst, ctx, variable_remap) for arg in args
         ]
@@ -92,7 +92,7 @@ def external_op(
 def float_op(
     op_name: str,
     ext: he.Extension = hugr.std.float.FLOAT_OPS_EXTENSION,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Utility method to create Hugr float arithmetic ops.
 
     Args:
@@ -110,7 +110,7 @@ def int_op(
     op_name: str,
     ext: he.Extension = hugr.std.int.INT_OPS_EXTENSION,
     n_vars: int = 1,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Utility method to create Hugr integer arithmetic ops.
 
     Args:
@@ -142,7 +142,7 @@ def logic_op(
     op_name: str,
     parametric_size: bool = False,
     ext: he.Extension = hugr.std.logic.EXTENSION,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Utility method to create Hugr logic ops.
 
     If `parametric_size` is True, the generated operations has a single argument
@@ -159,9 +159,9 @@ def logic_op(
     """
     op_def = ext.get_op(op_name)
 
-    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> ops.DataflowOp:
+    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> DataflowOp:
         args = [int_arg(len(ty.input))] if parametric_size else []
-        return ops.ExtOp(
+        return ExtOp(
             op_def,
             ty,
             args,
@@ -173,7 +173,7 @@ def logic_op(
 def list_op(
     op_name: str,
     ext: he.Extension = hugr.std.collections.list.EXTENSION,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Utility method to create Hugr list ops.
 
     Args:
@@ -186,8 +186,8 @@ def list_op(
     """
     op_def = ext.get_op(op_name)
 
-    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> ops.DataflowOp:
-        return ops.ExtOp(
+    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> DataflowOp:
+        return ExtOp(
             op_def,
             ty,
             [arg.to_hugr(ctx) for arg in inst],
@@ -199,7 +199,7 @@ def list_op(
 def quantum_op(
     op_name: str,
     ext: he.Extension = QUANTUM_EXTENSION,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Utility method to create Hugr quantum ops.
 
     args:
@@ -212,8 +212,8 @@ def quantum_op(
     """
     op_def = ext.get_op(op_name)
 
-    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> ops.DataflowOp:
-        return ops.ExtOp(
+    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> DataflowOp:
+        return ExtOp(
             op_def,
             ty,
             args=[],
@@ -224,7 +224,7 @@ def quantum_op(
 
 def unsupported_op(
     op_name: str,
-) -> Callable[[ht.FunctionType, Inst, ToHugrContext], ops.DataflowOp]:
+) -> Callable[[ht.FunctionType, Inst, ToHugrContext], DataflowOp]:
     """Utility method to define not-yet-implemented operations.
 
     Args:
@@ -235,7 +235,7 @@ def unsupported_op(
         the inferred input and output types and returns a concrete HUGR op.
     """
 
-    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> ops.DataflowOp:
+    def op(ty: ht.FunctionType, inst: Inst, ctx: ToHugrContext) -> DataflowOp:
         return UnsupportedOp(
             op_name=op_name,
             inputs=ty.input,

--- a/guppylang-internals/src/guppylang_internals/tracing/function.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/function.py
@@ -3,8 +3,6 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar
 
-from hugr import ops
-
 from guppylang_internals.ast_util import AstNode, with_loc, with_type
 from guppylang_internals.cfg.builder import tmp_vars
 from guppylang_internals.checker.core import (
@@ -17,6 +15,7 @@ from guppylang_internals.checker.core import (
 from guppylang_internals.checker.errors.type_errors import TypeMismatchError
 from guppylang_internals.checker.unitary_checker import BBUnitaryChecker
 from guppylang_internals.compiler.builder import FunctionBuilder
+from guppylang_internals.compiler.builder.ops import unpack_tuple
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.definition.overloaded import OverloadedFunctionDef
@@ -135,7 +134,7 @@ def trace_function(
         out_tys = type_to_row(out_obj._ty)
         if len(out_tys) > 1:
             regular_returns: list[Wire] = list(
-                builder.add_op(ops.UnpackTuple(), out_obj._use_wire(None)).outputs()
+                builder.add_op(unpack_tuple(), out_obj._use_wire(None)).outputs()
             )
         elif len(out_tys) > 0:
             regular_returns = [out_obj._use_wire(None)]

--- a/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/unpacking.py
@@ -1,13 +1,13 @@
 from typing import Any, TypeVar
 
-from hugr import ops
+from hugr.ops import DfParentOp
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.errors.comptime_errors import (
     UnsupportedPythonValueError,
 )
 from guppylang_internals.checker.expr_checker import python_value_to_guppy_type
-from guppylang_internals.compiler.builder import DFBuilder
+from guppylang_internals.compiler.builder import DFBuilder, ops
 from guppylang_internals.compiler.core import CompilerContext
 from guppylang_internals.compiler.expr_compiler import python_value_to_hugr
 from guppylang_internals.error import GuppyComptimeError, GuppyError
@@ -29,7 +29,7 @@ from guppylang_internals.tys.builtin import (
 from guppylang_internals.tys.const import ConstValue
 from guppylang_internals.tys.ty import EnumType, NoneType, StructType, TupleType
 
-P = TypeVar("P", bound=ops.DfParentOp)
+P = TypeVar("P", bound=DfParentOp)
 
 
 def unpack_guppy_object(
@@ -49,13 +49,13 @@ def unpack_guppy_object(
         case NoneType():
             return None
         case TupleType(element_types=tys):
-            unpack = builder.add_op(ops.UnpackTuple(), obj._use_wire(None))
+            unpack = builder.add_op(ops.unpack_tuple(), obj._use_wire(None))
             return tuple(
                 unpack_guppy_object(GuppyObject(ty, wire), builder, frozen)
                 for ty, wire in zip(tys, unpack.outputs(), strict=True)
             )
         case StructType() as ty:
-            unpack = builder.add_op(ops.UnpackTuple(), obj._use_wire(None))
+            unpack = builder.add_op(ops.unpack_tuple(), obj._use_wire(None))
             field_values = [
                 unpack_guppy_object(GuppyObject(field.ty, wire), builder, frozen)
                 for field, wire in zip(ty.fields, unpack.outputs(), strict=True)
@@ -98,12 +98,14 @@ def guppy_object_from_py(
         case TracingDefMixin() as defn:
             return defn.to_guppy_object()
         case None:
-            return GuppyObject(NoneType(), builder.add_op(ops.MakeTuple()))
+            return GuppyObject(NoneType(), builder.add_op(ops.make_tuple()))
         case tuple(vs):
             objs = [guppy_object_from_py(v, builder, node, ctx) for v in vs]
             return GuppyObject(
                 TupleType([obj._ty for obj in objs]),
-                builder.add_op(ops.MakeTuple(), *(obj._use_wire(None) for obj in objs)),
+                builder.add_op(
+                    ops.make_tuple(), *(obj._use_wire(None) for obj in objs)
+                ),
             )
         case GuppyStructObject(_ty=struct_ty, _field_values=values):
             wires = []
@@ -117,7 +119,7 @@ def guppy_object_from_py(
                         f"unexpected type. Expected `{f.ty}`, got `{obj._ty}`."
                     )
                 wires.append(obj._use_wire(None))
-            return GuppyObject(struct_ty, builder.add_op(ops.MakeTuple(), *wires))
+            return GuppyObject(struct_ty, builder.add_op(ops.make_tuple(), *wires))
         case GuppyEnumObject(_ty=enum_ty, _wire=wire):
             return GuppyObject(enum_ty, wire)
         case list(vs) if len(vs) > 0:
@@ -171,7 +173,7 @@ def update_packed_value(v: Any, obj: "GuppyObject", builder: DFBuilder) -> bool:
         case tuple(vs):
             assert isinstance(obj._ty, TupleType)
             wire_iterator = builder.add_op(
-                ops.UnpackTuple(), obj._use_wire(None)
+                ops.unpack_tuple(), obj._use_wire(None)
             ).outputs()
             for v, ty, out_wire in zip(
                 vs, obj._ty.element_types, wire_iterator, strict=True
@@ -182,7 +184,7 @@ def update_packed_value(v: Any, obj: "GuppyObject", builder: DFBuilder) -> bool:
         case GuppyStructObject(_ty=ty, _field_values=values):
             assert obj._ty == ty
             wire_iterator = builder.add_op(
-                ops.UnpackTuple(), obj._use_wire(None)
+                ops.unpack_tuple(), obj._use_wire(None)
             ).outputs()
             for field, out_wire in zip(ty.fields, wire_iterator, strict=True):
                 v = values[field.name]

--- a/guppylang-internals/src/guppylang_internals/tys/__init__.py
+++ b/guppylang-internals/src/guppylang_internals/tys/__init__.py
@@ -1,0 +1,17 @@
+from collections.abc import Iterable
+from enum import Enum
+
+
+class Effect(Enum):
+    ANY = "Any"
+
+    @classmethod
+    def __from_str__(cls, s: str) -> "Effect":
+        for effect in cls:
+            if effect.name == s:
+                return effect
+        raise ValueError(f"Invalid effect name: {s}")
+
+    @staticmethod
+    def format_list(effects: Iterable["Effect"]) -> str:
+        return f"[{', '.join(e.name for e in effects)}]"

--- a/guppylang/src/guppylang/emulator/_args.py
+++ b/guppylang/src/guppylang/emulator/_args.py
@@ -199,7 +199,7 @@ def wrap_entrypoint_with_args(package: Package, arg_names: Sequence[str]) -> Non
 
     Mutates ``package`` in place.
     """
-    # For now we mark this Pure, as this is fine for a global *constant*,
+    # For now we mark this pure, as this is fine for a global *constant*,
     # but we may need to revisit for multithreading.
     read_arg_effects: Iterable[Effect] = []
 

--- a/guppylang/src/guppylang/emulator/_args.py
+++ b/guppylang/src/guppylang/emulator/_args.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import tket_exts
+from guppylang_internals.compiler.builder import FunctionBuilder, OpWithEffects
 from guppylang_internals.std._internal.compiler.array import (
     standard_array_type,
     std_array_to_array,
@@ -27,6 +28,7 @@ from hugr.std.collections.borrow_array import EXTENSION as BORROW_ARRAY_EXT
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
+    from guppylang_internals.tys import Effect
     from guppylang_internals.tys.ty import Type
     from hugr.hugr import Hugr
     from hugr.package import Package
@@ -197,8 +199,11 @@ def wrap_entrypoint_with_args(package: Package, arg_names: Sequence[str]) -> Non
 
     Mutates ``package`` in place.
     """
+    # For now we mark this Pure, as this is fine for a global *constant*,
+    # but we may need to revisit for multithreading.
+    read_arg_effects: Iterable[Effect] = []
 
-    def read_arg_wire(wrapper: Function, name: str, ty: ht.Type) -> Wire:
+    def read_arg_wire(wrapper: FunctionBuilder, name: str, ty: ht.Type) -> Wire:
         """Read a single runtime argument, bridging array representations.
 
         Entrypoint array parameters are lowered to ``borrow_array``, but the
@@ -207,14 +212,18 @@ def wrap_entrypoint_with_args(package: Package, arg_names: Sequence[str]) -> Non
         expects (the mirror of how the result compiler converts the other way).
         """
         borrow_array_def = BORROW_ARRAY_EXT.types["borrow_array"]
+
+        def mk_read_arg(ty: ht.Type) -> OpWithEffects:
+            return (tket_exts.argument.read_arg(name, ty), read_arg_effects)
+
         if isinstance(ty, ht.ExtType) and ty.type_def is borrow_array_def:
             length_arg, elem_arg = ty.args
             assert isinstance(elem_arg, ht.TypeTypeArg)
             elem_ty = elem_arg.ty
             std_ty = standard_array_type(elem_ty, length_arg)
-            std_wire = wrapper.add_op(tket_exts.argument.read_arg(name, std_ty))[0]
+            std_wire = wrapper.add_op(mk_read_arg(std_ty))[0]
             return wrapper.add_op(std_array_to_array(elem_ty, length_arg), std_wire)[0]
-        return wrapper.add_op(tket_exts.argument.read_arg(name, ty))[0]
+        return wrapper.add_op(mk_read_arg(ty))[0]
 
     def _has_inputs(module: Hugr[Any]) -> bool:
         op = module[module.entrypoint].op
@@ -241,15 +250,17 @@ def wrap_entrypoint_with_args(package: Package, arg_names: Sequence[str]) -> Non
     # entrypoint to be called as a library function.
     # Name of the no-input wrapper generated around the original entrypoint.
     wrapper_name = f"__{op.f_name}_with_args"
-    wrapper = Function.new_nested(
+    func = Function.new_nested(
         ops.FuncDefn(wrapper_name, [], visibility="Public"),
         module,
         module.module_root,
     )
+    wrapper = FunctionBuilder(func)
+
     arg_wires = [
         read_arg_wire(wrapper, name, ty)
         for name, ty in zip(arg_names, input_types, strict=True)
     ]
-    call_node = wrapper.call(entrypoint, *arg_wires)
+    call_node = wrapper.call(entrypoint, *arg_wires, effects=read_arg_effects)
     wrapper.set_outputs(*(call_node[i] for i in range(len(output_types))))
-    module.entrypoint = wrapper.parent_node
+    module.entrypoint = func.parent_node

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -30,6 +30,7 @@ from guppylang_internals.std._internal.compiler.array import (
 from guppylang_internals.std._internal.compiler.frozenarray import (
     FrozenarrayGetitemCompiler,
 )
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import array_type_def, frozenarray_type_def
 
 from guppylang import guppy
@@ -320,7 +321,8 @@ def array_swap(arr: array[L, n], idx: int, idx2: int) -> None:
 class frozenarray(Generic[T, n]):
     """An immutable array of fixed static size."""
 
-    @custom_function(FrozenarrayGetitemCompiler())
+    # Panics on out-of-range.
+    @custom_function(FrozenarrayGetitemCompiler(), effects=[Effect.ANY])
     def __getitem__(self: frozenarray[T, n], item: int) -> T: ...  # type: ignore[type-arg]
 
     @guppy

--- a/guppylang/src/guppylang/std/mem.py
+++ b/guppylang/src/guppylang/std/mem.py
@@ -5,6 +5,7 @@ from typing import no_type_check
 from guppylang_internals.decorator import custom_function
 from guppylang_internals.std._internal.compiler.mem import WithOwnedCompiler
 from guppylang_internals.std._internal.compiler.prelude import MemSwapCompiler
+from guppylang_internals.tys import Effect
 
 from guppylang import guppy
 from guppylang.std.lang import Function, owned
@@ -19,7 +20,9 @@ def mem_swap(x: T, y: T) -> None:
     """Swaps the values of two variables."""
 
 
-@custom_function(WithOwnedCompiler())
+# For now we conservatively assume that any `Function` may have any effect.
+# Otherwise we would somehow have to plumb through the effects of parameter `f`.
+@custom_function(WithOwnedCompiler(), effects=[Effect.ANY])
 @no_type_check
 def with_owned(val: T, f: Function[[T @ owned], tuple[Out, T]]) -> Out:
     """Runs a closure where the borrowed argument is promoted to an owned one.

--- a/guppylang/src/guppylang/std/option.py
+++ b/guppylang/src/guppylang/std/option.py
@@ -9,6 +9,7 @@ from guppylang_internals.std._internal.compiler.option import (
     OptionUnwrapCompiler,
     OptionUnwrapNothingCompiler,
 )
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import option_type_def
 
 from guppylang import guppy
@@ -62,13 +63,15 @@ class Option(Generic[L]):  # type: ignore[misc]
         return self.swap(nothing())
 
 
-@custom_function(OptionConstructor(0))
+# EFFECTS this can + probably should be pure, but preserving behaviour for now
+@custom_function(OptionConstructor(0), effects=[Effect.ANY])
 @no_type_check
 def nothing() -> Option[L]:
     """Constructs a `nothing` optional value."""
 
 
-@custom_function(OptionConstructor(1))
+# EFFECTS this can + probably should be pure, but preserving behaviour for now
+@custom_function(OptionConstructor(1), effects=[Effect.ANY])
 @no_type_check
 def some(value: L @ owned) -> Option[L]:
     """Constructs a `some` optional value."""

--- a/guppylang/src/guppylang/std/platform.py
+++ b/guppylang/src/guppylang/std/platform.py
@@ -17,6 +17,7 @@ from guppylang_internals.std._internal.compiler.platform import (
     MeasurementOutputChecker,
     OutputCompiler,
 )
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.builtin import int_type, string_type
 from guppylang_internals.tys.ty import FuncInput, FunctionType, InputFlags, NoneType
 
@@ -116,6 +117,7 @@ result = output
         NoneType(),
     ),
     has_var_args=True,
+    effects=[Effect.ANY],
 )
 def _panic(msg: str, *args) -> None: ...
 
@@ -131,6 +133,7 @@ def _panic(msg: str, *args) -> None: ...
         NoneType(),
     ),
     has_var_args=True,
+    effects=[Effect.ANY],
 )
 def _panic_with_signal(msg: str, signal: int, *args) -> None: ...
 

--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -10,6 +10,7 @@ from guppylang_internals.std._internal.compiler.quantum import (
 )
 from guppylang_internals.std._internal.compiler.tket_exts import MEASUREMENT_EXTENSION
 from guppylang_internals.std._internal.util import quantum_op
+from guppylang_internals.tys import Effect
 from guppylang_internals.tys.ty import UnitaryFlags
 from hugr import tys as ht
 
@@ -23,7 +24,7 @@ from guppylang.std.option import Option
 
 @custom_type(ht.Qubit, copyable=False, droppable=False)
 class qubit:
-    @hugr_op(quantum_op("QAlloc"))
+    @hugr_op(quantum_op("QAlloc"), effects=[Effect.ANY])
     @no_type_check
     def __new__() -> "qubit": ...
 
@@ -387,13 +388,13 @@ def project_z(q: qubit) -> Measurement:
     return m
 
 
-@hugr_op(quantum_op("QFree"))
+@hugr_op(quantum_op("QFree"), effects=[Effect.ANY])
 @no_type_check
 def discard(q: qubit @ owned) -> None:
     """Discard a single qubit."""
 
 
-@hugr_op(quantum_op("MeasureFree"))
+@hugr_op(quantum_op("MeasureFree"), effects=[Effect.ANY])
 @no_type_check
 def measure(q: qubit @ owned) -> Measurement:
     """Request a destructive lazy measurement of a qubit, returning a `Measurement`

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -839,6 +839,24 @@ def test_field_access_after_subscript(validate):
     validate(main.compile_function())
 
 
+def test_swap_borrowed(run_int_fn):
+    from guppylang.std.array import array_swap
+
+    @guppy.struct
+    class MyStruct:
+        i: int
+
+    @guppy
+    def main() -> int:
+        arr = array(MyStruct(1), MyStruct(2), MyStruct(3))
+        m = arr.take(1)
+        array_swap(arr, 0, 1)
+        return 0
+
+    with pytest.raises(EmulatorError, match="Array element is already borrowed"):
+        run_int_fn(main, expected=0)
+
+
 def test_dynamic_index_subscript(validate):
     """Smoketest for checking duplicate subscript accesses:
     Asserts that dynamic accesses with duplicate subscripts

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -858,6 +858,11 @@ def test_swap_borrowed(run_int_fn):
         run_int_fn(main, expected=0)
 
 
+# This should panic, but the borrow's are optimized away
+# as effect-less. (With OptimizationLevel.Minimal, this
+# happens at the beginning of QSystemPass.)
+# https://github.com/Quantinuum/guppylang/issues/1747
+@pytest.mark.xfail(match="DID NOT RAISE")
 @pytest.mark.parametrize(
     "level", [OptimizationLevel.Minimal, OptimizationLevel.Default]
 )
@@ -873,11 +878,8 @@ def test_take_panic(level: OptimizationLevel, run_int_fn):
         arr.take(0)  # This should panic
         return 17  # Do not use array
 
-    # This should panic, but the borrow's are optimized away
-    # as effect-less. (With OptimizationLevel.Minimal, this
-    # happens at the beginning of QSystemPass.)
-    # https://github.com/Quantinuum/guppylang/issues/1747
-    main.with_opt_level(level).emulator(n_qubits=1).run()
+    with pytest.raises(EmulatorError, match="Array element is already borrowed"):
+        main.with_opt_level(level).emulator(n_qubits=1).run()
 
 
 def test_dynamic_index_subscript(validate):

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -11,6 +11,7 @@ from guppylang.std.platform import output
 from guppylang_internals.std._internal.compiler.arithmetic import UnsignedIntVal
 from tests.util import compile_guppy
 
+from guppylang.optimizer import OptimizationLevel
 from guppylang.std.quantum import (
     qubit,
     discard,
@@ -855,6 +856,28 @@ def test_swap_borrowed(run_int_fn):
 
     with pytest.raises(EmulatorError, match="Array element is already borrowed"):
         run_int_fn(main, expected=0)
+
+
+@pytest.mark.parametrize(
+    "level", [OptimizationLevel.Minimal, OptimizationLevel.Default]
+)
+def test_take_panic(level: OptimizationLevel, run_int_fn):
+    @guppy.struct
+    class MyStruct:
+        i: int
+
+    @guppy
+    def main() -> int:
+        arr = array(MyStruct(1), MyStruct(2), MyStruct(3))
+        arr.take(0)
+        arr.take(0)  # This should panic
+        return 17  # Do not use array
+
+    # This should panic, but the borrow's are optimized away
+    # as effect-less. (With OptimizationLevel.Minimal, this
+    # happens at the beginning of QSystemPass.)
+    # https://github.com/Quantinuum/guppylang/issues/1747
+    main.with_opt_level(level).emulator(n_qubits=1).run()
 
 
 def test_dynamic_index_subscript(validate):


### PR DESCRIPTION
closes #1746

* Removes the EXTENSION_OPS_WITH_SIDE_EFFECTS blacklist
* Instead `add_op` takes an `OpWithEffects` i.e. a `(DataflowOp, Iterable[Effect])`. Using a tuple so that factory methods returning both are straightforward.
* Zero change to hugrs, verified just prior to daf68f609c320eb6d86d9d8c7c840f1fccff9a6f i.e. with the assert that the old blacklist was the same as the value provided with the op.
* Adds a `@abstractproperty def call_effects` to `CallableDef` allowing to override for `@hugr_op` / `@custom_function`, but this PR maintains the same effects as before including that every user-defined `@guppy` function  has all effects". (We can improve upon both later, for user-defined functions [using a callgraph](#1748)).
* Also add a couple of tests documenting current behaviour of arrays

About 40 tests require the fallback to `Effect.ANY` if we cannot resolve target of a LocalCall :-(. There are ways we can try and do better but they would add significant complexity, beyond #1748, so no plans yet.