### PR TITLE
feat: Smarter coercions in array constructor

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1266,6 +1266,26 @@ def coerces_to(act: Type, exp: Type) -> bool:
     return function_coercion or numeric_coercion
 
 
+def coerce_to_common(ty1: Type, ty2: Type) -> Type | None:
+    """Checks whether two types implicitly coerce to a common type.
+
+    Returns the resulting type or `None` if there is no such type.
+    """
+    # First, check if one coerces to the other or vice versa
+    if coerces_to(ty1, ty2):
+        return ty2
+    if coerces_to(ty2, ty1):
+        return ty1
+    # The only other supported case at the moment is coercing both to an opaque function
+    if (
+        isinstance(ty1, FunctionDefType)
+        and isinstance(ty2, FunctionDefType)
+        and ty1.sig == ty2.sig
+    ):
+        return ty1.sig
+    return None
+
+
 def function_def_value_to_global_name(expr: AstNode, ty: FunctionDefType) -> GlobalName:
     """Turns an expressions with a `FunctionDefType` into the corresponding
     `GlobalName`.

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -1,4 +1,5 @@
 import ast
+from contextlib import suppress
 from dataclasses import dataclass
 from typing import ClassVar
 
@@ -17,8 +18,10 @@ from guppylang_internals.checker.expr_checker import (
     check_call,
     check_num_args,
     check_type_against,
+    coerce_to_common,
     synthesize_call,
     synthesize_comprehension,
+    try_coerce_to,
 )
 from guppylang_internals.definition.custom import (
     CustomCallChecker,
@@ -26,7 +29,12 @@ from guppylang_internals.definition.custom import (
 from guppylang_internals.definition.overloaded import InternalExpectOverloadError
 from guppylang_internals.diagnostic import Error, Note
 from guppylang_internals.engine import ENGINE
-from guppylang_internals.error import GuppyError, GuppyTypeError, InternalGuppyError
+from guppylang_internals.error import (
+    GuppyError,
+    GuppyTypeError,
+    GuppyTypeInferenceError,
+    InternalGuppyError,
+)
 from guppylang_internals.nodes import (
     AbortExpr,
     AbortKind,
@@ -309,26 +317,51 @@ class NewArrayChecker(CustomCallChecker):
             case []:
                 err = NewArrayChecker.InferenceError(self.node)
                 err.add_sub_diagnostic(NewArrayChecker.InferenceError.Suggestion(None))
-                raise GuppyTypeError(err)
+                raise GuppyTypeInferenceError(err)
             # Either an array comprehension
             case [DesugaredGeneratorExpr() as compr]:
                 return self.synthesize_array_comprehension(compr)
             # Or a list of array elements
-            case [fst, *rest]:
-                fst, ty = ExprSynthesizer(self.ctx).synthesize(fst)
+            case args:
+                # Check if there are any elements for which we can infer a type
+                tys: list[Type | None] = [None for _ in range(len(args))]
+                for i, arg in enumerate(args):
+                    with suppress(GuppyTypeInferenceError):
+                        args[i], tys[i] = ExprSynthesizer(self.ctx).synthesize(arg)
+                if not any(tys):
+                    err = NewArrayChecker.InferenceError(self.node)
+                    err.add_sub_diagnostic(
+                        NewArrayChecker.InferenceError.Suggestion(None)
+                    )
+                    raise GuppyTypeInferenceError(err)
+
+                # If we found multiple types, check if they can coerce to a common type
+                (_, common_ty), *other_tys = [(i, ty) for i, ty in enumerate(tys) if ty]
+                for i, ty in other_tys:
+                    if ty != common_ty:
+                        new_common_ty = coerce_to_common(common_ty, ty)
+                        if new_common_ty is None:
+                            err = TypeMismatchError(args[i], common_ty, ty)
+                            raise GuppyTypeError(err)
+                        common_ty = new_common_ty
+                assert not common_ty.unsolved_vars, "synth types are already closed"
+
+                # Finally, check the remaining elements and perform the coercions
                 checker = ExprChecker(self.ctx)
-                for i in range(len(rest)):
-                    rest[i], subst = checker.check(rest[i], ty)
-                    assert len(subst) == 0, "Array element type is closed"
-                result_ty = array_type(ty, len(args))
+                for i, ty in enumerate(tys):
+                    if ty is None:
+                        args[i], subst = checker.check(args[i], common_ty)
+                        assert len(subst) == 0, "common_ty is closed"
+                    elif ty != common_ty:
+                        coerced = try_coerce_to(ty, common_ty, args[i], self.ctx)
+                        assert coerced, "ty coerces to common_ty by definition"
+                        args[i] = coerced
+
+                result_ty = array_type(common_ty, len(args))
                 call = GlobalCall(
-                    def_id=self.func.id,
-                    args=[fst, *rest],
-                    type_args=tuple(result_ty.args),
+                    def_id=self.func.id, args=args, type_args=tuple(result_ty.args)
                 )
                 return with_loc(self.node, call), result_ty
-            case args:
-                return assert_never(args)  # type: ignore[arg-type]
 
     @override
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:

--- a/tests/error/array_errors/constructor_free_variable.err
+++ b/tests/error/array_errors/constructor_free_variable.err
@@ -1,0 +1,10 @@
+Error: Cannot infer type (at $FILE:11:3)
+   | 
+ 9 | @guppy
+10 | def main() -> None:
+11 |    array(foo())
+   |    ^^^^^^^^^^^^ Cannot infer the type of this array
+
+Note: Consider adding a type annotation: `x: array[???] = ...`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/array_errors/constructor_free_variable.py
+++ b/tests/error/array_errors/constructor_free_variable.py
@@ -1,0 +1,13 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import array
+
+T = guppy.type_var("T")
+
+@guppy.declare
+def foo() -> T: ...
+
+@guppy
+def main() -> None:
+   array(foo())
+
+main.compile()

--- a/tests/integration/test_array.py
+++ b/tests/integration/test_array.py
@@ -5,6 +5,7 @@ from guppylang import comptime
 from guppylang.decorator import guppy
 from guppylang.emulator import EmulatorError
 from guppylang.std.builtins import array, owned
+from guppylang.std.lang import Function
 from guppylang.std.mem import mem_swap
 from guppylang.std.num import nat
 from guppylang.std.platform import output
@@ -908,3 +909,25 @@ def test_array_reverse_linear(validate) -> None:
     validate(main.compile())
     results = main.emulator(4).run().results[0].entries
     assert results == [("result", True)]
+
+
+def test_array_constructor_coercion(validate) -> None:
+    """See https://github.com/Quantinuum/guppylang/issues/2036"""
+
+    @guppy.declare
+    def foo(x: int) -> int: ...
+
+    @guppy.declare
+    def bar(x: int) -> int: ...
+
+    @guppy.declare
+    def baz(x: int) -> int: ...
+
+    @guppy
+    def main() -> tuple[array[int, 2], array[float, 5], array[Function[[int], int], 3]]:
+        xs = array(1, nat(2))
+        ys = array(1, 1.5, nat(2), 3.5, 4)
+        fs = array(foo, bar, baz)
+        return xs, ys, fs
+
+    validate(main.compile_function())


### PR DESCRIPTION
Fixes #2036

Before, calls to the array constructor were type-checked by inferring a type for the first element and then checking the remaining elements against that. This worked fine in the past, but now that functions need a coercion to be turned into opaque functions, this started breaking some existing code (see #2036).

This PR makes the array constructor smarter by first inferring types for as many elements as possible and checking whether they can be coerced into a common type.