### PR TITLE
refactor: Remove inheritance of CompiledCallableDef from CallableDef

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/value.py
+++ b/guppylang-internals/src/guppylang_internals/definition/value.py
@@ -35,7 +35,8 @@ class CompiledValueDef(ValueDef, CompiledDef):
 
 @dataclass(frozen=True)
 class CallableDef(ValueDef):
-    """Abstract base class for definitions that represent functions."""
+    """Abstract base class for definitions that represent functions and to which
+    calls can be type-checked."""
 
     ty: FunctionType
 
@@ -55,8 +56,11 @@ class CallableDef(ValueDef):
         raise RuntimeError("Guppy functions can only be called in a Guppy context")
 
 
-class CompiledCallableDef(CallableDef, CompiledValueDef):  # type: ignore[misc, unused-ignore]
-    """Abstract base class a global module-level function."""
+class CompiledCallableDef(CompiledValueDef):  # type: ignore[misc, unused-ignore]
+    """Abstract base class for anything that compiles to a Hugr function (necessarily)
+    at module-level)."""
+
+    ty: FunctionType
 
     @abstractmethod
     def compile_call(

--- a/guppylang-internals/src/guppylang_internals/definition/value.py
+++ b/guppylang-internals/src/guppylang_internals/definition/value.py
@@ -56,7 +56,7 @@ class CallableDef(ValueDef):
         raise RuntimeError("Guppy functions can only be called in a Guppy context")
 
 
-class CompiledCallableDef(CompiledValueDef):  # type: ignore[misc, unused-ignore]
+class CompiledCallableDef(CompiledValueDef):
     """Abstract base class for anything that compiles to a Hugr function (necessarily)
     at module-level)."""
 


### PR DESCRIPTION
Tiny step towards https://github.com/Quantinuum/guppylang/discussions/1583 but may be demonstrative.

CompiledCallableDef inherits from CallableDef but not because it needs to be a subtype or because it needs `check_call` or `synthesize_call` methods (it doesn't) - only because it wants to inherit one data member (!...itself only a type refinement). That inheritance seems like a "code smell" and one data member is not much to repeat.

This also allows to drop a type:ignore that was silencing a (mildly scary) warning :)
