### PR TITLE
test: fixture for enabling experimental features selectively

### DIFF
--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ check:
 
 # Run the tests.
 test *PYTEST_FLAGS:
-    uv run pytest tests/ -n auto {{PYTEST_FLAGS}}
+    uv run pytest -n auto {{PYTEST_FLAGS}}
 
 # Export the integration test cases to a directory.
 export-integration-tests directory="guppy-exports":

--- a/justfile
+++ b/justfile
@@ -17,7 +17,7 @@ check:
 
 # Run the tests.
 test *PYTEST_FLAGS:
-    uv run pytest -n auto {{PYTEST_FLAGS}}
+    uv run pytest tests/ -n auto {{PYTEST_FLAGS}}
 
 # Export the integration test cases to a directory.
 export-integration-tests directory="guppy-exports":

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,8 +8,6 @@ from guppylang.experimental import (
     enable_experimental_features,
 )
 
-# guppylang.enable_experimental_features()
-
 
 def pytest_addoption(parser):
     def dir_path(s):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 import argparse
+from contextlib import contextmanager
 from pathlib import Path
 
-import guppylang
+import pytest
+from guppylang.experimental import (
+    disable_experimental_features,
+    enable_experimental_features,
+)
 
-guppylang.enable_experimental_features()
+# guppylang.enable_experimental_features()
 
 
 def pytest_addoption(parser):
@@ -41,3 +46,18 @@ def pytest_addoption(parser):
         default="helios",
         help="Target qsystem platform for integration emulation tests",
     )
+
+
+@contextmanager
+def experimental_features_enabled():
+    """Enable experimental features and yield"""
+    enable_experimental_features()
+    yield
+    disable_experimental_features()
+
+
+@pytest.fixture
+def use_experimental_features():
+    """Fixture for enabling experimental features."""
+    with experimental_features_enabled():
+        yield

--- a/tests/error/errors_on_usage/var_in_modifier4.err
+++ b/tests/error/errors_on_usage/var_in_modifier4.err
@@ -1,15 +1,15 @@
-Error: Variable assigned in modifier block (at $FILE:10:8)
-   | 
- 8 |     with power(3):
- 9 |         i = 3
-10 |     u = i
-   |         ^ `i` cannot be used...
+Error: Variable assigned in modifier block (at $FILE:8:8)
+  | 
+6 |     with power(3):
+7 |         i = 3
+8 |     u = i
+  |         ^ `i` cannot be used...
 
 Note:
-   | 
- 8 |     with power(3):
- 9 |         i = 3
-   |         ----- ... since it was assigned in a modifier block
+  | 
+6 |     with power(3):
+7 |         i = 3
+  |         ----- ... since it was assigned in a modifier block
 
 Help: Variables assigned inside a modifier block are not available outside the
 block

--- a/tests/error/errors_on_usage/var_in_modifier4.py
+++ b/tests/error/errors_on_usage/var_in_modifier4.py
@@ -1,7 +1,7 @@
 import guppylang
 from guppylang import guppy
 from guppylang.std.builtins import power
-guppylang.enable_experimental_features()
+#guppylang.enable_experimental_features()
 
 @guppy
 def main() -> None:

--- a/tests/error/errors_on_usage/var_in_modifier4.py
+++ b/tests/error/errors_on_usage/var_in_modifier4.py
@@ -1,7 +1,5 @@
-import guppylang
 from guppylang import guppy
 from guppylang.std.builtins import power
-#guppylang.enable_experimental_features()
 
 @guppy
 def main() -> None:

--- a/tests/error/errors_on_usage/var_undefined_before_modifier1.err
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier1.err
@@ -1,8 +1,8 @@
-Error: Variable not defined (at $FILE:8:8)
+Error: Variable not defined (at $FILE:6:8)
   | 
-6 | @guppy
-7 | def main() -> None:
-8 |     x = i
+4 | @guppy
+5 | def main() -> None:
+6 |     x = i
   |         ^ `i` is not defined
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/var_undefined_before_modifier1.py
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier1.py
@@ -1,7 +1,7 @@
 import guppylang
 from guppylang import guppy
 from guppylang.std.builtins import power
-guppylang.enable_experimental_features()
+#guppylang.enable_experimental_features()
 
 @guppy
 def main() -> None:

--- a/tests/error/errors_on_usage/var_undefined_before_modifier1.py
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier1.py
@@ -1,7 +1,5 @@
-import guppylang
 from guppylang import guppy
 from guppylang.std.builtins import power
-#guppylang.enable_experimental_features()
 
 @guppy
 def main() -> None:

--- a/tests/error/errors_on_usage/var_undefined_before_modifier2.err
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier2.err
@@ -1,8 +1,8 @@
-Error: Variable not defined (at $FILE:12:8)
+Error: Variable not defined (at $FILE:10:8)
    | 
-10 |     if b:
-11 |         y = 2
-12 |     a = i
+ 8 |     if b:
+ 9 |         y = 2
+10 |     a = i
    |         ^ `i` is not defined
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/errors_on_usage/var_undefined_before_modifier2.py
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier2.py
@@ -4,7 +4,7 @@ from guppylang.std.builtins import power
 @guppy
 def main(b: bool) -> None:
     x = 3
-    
+
     if b:
         y = 2
     a = i
@@ -13,5 +13,4 @@ def main(b: bool) -> None:
     a = y
 
 
-                
 main.check()

--- a/tests/error/errors_on_usage/var_undefined_before_modifier2.py
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier2.py
@@ -1,7 +1,5 @@
-import guppylang
 from guppylang import guppy
 from guppylang.std.builtins import power
-#guppylang.enable_experimental_features()
 
 @guppy
 def main(b: bool) -> None:

--- a/tests/error/errors_on_usage/var_undefined_before_modifier2.py
+++ b/tests/error/errors_on_usage/var_undefined_before_modifier2.py
@@ -1,7 +1,7 @@
 import guppylang
 from guppylang import guppy
 from guppylang.std.builtins import power
-guppylang.enable_experimental_features()
+#guppylang.enable_experimental_features()
 
 @guppy
 def main(b: bool) -> None:

--- a/tests/error/test_array_errors.py
+++ b/tests/error/test_array_errors.py
@@ -21,6 +21,7 @@ skipped_files = {
     "array_index_put.py",
     "array_index_set.py",
     "array_index_take.py",
+    "non_array_subscript.py",
 }
 
 # Turn paths into strings, otherwise pytest doesn't display the names

--- a/tests/error/test_comprehension_errors.py
+++ b/tests/error/test_comprehension_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "comprehension_errors"
 files = [
@@ -16,4 +17,5 @@ files = [str(f) for f in files]
 
 @pytest.mark.parametrize("file", files)
 def test_comprehension_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+    with experimental_features_enabled():
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_errors_on_usage.py
+++ b/tests/error/test_errors_on_usage.py
@@ -37,8 +37,4 @@ files_with_experimental_flag = [
 
 @pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
 def test_errors_on_usage(file: str, needs_experimental_features: bool, capsys, snapshot):
-    if needs_experimental_features:
-        with experimental_features_enabled():
-            run_error_test(file, capsys, snapshot)
-    else:
-        run_error_test(file, capsys, snapshot)
+    run_error_test(file, capsys, snapshot, needs_experimental_features)

--- a/tests/error/test_errors_on_usage.py
+++ b/tests/error/test_errors_on_usage.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "errors_on_usage"
 files = [
@@ -16,7 +17,28 @@ files = [f for f in files if "functional" not in f.name]
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 
+# Snapshot tests that require experimental features.
+tests_that_require_experimental_features = [
+        "for_new_var.py",
+        "for_target.py",
+        "for_target_type_change.py",
+        "for_type_change.py",
+        "var_in_modifier1.py",
+        "var_in_modifier2.py",
+        "var_in_modifier3.py",
+        "var_in_modifier4.py",
+        "var_undefined_before_modifier1.py",
+        "var_undefined_before_modifier2.py",
+]
+files_with_experimental_flag = [
+    (file, any(case in file for case in tests_that_require_experimental_features))
+    for file in files
+]
 
-@pytest.mark.parametrize("file", files)
-def test_errors_on_usage(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+@pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
+def test_errors_on_usage(file: str, needs_experimental_features: bool, capsys, snapshot):
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_error_test(file, capsys, snapshot)
+    else:
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_linear_errors.py
+++ b/tests/error/test_linear_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "linear_errors"
 files = [
@@ -16,7 +17,22 @@ files = [f for f in files if "functional" not in f.name]
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 
+# Snapshot tests that require experimental features.
+tests_that_require_experimental_features = [
+    "captured_var_inout_own1.py",
+    "captured_var_inout_own2.py",
+    "for_break.py",
+    "for_return.py",
+]
+files_with_experimental_flag = [
+    (file, any(case in file for case in tests_that_require_experimental_features))
+    for file in files
+]
 
-@pytest.mark.parametrize("file", files)
-def test_linear_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+@pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
+def test_linear_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_error_test(file, capsys, snapshot)
+    else:
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_linear_errors.py
+++ b/tests/error/test_linear_errors.py
@@ -31,8 +31,4 @@ files_with_experimental_flag = [
 
 @pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
 def test_linear_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
-    if needs_experimental_features:
-        with experimental_features_enabled():
-            run_error_test(file, capsys, snapshot)
-    else:
-        run_error_test(file, capsys, snapshot)
+    run_error_test(file, capsys, snapshot, needs_experimental_features)

--- a/tests/error/test_modifier_errors.py
+++ b/tests/error/test_modifier_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "modifier_errors"
 files = [
@@ -13,7 +14,35 @@ files = [
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 
+# Snapshot tests that require experimental features.
+tests_that_require_experimental_features = [
+    "dagger_loop3.py",
+    "power_arg_typecheck_inside.py",
+    "flags_nested_combined_outer.py",
+    "captured_classical_modified_nested.py",
+    "captured_classical_modified.py",
+    "captured_modifier_in_branch.py",
+    "dagger_branch2.py",
+    "captured_classical_modified_multiple.py",
+    "flags_nested.py",
+    "power_arg_type.py",
+    "captured_classical_modified_sequential.py",
+    "captured_classical_modified_branch.py",
+    "flags_triple_dagger2.py",
+    "flags_nested_triple.py",
+    "flags_nested_power_control.py",
+    "power_many_arg.py",
+    "power_no_arg.py",
+]
+files_with_experimental_flag = [
+    (file, any(case in file for case in tests_that_require_experimental_features))
+    for file in files
+]
 
-@pytest.mark.parametrize("file", files)
-def test_modifier_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+@pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
+def test_modifier_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_error_test(file, capsys, snapshot)
+    else:
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_modifier_errors.py
+++ b/tests/error/test_modifier_errors.py
@@ -41,8 +41,4 @@ files_with_experimental_flag = [
 
 @pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
 def test_modifier_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
-    if needs_experimental_features:
-        with experimental_features_enabled():
-            run_error_test(file, capsys, snapshot)
-    else:
-        run_error_test(file, capsys, snapshot)
+    run_error_test(file, capsys, snapshot, needs_experimental_features)

--- a/tests/error/test_nested_errors.py
+++ b/tests/error/test_nested_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "nested_errors"
 files = [
@@ -16,4 +17,5 @@ files = [str(f) for f in files]
 
 @pytest.mark.parametrize("file", files)
 def test_nested_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+    with experimental_features_enabled():
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_poly_errors.py
+++ b/tests/error/test_poly_errors.py
@@ -25,8 +25,4 @@ files_with_experimental_flag = [
 
 @pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
 def test_type_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
-    if needs_experimental_features:
-        with experimental_features_enabled():
-            run_error_test(file, capsys, snapshot)
-    else:
-        run_error_test(file, capsys, snapshot)
+    run_error_test(file, capsys, snapshot, needs_experimental_features)

--- a/tests/error/test_poly_errors.py
+++ b/tests/error/test_poly_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "poly_errors"
 files = [
@@ -13,7 +14,19 @@ files = [
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 
+# Snapshot tests that require experimental features.
+tests_that_require_experimental_features = [
+        "arg_mismatch5.py",
+]
+files_with_experimental_flag = [
+    (file, any(case in file for case in tests_that_require_experimental_features))
+    for file in files
+]
 
-@pytest.mark.parametrize("file", files)
-def test_type_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+@pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
+def test_type_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_error_test(file, capsys, snapshot)
+    else:
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_tensor_errors.py
+++ b/tests/error/test_tensor_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "tensor_errors"
 files = [
@@ -16,4 +17,5 @@ files = [str(f) for f in files]
 
 @pytest.mark.parametrize("file", files)
 def test_type_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+    with experimental_features_enabled():
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_tracing_errors.py
+++ b/tests/error/test_tracing_errors.py
@@ -31,9 +31,4 @@ def test_tracing_errors(file: str, needs_experimental_features: bool, capsys, sn
     # Reset the tracing state by hand since the previous test catches the exception so
     # it's not reset
     reset_state()
-
-    if needs_experimental_features:
-        with experimental_features_enabled():
-            run_error_test(file, capsys, snapshot)
-    else:
-        run_error_test(file, capsys, snapshot)
+    run_error_test(file, capsys, snapshot, needs_experimental_features)

--- a/tests/error/test_tracing_errors.py
+++ b/tests/error/test_tracing_errors.py
@@ -3,6 +3,7 @@ import pytest
 
 from guppylang_internals.tracing.state import reset_state
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "tracing_errors"
 files = [
@@ -14,10 +15,25 @@ files = [
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 
+# Snapshot tests that require experimental features.
+tests_that_require_experimental_features = [
+        "comptime_flags_nested_triple.py",
+        "comptime_flags_nested_dagger_power.py",
+        "comptime_flags_nested_power_control.py",
+]
+files_with_experimental_flag = [
+    (file, any(case in file for case in tests_that_require_experimental_features))
+    for file in files
+]
 
-@pytest.mark.parametrize("file", files)
-def test_tracing_errors(file, capsys, snapshot):
+@pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
+def test_tracing_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
     # Reset the tracing state by hand since the previous test catches the exception so
     # it's not reset
     reset_state()
-    run_error_test(file, capsys, snapshot)
+
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_error_test(file, capsys, snapshot)
+    else:
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/test_type_errors.py
+++ b/tests/error/test_type_errors.py
@@ -28,8 +28,4 @@ files_with_experimental_flag = [
 
 @pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
 def test_type_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
-    if needs_experimental_features:
-        with experimental_features_enabled():
-            run_error_test(file, capsys, snapshot)
-    else:
-        run_error_test(file, capsys, snapshot)
+    run_error_test(file, capsys, snapshot, needs_experimental_features)

--- a/tests/error/test_type_errors.py
+++ b/tests/error/test_type_errors.py
@@ -2,6 +2,7 @@ import pathlib
 import pytest
 
 from tests.error.util import run_error_test
+from tests.conftest import experimental_features_enabled
 
 path = pathlib.Path(__file__).parent.resolve() / "type_errors"
 files = [
@@ -16,7 +17,19 @@ files = [f for f in files if "functional" not in f.name]
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 
+# Snapshot tests that require experimental features.
+tests_that_require_experimental_features = [
+        "unpack_non_static.py",
+]
+files_with_experimental_flag = [
+    (file, any(case in file for case in tests_that_require_experimental_features))
+    for file in files
+]
 
-@pytest.mark.parametrize("file", files)
-def test_type_errors(file, capsys, snapshot):
-    run_error_test(file, capsys, snapshot)
+@pytest.mark.parametrize("file,needs_experimental_features", files_with_experimental_flag)
+def test_type_errors(file: str, needs_experimental_features: bool, capsys, snapshot):
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_error_test(file, capsys, snapshot)
+    else:
+        run_error_test(file, capsys, snapshot)

--- a/tests/error/util.py
+++ b/tests/error/util.py
@@ -11,6 +11,7 @@ from hugr.tys import TypeBound
 from guppylang_internals.decorator import custom_type
 from guppylang_internals.diagnostic import DiagnosticsRenderer, wrap
 from tests.util import get_wasm_file
+from tests.conftest import experimental_features_enabled
 
 # Regular expression to match the `~~~~~^^^~~~` highlights that are printed in
 # tracebacks from Python 3.11 onwards. We strip those out so we can use the same golden
@@ -37,35 +38,43 @@ def filter_traceback_not_containing(s: str, disallowed_regex: re.Pattern[str]) -
 
     return "\n".join(result)
 
-def run_error_test(file, capsys, snapshot):
+def run_error_test(file, capsys, snapshot, needs_experimental_features=False):
     file = pathlib.Path(file)
 
-    with pytest.raises(Exception) as exc_info:
-        importlib.import_module(f"tests.error.{file.parent.name}.{file.stem}")
+    def run_test():
+        with pytest.raises(Exception) as exc_info:
+            importlib.import_module(f"tests.error.{file.parent.name}.{file.stem}")
 
-    # Remove the importlib frames from the traceback by skipping beginning frames until
-    # we end up in the executed file
-    tb = exc_info.tb
-    while tb is not None and inspect.getfile(tb.tb_frame) != str(file):
-        tb = tb.tb_next
+        # Remove the importlib frames from the traceback by skipping beginning frames until
+        # we end up in the executed file
+        tb = exc_info.tb
+        while tb is not None and inspect.getfile(tb.tb_frame) != str(file):
+            tb = tb.tb_next
 
-    # Invoke except hook to print the exception to stderr
-    sys.excepthook(exc_info.type, exc_info.value.with_traceback(tb), tb)
+        # Invoke except hook to print the exception to stderr
+        sys.excepthook(exc_info.type, exc_info.value.with_traceback(tb), tb)
 
-    err = capsys.readouterr().err
-    err = err.replace(str(file), "$FILE")
-    # The WASM file descriptor can stretch across multiple lines in a longer message,
-    # so we try to predict the wrapping points to be able to build a replacement regex.
-    wasm_module = get_wasm_file()
-    wrapped_wasm = wrap(f"`{wasm_module}`", DiagnosticsRenderer.MAX_MESSAGE_LINE_LEN)
-    err = re.sub("\n".join(wrapped_wasm), "`$WASM`", err)
-    # Strip the bootstrap included in the traceback by Python 3.13+ for parallel tests
-    err = filter_traceback_not_containing(err, EXECNET_BOOTSTRAP)
-    # Strip the error markers that are only present for Python 3.11+
-    err = filter_traceback_not_containing(err, TRACEBACK_HIGHLIGHT)
+        err = capsys.readouterr().err
+        err = err.replace(str(file), "$FILE")
+        # The WASM file descriptor can stretch across multiple lines in a longer message,
+        # so we try to predict the wrapping points to be able to build a replacement regex.
+        wasm_module = get_wasm_file()
+        wrapped_wasm = wrap(f"`{wasm_module}`", DiagnosticsRenderer.MAX_MESSAGE_LINE_LEN)
+        err = re.sub("\n".join(wrapped_wasm), "`$WASM`", err)
+        # Strip the bootstrap included in the traceback by Python 3.13+ for parallel tests
+        err = filter_traceback_not_containing(err, EXECNET_BOOTSTRAP)
+        # Strip the error markers that are only present for Python 3.11+
+        err = filter_traceback_not_containing(err, TRACEBACK_HIGHLIGHT)
 
-    snapshot.snapshot_dir = str(file.parent)
-    snapshot.assert_match(err, file.with_suffix(".err").name)
+        snapshot.snapshot_dir = str(file.parent)
+        snapshot.assert_match(err, file.with_suffix(".err").name)
+
+    # Enable experimental features in context to properly clean up
+    if needs_experimental_features:
+        with experimental_features_enabled():
+            run_test()
+    else:
+        run_test()
 
 
 @custom_type(

--- a/tests/integration/test_comprehension.py
+++ b/tests/integration/test_comprehension.py
@@ -1,3 +1,4 @@
+import pytest
 from hugr import tys
 
 from guppylang.decorator import guppy
@@ -9,6 +10,11 @@ from guppylang_internals.decorator import custom_type
 
 from guppylang_internals.tys.ty import NoneType
 from tests.util import compile_guppy
+
+
+@pytest.fixture(autouse=True)
+def enable_experimental_features_for_suite(use_experimental_features):
+    pass
 
 
 def test_basic(validate):

--- a/tests/integration/test_enum.py
+++ b/tests/integration/test_enum.py
@@ -176,7 +176,7 @@ def test_methods(validate):
     validate(main.compile_function())
 
 
-def test_generic_explicit(validate):
+def test_generic_explicit(validate, use_experimental_features):
     S = guppy.type_var("S")
     T = guppy.type_var("T")
 
@@ -211,7 +211,7 @@ def test_generic_explicit(validate):
     validate(main.compile_function())
 
 
-def test_generic_infer(validate):
+def test_generic_infer(validate, use_experimental_features):
     S = guppy.type_var("S")
     T = guppy.type_var("T")
 

--- a/tests/integration/test_for.py
+++ b/tests/integration/test_for.py
@@ -1,4 +1,10 @@
+import pytest
 from tests.util import compile_guppy
+
+
+@pytest.fixture(autouse=True)
+def enable_experimental_features_for_suite(use_experimental_features):
+    pass
 
 
 def test_basic(validate):

--- a/tests/integration/test_higher_order.py
+++ b/tests/integration/test_higher_order.py
@@ -65,7 +65,7 @@ def test_conditional(validate):
     validate(main.compile_function())
 
 
-def test_method(validate):
+def test_method(validate, use_experimental_features):
     @guppy
     def foo(x: int) -> tuple[int, Function[[int], int]]:
         f = x.__add__
@@ -74,7 +74,7 @@ def test_method(validate):
     validate(foo.compile_function())
 
 
-def test_nested(validate):
+def test_nested(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> Function[[int], bool]:
         def bar(y: int) -> bool:
@@ -85,7 +85,7 @@ def test_nested(validate):
     validate(foo)
 
 
-def test_nested_capture_struct(validate):
+def test_nested_capture_struct(validate, use_experimental_features):
     @guppy.struct(frozen=True)
     class MyStruct:
         x: int
@@ -100,7 +100,7 @@ def test_nested_capture_struct(validate):
     validate(foo.compile_function())
 
 
-def test_nested_capture_enum(validate):
+def test_nested_capture_enum(validate, use_experimental_features):
     @guppy.enum
     class MyEnum:
         VariantA = {}
@@ -119,7 +119,7 @@ def test_nested_capture_enum(validate):
     validate(foo.compile_function())
 
 
-def test_curry(validate):
+def test_curry(validate, use_experimental_features):
     @guppy
     def curry(f: Function[[int, int], bool]) -> Function[[int], Function[[int], bool]]:
         def g(x: int) -> Function[[int], bool]:
@@ -154,7 +154,7 @@ def test_curry(validate):
     validate(main.compile_function())
 
 
-def test_y_combinator(validate):
+def test_y_combinator(validate, use_experimental_features):
     @guppy
     def fac_(f: Function[[int], int], n: int) -> int:
         if n == 0:

--- a/tests/integration/test_inout.py
+++ b/tests/integration/test_inout.py
@@ -140,7 +140,7 @@ def test_control_flow(validate):
     validate(test.compile_function())
 
 
-def test_tensor(validate):
+def test_tensor(validate, use_experimental_features):
     @guppy.struct
     class A:
         q: qubit

--- a/tests/integration/test_linear.py
+++ b/tests/integration/test_linear.py
@@ -438,7 +438,7 @@ def test_while_move_back(validate):
     validate(test.compile_function())
 
 
-def test_for(validate):
+def test_for(validate, use_experimental_features):
     @guppy
     def test(qs: list[tuple[qubit, qubit]] @ owned) -> list[qubit]:
         rs: list[qubit] = []
@@ -451,7 +451,7 @@ def test_for(validate):
     validate(test.compile_function())
 
 
-def test_for_measure(validate):
+def test_for_measure(validate, use_experimental_features):
     @guppy
     def test(qs: list[qubit] @ owned) -> bool:
         parity = False
@@ -462,7 +462,7 @@ def test_for_measure(validate):
     validate(test.compile_function())
 
 
-def test_for_continue(validate):
+def test_for_continue(validate, use_experimental_features):
     @guppy
     def test(qs: list[qubit] @ owned) -> int:
         x = 0
@@ -475,7 +475,7 @@ def test_for_continue(validate):
     validate(test.compile_function())
 
 
-def test_for_nonlinear_break(validate):
+def test_for_nonlinear_break(validate, use_experimental_features):
     @custom_type(lambda _, ctx: NoneType().to_hugr(ctx))
     class MyIter:
         """An iterator that yields linear values but is not linear itself."""
@@ -516,7 +516,7 @@ def test_rus(validate):
     validate(repeat_until_success.compile_function())
 
 
-def test_list_iter_arg(validate):
+def test_list_iter_arg(validate, use_experimental_features):
     @guppy
     def owned_arg(qs: list[qubit] @ owned) -> list[qubit]:
         qs = [h(q) for q in qs]
@@ -525,7 +525,7 @@ def test_list_iter_arg(validate):
     validate(owned_arg.compile_function())
 
 
-def test_list_iter(validate):
+def test_list_iter(validate, use_experimental_features):
     @guppy
     def owned_arg() -> list[qubit]:
         qs = [qubit() for _ in [0, 1, 2]]

--- a/tests/integration/test_list.py
+++ b/tests/integration/test_list.py
@@ -8,6 +8,11 @@ from guppylang.std.quantum.functional import h
 from tests.util import compile_guppy
 
 
+@pytest.fixture(autouse=True)
+def enable_experimental_features_for_suite(use_experimental_features):
+    pass
+
+
 def test_types(validate):
     @compile_guppy
     def test(

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -174,7 +174,7 @@ def test_control_subscript_nested(validate):
     validate(main.compile())
 
 
-def test_power_simple(validate):
+def test_power_simple(validate, use_experimental_features):
     @guppy
     def bar(n: nat) -> None:
         with power(n):
@@ -421,7 +421,7 @@ def test_double_dagger_cancellation_1(validate):
     validate(bar.compile_function())
 
 
-def test_double_dagger_cancellation_2(validate):
+def test_double_dagger_cancellation_2(validate, use_experimental_features):
     @guppy(controllable=True)
     def not_dagger_func(q: qubit) -> None:
         pass

--- a/tests/integration/test_nested.py
+++ b/tests/integration/test_nested.py
@@ -88,7 +88,7 @@ def test_recurse(validate):
     validate(foo)
 
 
-def test_capture_arg(validate):
+def test_capture_arg(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         def bar() -> int:
@@ -99,7 +99,7 @@ def test_capture_arg(validate):
     validate(foo)
 
 
-def test_capture_assigned(validate):
+def test_capture_assigned(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         y = x + 1
@@ -112,7 +112,7 @@ def test_capture_assigned(validate):
     validate(foo)
 
 
-def test_capture_multiple(validate):
+def test_capture_multiple(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         if x > 5:
@@ -130,7 +130,7 @@ def test_capture_multiple(validate):
     validate(foo)
 
 
-def test_capture_fn(validate):
+def test_capture_fn(validate, use_experimental_features):
     @compile_guppy
     def foo() -> bool:
         def f(x: bool) -> bool:
@@ -144,7 +144,7 @@ def test_capture_fn(validate):
     validate(foo)
 
 
-def test_capture_cfg(validate):
+def test_capture_cfg(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         a = x + 4
@@ -160,7 +160,7 @@ def test_capture_cfg(validate):
     validate(foo)
 
 
-def test_capture_deep(validate):
+def test_capture_deep(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         a = x * 2
@@ -179,7 +179,7 @@ def test_capture_deep(validate):
     validate(foo)
 
 
-def test_capture_recurse(validate):
+def test_capture_recurse(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         def bar(y: int, z: int) -> int:
@@ -192,7 +192,7 @@ def test_capture_recurse(validate):
     validate(foo)
 
 
-def test_capture_recurse_nested(validate):
+def test_capture_recurse_nested(validate, use_experimental_features):
     @guppy
     def foo(x: int) -> int:
         def bar(y: int, z: int) -> int:
@@ -211,7 +211,7 @@ def test_capture_recurse_nested(validate):
     validate(foo.compile_function())
 
 
-def test_capture_while(validate):
+def test_capture_while(validate, use_experimental_features):
     @compile_guppy
     def foo(x: int) -> int:
         a = 0

--- a/tests/integration/test_poly.py
+++ b/tests/integration/test_poly.py
@@ -137,7 +137,7 @@ def test_infer_basic(validate):
     validate(main.compile_function())
 
 
-def test_infer_list(validate):
+def test_infer_list(validate, use_experimental_features):
     T = guppy.type_var("T")
 
     @guppy.declare

--- a/tests/integration/test_struct.py
+++ b/tests/integration/test_struct.py
@@ -87,7 +87,7 @@ def test_imported_struct_dependency_uses_defining_scope(validate):
     validate(main.compile_function())
 
 
-def test_generic(validate):
+def test_generic(validate, use_experimental_features):
     S = guppy.type_var("S")
     T = guppy.type_var("T")
 

--- a/tests/integration/test_tensor.py
+++ b/tests/integration/test_tensor.py
@@ -4,7 +4,7 @@ from guppylang.decorator import guppy
 from guppylang.std.builtins import Function
 
 
-def test_check_callable(validate):
+def test_check_callable(validate, use_experimental_features):
     @guppy
     def bar(f: Function[[int], bool]) -> Function[[int], bool]:
         return f
@@ -34,7 +34,7 @@ def test_check_callable(validate):
     validate(baz2.compile_function())
 
 
-def test_call(validate):
+def test_call(validate, use_experimental_features):
     @guppy
     def foo() -> int:
         return 42
@@ -70,7 +70,7 @@ def test_call(validate):
     validate(call_var.compile_function())
 
 
-def test_call_inplace(validate):
+def test_call_inplace(validate, use_experimental_features):
     @guppy
     def local(f: Function[[int], bool], g: Function[[bool], int]) -> tuple[bool, int]:
         return (f, g)(42, True)
@@ -78,7 +78,7 @@ def test_call_inplace(validate):
     validate(local.compile_function())
 
 
-def test_singleton(validate):
+def test_singleton(validate, use_experimental_features):
     @guppy
     def foo(x: int, y: int) -> tuple[int, int]:
         return y, x
@@ -90,7 +90,7 @@ def test_singleton(validate):
     validate(baz.compile_function())
 
 
-def test_call_back(validate):
+def test_call_back(validate, use_experimental_features):
     @guppy
     def foo(x: int) -> int:
         return x
@@ -154,7 +154,7 @@ def test_higher_order(validate):
     validate(baz.compile_function())
 
 
-def test_nesting(validate):
+def test_nesting(validate, use_experimental_features):
     @guppy
     def foo(x: int, y: int) -> int:
         return x + y

--- a/tests/metadata/test_modifier_metadata.py
+++ b/tests/metadata/test_modifier_metadata.py
@@ -1,6 +1,5 @@
 """Tests that modifier blocks have the correct `unitary` metadata attached."""
 
-import guppylang as _guppylang
 from guppylang import guppy
 from guppylang.std.angles import angle
 from guppylang.std.builtins import control, dagger, power, qubit
@@ -9,8 +8,6 @@ from guppylang_internals.tys.ty import UnitaryFlags
 from hugr.hugr.base import Hugr
 from hugr.ops import FuncDecl, FuncDefn
 from tket.metadata import UnitaryFlags as TketUnitaryFlags
-
-_guppylang.enable_experimental_features()
 
 
 def _check_block_metadata(hugr_module: Hugr, unitary_values: list[int]) -> list:
@@ -57,7 +54,7 @@ def test_unitary_metadata_control_only():
 
 
 # Tests nested modifiers metadata
-def test_unitary_metadata_power_dagger_control():
+def test_unitary_metadata_power_dagger_control(use_experimental_features):
     @guppy
     def main() -> None:
         c1 = qubit()
@@ -81,7 +78,7 @@ def test_unitary_metadata_power_dagger_control():
     )
 
 
-def test_unitary_metadata_dagger_power_control():
+def test_unitary_metadata_dagger_power_control(use_experimental_features):
     @guppy
     def main() -> None:
         c1 = qubit()
@@ -105,7 +102,7 @@ def test_unitary_metadata_dagger_power_control():
     )
 
 
-def test_unitary_metadata_control_dagger_power():
+def test_unitary_metadata_control_dagger_power(use_experimental_features):
     @guppy
     def main() -> None:
         c1 = qubit()
@@ -129,7 +126,7 @@ def test_unitary_metadata_control_dagger_power():
     )
 
 
-def test_unitary_metadata_power_control_dagger():
+def test_unitary_metadata_power_control_dagger(use_experimental_features):
     @guppy
     def main() -> None:
         c1 = qubit()
@@ -153,7 +150,7 @@ def test_unitary_metadata_power_control_dagger():
     )
 
 
-def test_unitary_metadata_dagger_control_power():
+def test_unitary_metadata_dagger_control_power(use_experimental_features):
     @guppy
     def main() -> None:
         c1 = qubit()
@@ -177,7 +174,7 @@ def test_unitary_metadata_dagger_control_power():
     )
 
 
-def test_unitary_metadata_control_power_dagger():
+def test_unitary_metadata_control_power_dagger(use_experimental_features):
     @guppy
     def main() -> None:
         c1 = qubit()
@@ -201,7 +198,7 @@ def test_unitary_metadata_control_power_dagger():
     )
 
 
-def test_unitary_metadata_function_definition():
+def test_unitary_metadata_function_definition(use_experimental_features):
     @guppy(daggerable=True)
     def dag() -> None:
         pass


### PR DESCRIPTION
Closes #2028. Includes the following changes:

- New `experimental_features_enabled` context manager for temporarily enabling experimental features. Used in some snapshot tests for enabling experimental features and making sure they are disabled even if the test fails.
    - We are using hardcoded lists to mark the ones that require experimental features. Another option would be to set a naming convention for snapshot tests that require them, but this seemed like a worst option. Happy to be convinced otherwise.
- New `use_experimental_features` fixture that uses above context manager. It is used in test cases directly or whole suites via a fixture with `autouse=True`.