### PR TITLE
fix: Don't emit coercion hint for temporary variables

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
@@ -246,6 +246,12 @@ class BranchTypeError(Error):
         var: str
         ty: Type
 
+        @property
+        def rendered_span_label(self) -> str:
+            if is_tmp_var(self.var):
+                return f"Consider coercing this value to `{self.ty}`"
+            return f"Consider adding a type annotation: `{self.var}: {self.ty} = ...`"
+
     @dataclass(frozen=True)
     class CoerceBothHint(Help):
         message: ClassVar[str] = (
@@ -254,6 +260,15 @@ class BranchTypeError(Error):
         var: str
         ty: str
         extra: str = ""
+
+        @property
+        def rendered_message(self) -> str:
+            if is_tmp_var(self.var):
+                return f"Consider coercing both values to `{self.ty}`"
+            return (
+                f"Consider adding type annotations{self.extra}: "
+                f"`{self.var}: {self.ty} = ...`"
+            )
 
 
 @dataclass(frozen=True)
@@ -428,8 +443,6 @@ def maybe_coerce_hint(v1: Variable, v2: Variable) -> Help | None:
     coercions that fix a type mismatch across different control-flow paths."""
     assert v1.name == v2.name
     assert v1.ty != v2.ty
-    if is_tmp_var(v1.name):
-        return None
     if coerces_to(v1.ty, v2.ty):
         return BranchTypeError.CoerceOneHint(v1.defined_at, v1.name, v2.ty)
     if coerces_to(v2.ty, v1.ty):

--- a/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
@@ -240,9 +240,6 @@ class BranchTypeError(Error):
 
     @dataclass(frozen=True)
     class CoerceOneHint(Help):
-        span_label: ClassVar[str] = (
-            "Consider adding a type annotation: `{var}: {ty} = ...`"
-        )
         var: str
         ty: Type
 
@@ -254,9 +251,6 @@ class BranchTypeError(Error):
 
     @dataclass(frozen=True)
     class CoerceBothHint(Help):
-        message: ClassVar[str] = (
-            "Consider adding type annotations{extra}: `{var}: {ty} = ...`"
-        )
         var: str
         ty: str
         extra: str = ""

--- a/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/cfg_checker.py
@@ -13,6 +13,7 @@ from typing import ClassVar, Generic, TypeVar
 
 from guppylang_internals.ast_util import line_col
 from guppylang_internals.cfg.bb import BB
+from guppylang_internals.cfg.builder import is_tmp_var
 from guppylang_internals.cfg.cfg import CFG, BaseCFG
 from guppylang_internals.checker.core import (
     Context,
@@ -427,6 +428,8 @@ def maybe_coerce_hint(v1: Variable, v2: Variable) -> Help | None:
     coercions that fix a type mismatch across different control-flow paths."""
     assert v1.name == v2.name
     assert v1.ty != v2.ty
+    if is_tmp_var(v1.name):
+        return None
     if coerces_to(v1.ty, v2.ty):
         return BranchTypeError.CoerceOneHint(v1.defined_at, v1.name, v2.ty)
     if coerces_to(v2.ty, v1.ty):

--- a/tests/error/errors_on_usage/if_different_types_coerce3.err
+++ b/tests/error/errors_on_usage/if_different_types_coerce3.err
@@ -1,0 +1,23 @@
+Error: Different types (at $FILE:6:8)
+  | 
+4 | @compile_guppy
+5 | def foo(x: bool) -> float:
+6 |     y = 1.0 if x else 1
+  |         ^^^^^^^^^^^^^^^ Expression may refer to different types
+
+Notes:
+  | 
+5 | def foo(x: bool) -> float:
+6 |     y = 1.0 if x else 1
+  |         --- This is of type `float`
+  | 
+6 |     y = 1.0 if x else 1
+  |                       - This is of type `int`
+
+Help:
+  | 
+5 | def foo(x: bool) -> float:
+6 |     y = 1.0 if x else 1
+  |                       - Consider coercing this value to `float`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/if_different_types_coerce3.py
+++ b/tests/error/errors_on_usage/if_different_types_coerce3.py
@@ -1,0 +1,7 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def foo(x: bool) -> float:
+    y = 1.0 if x else 1
+    return y

--- a/tests/error/errors_on_usage/if_different_types_coerce4.err
+++ b/tests/error/errors_on_usage/if_different_types_coerce4.err
@@ -1,0 +1,23 @@
+Error: Different types (at $FILE:6:8)
+  | 
+4 | @compile_guppy
+5 | def foo(x: bool) -> float:
+6 |     y = 1 if x else 1.0
+  |         ^^^^^^^^^^^^^^^ Expression may refer to different types
+
+Notes:
+  | 
+5 | def foo(x: bool) -> float:
+6 |     y = 1 if x else 1.0
+  |         - This is of type `int`
+  | 
+6 |     y = 1 if x else 1.0
+  |                     --- This is of type `float`
+
+Help:
+  | 
+5 | def foo(x: bool) -> float:
+6 |     y = 1 if x else 1.0
+  |         - Consider coercing this value to `float`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/if_different_types_coerce4.py
+++ b/tests/error/errors_on_usage/if_different_types_coerce4.py
@@ -1,0 +1,7 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def foo(x: bool) -> float:
+    y = 1 if x else 1.0
+    return y

--- a/tests/error/type_errors/fun_item_ty_mismatch_if.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch_if.err
@@ -1,0 +1,17 @@
+Error: Different types (at $FILE:14:10)
+   | 
+12 | @guppy
+13 | def main(b: bool) -> int:
+14 |     baz = foo if b else bar
+   |           ^^^^^^^^^^^^^^^^^ Expression may refer to different types
+
+Notes:
+   | 
+13 | def main(b: bool) -> int:
+14 |     baz = foo if b else bar
+   |           --- This is of type `def foo() -> int`
+   | 
+14 |     baz = foo if b else bar
+   |                         --- This is of type `def bar() -> int`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_if.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch_if.err
@@ -14,4 +14,6 @@ Notes:
 14 |     baz = foo if b else bar
    |                         --- This is of type `def bar() -> int`
 
+Help: Consider coercing both values to `Function[[], int]`
+
 Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_if.py
+++ b/tests/error/type_errors/fun_item_ty_mismatch_if.py
@@ -1,0 +1,18 @@
+from guppylang import guppy
+
+
+@guppy.declare
+def foo() -> int: ...
+
+
+@guppy.declare
+def bar() -> int: ...
+
+
+@guppy
+def main(b: bool) -> int:
+    baz = foo if b else bar
+    return baz()
+
+
+main.compile_function()


### PR DESCRIPTION
Fixing a bug that was introduced in #2013