### PR TITLE
feat(guppylang)!: Raise an error if non daggerable classical functions are used in dagger cotext

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -9,6 +9,7 @@ from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError, GuppyTypeError
 from guppylang_internals.nodes import (
+    AbortExpr,
     AnyCall,
     BarrierExpr,
     CheckedModifiedBlock,
@@ -96,15 +97,35 @@ class BBUnitaryChecker(ast.NodeVisitor):
         return True
 
     def _check_call(
-        self, node: AnyCall, ty: FunctionType, func: CallableDef | None = None
+        self, node: AnyCall, call_ty: FunctionType, func: CallableDef | None = None
     ) -> None:
         """
         `func`: it's only used for a better error message when the call is a GlobalCall.
         Is None for LocalCall and TensorCall.
         """
-        classic_args = self._check_classical_args(node.args)
-        flag_ok = self.flags in ty.unitary_flags
-        if not classic_args and not flag_ok:
+
+        # If we are under any modifier, we cannot allocate qubits
+        if contain_qubit_ty(call_ty.output) and self.flags != UnitaryFlags.NoFlags:
+            err = UnitaryCallError(node, self.flags, missing_keyword_hint=False)
+            err.add_sub_diagnostic(UnitaryCallError.QubitAllocationNote(None))
+            raise GuppyError(err)
+
+        # If the function has quantum i/o, the flags must be compatible with the
+        # function's unitary flags. Otherwise, if the function is classical, we only
+        # need to check that if we are in dagger (or unitary) context, the function
+        # is daggerable.
+        is_classic_fun = self._check_classical_args(node.args)
+        is_a_valid_call = (
+            self.flags in call_ty.unitary_flags
+            if not is_classic_fun
+            else (
+                True
+                if UnitaryFlags.Dagger not in self.flags
+                else UnitaryFlags.Dagger in call_ty.unitary_flags
+            )
+        )
+
+        if not is_a_valid_call:
             from guppylang_internals.definition.custom import CustomFunctionDef
 
             # We want the hint only for non-custom functions, since custom
@@ -112,14 +133,14 @@ class BBUnitaryChecker(ast.NodeVisitor):
             if isinstance(func, CustomFunctionDef):
                 err = UnitaryCallError(
                     node,
-                    self.flags & (~ty.unitary_flags),
+                    self.flags & (~call_ty.unitary_flags),
                     missing_keyword_hint=True,
                 )
             else:
                 if func is not None:
                     err = UnitaryCallError(
                         node,
-                        self.flags & (~ty.unitary_flags),
+                        self.flags & (~call_ty.unitary_flags),
                         missing_keyword_hint=False,
                     )
                     from guppylang_internals.definition.pytket_circuits import (
@@ -134,7 +155,7 @@ class BBUnitaryChecker(ast.NodeVisitor):
                         err.add_sub_diagnostic(UnitaryCallError.Hint(None, func.name))
                 else:
                     # If func is None, we are checking a higher-order call
-                    missing_flags = self.flags & (~ty.unitary_flags)
+                    missing_flags = self.flags & (~call_ty.unitary_flags)
                     err = UnitaryCallError(
                         node,
                         missing_flags,
@@ -145,17 +166,11 @@ class BBUnitaryChecker(ast.NodeVisitor):
                             None,
                             missing_flags.callable_name(),
                             "higher-order"
-                            if ty.unitary_flags == UnitaryFlags.NoFlags
-                            else ty.unitary_flags.callable_name(),
+                            if call_ty.unitary_flags == UnitaryFlags.NoFlags
+                            else call_ty.unitary_flags.callable_name(),
                         )
                     )
             raise GuppyTypeError(err)
-
-        # If we are under any modifier, we cannot allocate qubits
-        if contain_qubit_ty(ty.output) and self.flags != UnitaryFlags.NoFlags:
-            err = UnitaryCallError(node, self.flags, missing_keyword_hint=False)
-            err.add_sub_diagnostic(UnitaryCallError.QubitAllocationNote(None))
-            raise GuppyError(err)
 
     def visit_GlobalCall(self, node: GlobalCall) -> None:
         func = ENGINE.get_parsed(node.def_id)
@@ -175,8 +190,32 @@ class BBUnitaryChecker(ast.NodeVisitor):
         pass
 
     def visit_StateOutputExpr(self, node: StateOutputExpr) -> None:
-        # StateOutput is always allowed
-        pass
+        # State output is not allowed under dagger, since the execution order
+        # is not guaranteed
+        if UnitaryFlags.Dagger in self.flags:
+            raise GuppyTypeError(
+                UnitaryCallError(
+                    node,
+                    self.flags,
+                    missing_keyword_hint=True,
+                )
+            )
+
+    def visit_AbortExpr(self, node: AbortExpr) -> None:
+        # panics and exits are not allowed under dagger, since the execution order
+        # is not guaranteed
+        if UnitaryFlags.Dagger in self.flags:
+            raise GuppyTypeError(
+                UnitaryCallError(
+                    node,
+                    self.flags,
+                    missing_keyword_hint=True,
+                )
+            )
+        self.visit(node.signal)
+        self.visit(node.msg)
+        for value in node.values:
+            self.visit(value)
 
     def visit_CheckedModifiedBlock(self, node: CheckedModifiedBlock) -> None:
         # Nested modified blocks are checked separately by the CFG checker

--- a/tests/error/modifier_errors/exit_in_dagger.err
+++ b/tests/error/modifier_errors/exit_in_dagger.err
@@ -1,0 +1,9 @@
+Error: Dagger constraint violation (at $FILE:8:8)
+  | 
+6 | def test() -> None:
+7 |     with dagger():
+8 |         exit("a")
+  |         ^^^^^^^^^ This function cannot be called in a daggerable context
+  |                   because it is not daggerable itself
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/exit_in_dagger.py
+++ b/tests/error/modifier_errors/exit_in_dagger.py
@@ -1,0 +1,10 @@
+from guppylang import guppy
+from guppylang.std.builtins import dagger
+
+
+@guppy
+def test() -> None:
+    with dagger():
+        exit("a")
+
+test.compile()

--- a/tests/error/modifier_errors/flag_classic_fun_dagger1.err
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger1.err
@@ -1,0 +1,11 @@
+Error: Dagger constraint violation (at $FILE:13:8)
+   | 
+11 | def test() -> None:
+12 |     with dagger:
+13 |         foo()
+   |         ^^^^^ This function cannot be called in a daggerable context
+
+Help: Consider adding the flag `(daggerable=True)` to the decorator of the
+function `foo`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/flag_classic_fun_dagger1.py
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger1.py
@@ -1,0 +1,15 @@
+from guppylang import guppy
+from guppylang.std.builtins import dagger
+from guppylang.std.quantum import qubit
+
+
+@guppy
+def foo() -> None:
+    pass
+
+@guppy
+def test() -> None:
+    with dagger:
+        foo()
+
+test.compile()

--- a/tests/error/modifier_errors/flag_classic_fun_dagger2.err
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger2.err
@@ -1,0 +1,11 @@
+Error: Unitary constraint violation (at $FILE:14:8)
+   | 
+12 |     q = qubit()
+13 |     with dagger, control(q):
+14 |         foo()
+   |         ^^^^^ This function cannot be called in a unitary context
+
+Help: Consider adding the flag `(unitary=True)` to the decorator of the function
+`foo`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/flag_classic_fun_dagger2.py
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger2.py
@@ -1,0 +1,17 @@
+from guppylang import guppy
+from guppylang.std.builtins import control, dagger
+from guppylang.std.quantum import measure, qubit
+
+
+@guppy
+def foo() -> None:
+    pass
+
+@guppy
+def test() -> None:
+    q = qubit()
+    with dagger, control(q):
+        foo()
+    measure(q)
+
+test.compile()

--- a/tests/error/modifier_errors/flag_classic_fun_dagger_nested1.err
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger_nested1.err
@@ -1,0 +1,11 @@
+Error: Dagger constraint violation (at $FILE:12:4)
+   | 
+10 | @guppy(daggerable=True)
+11 | def test() -> None:
+12 |     foo()
+   |     ^^^^^ This function cannot be called in a daggerable context
+
+Help: Consider adding the flag `(daggerable=True)` to the decorator of the
+function `foo`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/flag_classic_fun_dagger_nested1.py
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger_nested1.py
@@ -1,0 +1,14 @@
+from guppylang import guppy
+from guppylang.std.builtins import control, dagger
+from guppylang.std.quantum import measure, qubit
+
+
+@guppy
+def foo() -> None:
+    pass
+
+@guppy(daggerable=True)
+def test() -> None:
+    foo()
+
+test.compile()

--- a/tests/error/modifier_errors/flag_classic_fun_dagger_nested2.err
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger_nested2.err
@@ -1,0 +1,11 @@
+Error: Unitary constraint violation (at $FILE:12:4)
+   | 
+10 | @guppy(unitary=True)
+11 | def test() -> None:
+12 |     foo()
+   |     ^^^^^ This function cannot be called in a unitary context
+
+Help: Consider adding the flag `(unitary=True)` to the decorator of the function
+`foo`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/flag_classic_fun_dagger_nested2.py
+++ b/tests/error/modifier_errors/flag_classic_fun_dagger_nested2.py
@@ -1,0 +1,14 @@
+from guppylang.decorator import guppy
+from guppylang.std.builtins import control, dagger
+from guppylang.std.quantum import measure, qubit
+
+
+@guppy
+def foo() -> None:
+    pass
+
+@guppy(unitary=True)
+def test() -> None:
+    foo()
+
+test.compile()

--- a/tests/error/modifier_errors/nested_in_panic_function.err
+++ b/tests/error/modifier_errors/nested_in_panic_function.err
@@ -1,0 +1,11 @@
+Error: Control constraint violation (at $FILE:14:19)
+   | 
+12 |     qq = qubit()
+13 |     with control(q):
+14 |         panic("a", test(qq))
+   |                    ^^^^^^^^ This function cannot be called in a controllable context
+
+Help: Consider adding the flag `(controllable=True)` to the decorator of the
+function `test`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/nested_in_panic_function.py
+++ b/tests/error/modifier_errors/nested_in_panic_function.py
@@ -1,0 +1,19 @@
+from guppylang import guppy, qubit
+from guppylang.std.builtins import panic, control
+from guppylang.std.quantum import measure
+
+@guppy
+def test(q: qubit) -> None:
+    pass
+
+@guppy
+def bar() -> None:
+    q = qubit()
+    qq = qubit()
+    with control(q):
+        panic("a", test(qq))
+
+    measure(q)
+    measure(qq)
+
+bar.compile_function()

--- a/tests/error/modifier_errors/output_in_dagger.err
+++ b/tests/error/modifier_errors/output_in_dagger.err
@@ -1,0 +1,9 @@
+Error: Dagger constraint violation (at $FILE:8:4)
+  | 
+6 | @guppy(daggerable=True)
+7 | def test() -> None:
+8 |     output("a", True)
+  |     ^^^^^^^^^^^^^^^^^ This function cannot be called in a daggerable context
+  |                       because it is not daggerable itself
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/output_in_dagger.py
+++ b/tests/error/modifier_errors/output_in_dagger.py
@@ -1,0 +1,10 @@
+from guppylang import guppy
+from guppylang.std.builtins import output
+
+
+
+@guppy(daggerable=True)
+def test() -> None:
+    output("a", True)
+
+test.compile()

--- a/tests/error/modifier_errors/output_in_unitary.err
+++ b/tests/error/modifier_errors/output_in_unitary.err
@@ -1,0 +1,9 @@
+Error: Unitary constraint violation (at $FILE:8:4)
+  | 
+6 | @guppy(unitary=True)
+7 | def test() -> None:
+8 |     output("a", True)
+  |     ^^^^^^^^^^^^^^^^^ This function cannot be called in a unitary context because
+  |                       it is not unitary itself
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/output_in_unitary.py
+++ b/tests/error/modifier_errors/output_in_unitary.py
@@ -1,0 +1,10 @@
+from guppylang import guppy
+from guppylang.std.builtins import output
+
+
+
+@guppy(unitary=True)
+def test() -> None:
+    output("a", True)
+
+test.compile()

--- a/tests/error/modifier_errors/panic_in_dagger.err
+++ b/tests/error/modifier_errors/panic_in_dagger.err
@@ -1,0 +1,9 @@
+Error: Dagger constraint violation (at $FILE:8:8)
+  | 
+6 | def test() -> None:
+7 |     with dagger():
+8 |         panic("a")
+  |         ^^^^^^^^^^ This function cannot be called in a daggerable context
+  |                    because it is not daggerable itself
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/panic_in_dagger.py
+++ b/tests/error/modifier_errors/panic_in_dagger.py
@@ -1,0 +1,10 @@
+from guppylang import guppy
+from guppylang.std.builtins import dagger, panic
+
+
+@guppy
+def test() -> None:
+    with dagger():
+        panic("a")
+
+test.compile()

--- a/tests/error/modifier_errors/state_output_in_dagger.err
+++ b/tests/error/modifier_errors/state_output_in_dagger.err
@@ -1,0 +1,9 @@
+Error: Dagger constraint violation (at $FILE:12:8)
+   | 
+10 |     q = qubit()
+11 |     with dagger():
+12 |         state_output("a", q)
+   |         ^^^^^^^^^^^^^^^^^^^^ This function cannot be called in a daggerable context
+   |                              because it is not daggerable itself
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/state_output_in_dagger.py
+++ b/tests/error/modifier_errors/state_output_in_dagger.py
@@ -1,0 +1,15 @@
+from guppylang import guppy, qubit
+from guppylang.std.builtins import dagger
+from guppylang.std.debug import state_output
+from guppylang.std.quantum import measure
+
+
+
+@guppy
+def test() -> None:
+    q = qubit()
+    with dagger():
+        state_output("a", q)
+    measure(q)
+
+test.compile()

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -13,6 +13,7 @@ from guppylang.std.builtins import (
     control,
     dagger,
     owned,
+    panic,
     power,
 )
 from guppylang.std.num import nat
@@ -189,7 +190,7 @@ def test_power_simple(validate):
 
 
 def test_call_in_modifier(validate):
-    @guppy
+    @guppy(daggerable=True)
     def foo() -> None:
         pass
 
@@ -216,6 +217,15 @@ def test_nested_modifiers(validate):
         with control(q):
             with dagger:
                 pass
+
+    validate(bar.compile_function())
+
+
+def test_panic_in_control(validate):
+    @guppy
+    def bar(q: qubit) -> None:
+        with control(q):
+            panic("a")
 
     validate(bar.compile_function())
 


### PR DESCRIPTION
Backport of #2061

BREAKING CHANGE: previous guppy program that used classical function in dagger context may be non valid anymore