### PR TITLE
refactor: Remove ProtocolCall

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -122,7 +122,6 @@ from guppylang_internals.nodes import (
     MakeIter,
     PartialApply,
     PlaceNode,
-    ProtocolCall,
     SubscriptAccessAndDrop,
     TensorCall,
     TupleAccessAndDrop,
@@ -381,24 +380,13 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             if isinstance(defn, CallableDef):
                 return defn.check_call(node.args, ty, node, self.ctx)
 
-            from guppylang_internals.definition.protocol import (
-                ParsedProtocolDef,
-            )
+            from guppylang_internals.definition.protocol import ParsedProtocolDef
 
-            # Protocol methods don't have their own definition, we have to look up the
-            # protocol definition itself first.
-            if isinstance(defn, ParsedProtocolDef):
-                assert isinstance(func_ty, FunctionType)
-                args, subst, inst = check_call(func_ty, node.args, ty, node, self.ctx)
-                return with_loc(
-                    node,
-                    ProtocolCall(
-                        member=node.func.id,
-                        proto_id=node.func.def_id,
-                        args=args,
-                        type_args=inst,
-                    ),
-                ), subst
+            # This would correspond to something like:
+            #   Callable(x,y)
+            # ...but even picking a protocol which it might make sense to call,
+            # that still doesn't.
+            assert not isinstance(defn, ParsedProtocolDef)
 
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):
@@ -1008,20 +996,11 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
 
             from guppylang_internals.definition.protocol import ParsedProtocolDef
 
-            # Protocol methods don't have their own definition, we have to look up the
-            # protocol definition itself first.
-            if isinstance(defn, ParsedProtocolDef):
-                assert isinstance(ty, FunctionType)
-                args, return_ty, inst = synthesize_call(ty, node.args, node, self.ctx)
-                return with_loc(
-                    node,
-                    ProtocolCall(
-                        member=node.func.id,
-                        proto_id=node.func.def_id,
-                        args=args,
-                        type_args=inst,
-                    ),
-                ), return_ty
+            # This would correspond to some source code like
+            #   Callable(x)
+            # but even picking a protocol which supports some notion of calling,
+            # this still makes no sense.
+            assert not isinstance(defn, ParsedProtocolDef)
 
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -380,14 +380,6 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             if isinstance(defn, CallableDef):
                 return defn.check_call(node.args, ty, node, self.ctx)
 
-            from guppylang_internals.definition.protocol import ParsedProtocolDef
-
-            # This would correspond to something like:
-            #   Callable(x,y)
-            # ...but even picking a protocol which it might make sense to call,
-            # that still doesn't.
-            assert not isinstance(defn, ParsedProtocolDef)
-
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):
             node.args = [*node.func.args, *node.args]
@@ -993,14 +985,6 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
             defn = self.ctx.globals[node.func.def_id]
             if isinstance(defn, CallableDef):
                 return defn.synthesize_call(node.args, node, self.ctx)
-
-            from guppylang_internals.definition.protocol import ParsedProtocolDef
-
-            # This would correspond to some source code like
-            #   Callable(x)
-            # but even picking a protocol which supports some notion of calling,
-            # this still makes no sense.
-            assert not isinstance(defn, ParsedProtocolDef)
 
         # When calling a `PartialApply` node, we just move the args into this call
         if isinstance(node.func, PartialApply):

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -48,7 +48,6 @@ from guppylang_internals.checker.errors.linearity import (
     UnnamedTupleNotUsedError,
 )
 from guppylang_internals.definition.custom import CustomFunctionDef
-from guppylang_internals.definition.protocol import CheckedProtocolDef
 from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.engine import DEF_STORE, ENGINE
 from guppylang_internals.error import GuppyError, GuppyTypeError
@@ -66,7 +65,6 @@ from guppylang_internals.nodes import (
     LocalCall,
     PartialApply,
     PlaceNode,
-    ProtocolCall,
     StateOutputExpr,
     SubscriptAccessAndDrop,
     TensorCall,
@@ -498,13 +496,6 @@ class BBLinearityChecker(ast.NodeVisitor):
         func_ty = get_type(node.func)
         assert isinstance(func_ty, FunctionType)
         self.visit(node.func)
-        self._visit_call_args(func_ty, node)
-        self._reassign_inout_args(func_ty, node)
-
-    def visit_ProtocolCall(self, node: ProtocolCall) -> None:
-        proto = ENGINE.get_checked(node.proto_id, node.type_args)
-        assert isinstance(proto, CheckedProtocolDef)
-        func_ty = proto.member_sig(node.member)
         self._visit_call_args(func_ty, node)
         self._reassign_inout_args(func_ty, node)
 

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -135,29 +135,6 @@ class GlobalCall(ast.expr):
     __reduce_ex__ = object.__reduce_ex__
 
 
-class ProtocolCall(ast.expr):
-    member: str
-    proto_id: "DefId"
-    args: list[ast.expr]
-    type_args: Inst
-
-    _fields = (
-        "member",
-        "proto_id",
-        "args",
-        "type_args",
-    )
-
-    def __init__(
-        self, member: str, proto_id: "DefId", args: list[ast.expr], type_args: Inst
-    ):
-        super().__init__()
-        self.member = member
-        self.proto_id = proto_id
-        self.args = args
-        self.type_args = type_args
-
-
 class TensorCall(ast.expr):
     """A call to a tuple of functions. Behaves like a local call, but more
     unpacking of tuples is required at compilation"""
@@ -563,9 +540,7 @@ class StateOutputExpr(ast.expr):
     __reduce_ex__ = object.__reduce_ex__
 
 
-AnyCall = (
-    LocalCall | GlobalCall | TensorCall | BarrierExpr | StateOutputExpr | ProtocolCall
-)
+AnyCall = LocalCall | GlobalCall | TensorCall | BarrierExpr | StateOutputExpr
 
 
 class InoutReturnSentinel(ast.expr):


### PR DESCRIPTION
There were a couple of cases in `expr_checker.py` that asserts demonstrated never happened - roughly equivalent to:
```
@guppy.protocol
class Proto:
    @guppy.require
    def foo() -> None: ...

Proto.foo()
```
Removing these then leaves the ProtocolCall ast node as no longer used, so remove that, too.