### PR TITLE
chore: Bump selene to 0.3.0a2

### DIFF
--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "guppylang-internals==1.0.0-a8",
     "numpy~=2.5",
     "selene-hugr-qis-compiler~=0.4.1",
-    "selene-sim~=0.3.0a1",
+    "selene-sim~=0.3.0a2",
     "tqdm>=4.68.4",
     "pytket>=2.7.0",
     "types-tqdm>=4.67.0.20250809",

--- a/tests/integration/test_emulator_args.py
+++ b/tests/integration/test_emulator_args.py
@@ -142,17 +142,7 @@ def test_per_shot_args() -> None:
     )
 
 
-@pytest.mark.xfail(
-    raises=ValueError,
-    reason=(
-        "selene's ArgProvider rejects empty lists with 'List for key ... cannot be "
-        "empty'. Expected to be fixed in https://github.com/Quantinuum/selene/pull/187."
-    ),
-    strict=True,
-)
 def test_empty_array_arg() -> None:
-    # TODO: Once https://github.com/Quantinuum/selene/pull/187 is merged and
-    # released, remove the xfail mark above.
     @guppy
     def main(xs: array[int, 0]) -> None:
         output("done", 1)

--- a/uv.lock
+++ b/uv.lock
@@ -803,7 +803,7 @@ requires-dist = [
     { name = "numpy", specifier = "~=2.5" },
     { name = "pytket", specifier = ">=2.7.0" },
     { name = "selene-hugr-qis-compiler", specifier = "~=0.4.1" },
-    { name = "selene-sim", specifier = "~=0.3.0a1" },
+    { name = "selene-sim", specifier = "~=0.3.0a2" },
     { name = "tqdm", specifier = ">=4.68.4" },
     { name = "types-tqdm", specifier = ">=4.67.0.20250809" },
 ]
@@ -2777,7 +2777,7 @@ wheels = [
 
 [[package]]
 name = "selene-sim"
-version = "0.3.0a1"
+version = "0.3.0a2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -2786,11 +2786,11 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/0f/7fd1537cb8cdef177a753c788006ea4e0514890ccaa52569729d209516ba/selene_sim-0.3.0a1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4eacf8552dfd9d29acdd9ecdaadacd505fe58b8ee0aa1c9f31729205a6dde0cc", size = 4886783, upload-time = "2026-06-12T15:51:59.781Z" },
-    { url = "https://files.pythonhosted.org/packages/38/17/679b1c59276e2fd01e68e3f46104f1c0f7a9d3c67b21c96475f7db021746/selene_sim-0.3.0a1-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:340d5288d964089e37f8217680c9042565049a46cf2d4aa182a2f2be61c9c0ad", size = 5092899, upload-time = "2026-06-12T15:52:01.863Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/94/8ed7a5becf2f34a6412524a73a3fd6c962994029ef282e3690f5314f7ce7/selene_sim-0.3.0a1-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:745cb0d775e3fdf1361d8a18074c79d7eb93c7647e5e5142b096aeb1f576f2f6", size = 4900730, upload-time = "2026-06-12T15:52:03.689Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/86/7e3889995deac2102fcbdb7079421f5cbbdbf79ad9cba2915d7eaef1b0d7/selene_sim-0.3.0a1-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:29f1a258be41ac4cb0a239721766009ffc48f0c9fca5b4680ea1ae73d35a6774", size = 5096977, upload-time = "2026-06-12T15:52:05.564Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/ce/0dfda225153a0e691f6002411bb1138312aeeb4105ac30ae5275a74d3adc/selene_sim-0.3.0a1-py3-none-win_amd64.whl", hash = "sha256:c02f78c948cf7d07a4e38ae15052a8360a3ecab906458da010a65b195a36e9fc", size = 10618573, upload-time = "2026-06-12T15:52:08.027Z" },
+    { url = "https://files.pythonhosted.org/packages/54/2c/98835dc3c61e00a208e06297701cd60e78183e3d36216d98660750ac109a/selene_sim-0.3.0a2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:208864a46b190d89032153cf1653b42178bf7f3e3e9e59551f082dcadf0c940e", size = 5117464, upload-time = "2026-07-16T12:19:12.485Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a0/9b68aa051942e1c0bd47c66c82daaf9b5fc1297bcfa4be55f11ca3b49d39/selene_sim-0.3.0a2-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:6b092404dd751b3583d575c04c593d44e6df2231f336588b0902ccbef47ef4a6", size = 5334925, upload-time = "2026-07-16T12:19:14.475Z" },
+    { url = "https://files.pythonhosted.org/packages/64/da/64fce3d14d278d8cc8929a67f6caa5dbc06e34020273432df4c1c2e576d3/selene_sim-0.3.0a2-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:07a4014cfd3c4928cfdae72b0961daf36ed8409ad4b45445c54b0fea655ef98d", size = 5161015, upload-time = "2026-07-16T12:19:15.973Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b6/3e0ea2ccb2c636a62634bc66781ca1cf7de2a5eaeced246cfccc60f5bcdc/selene_sim-0.3.0a2-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:cd69a1046918a1b953fa56f00088f9cbb6bb163ebd101ea14d9e60ab638ad189", size = 5361805, upload-time = "2026-07-16T12:19:17.729Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a5/49e8bfcab422c51589818c3d39b2964e17f63f4670b1cc2b88d98aa3aac3/selene_sim-0.3.0a2-py3-none-win_amd64.whl", hash = "sha256:a051e2f6445a581812aff70ee3aad06eca4994f2aca5dd7b56d38adca6677276", size = 11271768, upload-time = "2026-07-16T12:19:19.53Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Selene 0.3.0a2 includes:
- Zero-length arg support for argreader (entrypoint params)
- An env reader API (if wanted) that supports different values during multiprocessing

selene-core remains at 0.3.0a1 and plugins that are built for 0.3.0 will remain compatible.

It is likely that this will change minimally for the final 0.3.0 release.