### PR TITLE
fix: Fix diagnostics rendering for type aliases in Jupyter notebooks

### DIFF
--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -1,6 +1,7 @@
 import ast
 import builtins
 import inspect
+import linecache
 from collections.abc import Callable
 from types import FrameType
 from typing import (
@@ -734,8 +735,13 @@ def _parse_expr_string(ty_str: str, parse_err: str, sources: SourceMap) -> ast.e
     if caller_frame := get_calling_frame():
         info = inspect.getframeinfo(caller_frame)
         if caller_module := inspect.getmodule(caller_frame):
-            sources.add_file(info.filename)
             source_lines, _ = inspect.getsourcelines(caller_module)
+        else:
+            # inspect.getmodule can fail, for example if we are running in IPython. Fall
+            # back to linecache in that case
+            source_lines = linecache.getlines(info.filename)
+        if source_lines:
+            sources.add_file(info.filename)
             source = "".join(source_lines)
             annotate_location(expr_ast, source, info.filename, 1)
             # Modify the AST so that all sub-nodes span the entire line. We

--- a/tests/integration/notebooks/misc_notebook_tests.ipynb
+++ b/tests/integration/notebooks/misc_notebook_tests.ipynb
@@ -227,6 +227,11 @@
    "execution_count": 6,
    "id": "e67f98e9",
    "metadata": {
+    "deletable": true,
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
     "tags": [
      "raises-exception"
     ]
@@ -269,11 +274,52 @@
     "\n",
     "main.compile()"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3e46004f-54db-4101-b467-c815c3e14ed6",
+   "metadata": {},
+   "source": [
+    "Test that error locations for top-level declarations are correct. See https://github.com/Quantinuum/guppylang/issues/2039"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "61d519ca-87b4-4811-85f4-5e266ec301c8",
+   "metadata": {
+    "deletable": true,
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "raises-exception"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Error: Unsupported (at <In[7]>:1:0)\n",
+      "  | \n",
+      "1 | InfiniteInts = guppy.type_alias(\"InfiniteInts\", \"tuple[int, InfiniteInts]\")\n",
+      "  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Recursive definitions are not supported\n",
+      "\n",
+      "Guppy compilation failed due to 1 previous error\n"
+     ]
+    }
+   ],
+   "source": [
+    "InfiniteInts = guppy.type_alias(\"InfiniteInts\", \"tuple[int, InfiniteInts]\")\n",
+    "InfiniteInts.check()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "guppylang (3.13.11)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -287,7 +333,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Fixes #2039