### PR TITLE
feat: Revert "feat: Add quantum pass to default opt level (#2063)" but keep tket dependency bump

### DIFF
--- a/guppylang/src/guppylang/optimizer.py
+++ b/guppylang/src/guppylang/optimizer.py
@@ -56,7 +56,7 @@ class OptimizationLevel(Enum):
             case OptimizationLevel.Default | OptimizationLevel.Classical:
                 from tket import passes
 
-                return [passes.NormalizeGuppy()]
+                return [passes.Normalize()]
             case OptimizationLevel.Minimal:
                 return []
 

--- a/guppylang/src/guppylang/optimizer.py
+++ b/guppylang/src/guppylang/optimizer.py
@@ -53,18 +53,10 @@ class OptimizationLevel(Enum):
     def passes(self) -> list[ComposablePass]:
         """Return the HUGR passes that implement this optimization level."""
         match self:
-            case OptimizationLevel.Default:
-                # The pytket dependency could be bypassed by using the json
-                # encoding of the passes rather than the pytket objects
-                # themselves.
-                from pytket.passes import RemoveRedundancies
+            case OptimizationLevel.Default | OptimizationLevel.Classical:
                 from tket import passes
 
-                return [passes.Normalize(), passes.PytketHugrPass(RemoveRedundancies())]
-            case OptimizationLevel.Classical:
-                from tket import passes
-
-                return [passes.Normalize()]
+                return [passes.NormalizeGuppy()]
             case OptimizationLevel.Minimal:
                 return []
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ guppylang-internals = { workspace = true }
 miette-py = { workspace = true }
 # Uncomment these to test the latest dependency version during development
 # hugr = { git = "https://github.com/quantinuum/hugr", subdirectory = "hugr-py", rev = "a4da8ef" }
-#tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "a387f0d" }
-#selene-hugr-qis-compiler = { git = "https://github.com/quantinuum/tket2", subdirectory = "qis-compiler", rev = "a387f0d" }
+# tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "cdb47dd" }
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/integration/test_exported_hugrs.py
+++ b/tests/integration/test_exported_hugrs.py
@@ -1,9 +1,9 @@
 import pytest
-from tket.passes import NormalizeGuppy
+from tket.passes import Normalize
 from hugr.package import Package
 from pathlib import Path
 
-normalize = NormalizeGuppy()
+normalize = Normalize()
 
 
 @pytest.mark.test_exported_hugrs

--- a/tests/integration/tket_opt/test_opt.py
+++ b/tests/integration/tket_opt/test_opt.py
@@ -6,7 +6,7 @@ from guppylang.std.builtins import array
 
 from pytket.passes import RemoveRedundancies, CliffordSimp, SquashRzPhasedX
 
-from tket.passes import NormalizeGuppy, PytketHugrPass, PassResult, PlatformTarget
+from tket.passes import Normalize, PytketHugrPass, PassResult, PlatformTarget
 
 from hugr.hugr.base import Hugr
 
@@ -20,11 +20,11 @@ def _count_ops(hugr: Hugr, string_name: str) -> int:
     return count
 
 
-normalize = NormalizeGuppy()
+normalize = Normalize()
 
 
-# NormalizeGuppy documentation
-# -> https://quantinuum.github.io/tket2/generated/tket.passes.NormalizeGuppy.html#tket.passes.NormalizeGuppy
+# Normalize documentation
+# -> https://quantinuum.github.io/tket2/generated/tket.passes.Normalize.html#tket.passes.Normalize
 def test_guppy_normalization() -> None:
     @guppy
     def pauli_zz_rotation(q0: qubit, q1: qubit) -> None:
@@ -42,9 +42,9 @@ def test_guppy_normalization() -> None:
 
     normalized_hugr = normalize(unnormalized_hugr)
 
-    # Test that the dataflow block is inlined by NormalizeGuppy
+    # Test that the dataflow block is inlined by Normalize
     assert _count_ops(normalized_hugr, "DataflowBlock") == 0
-    # Test that MakeTuple nodes are removed by NormalizeGuppy
+    # Test that MakeTuple nodes are removed by Normalize
     assert _count_ops(normalized_hugr, "MakeTuple") == 0
 
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -67,6 +67,7 @@ def test_opt_levels() -> None:
     assert isinstance(optimizer_classical, GuppyCompilableProgram)
     assert optimizer_classical.definition is main_classical
     assert optimizer_classical.passes == OptimizationLevel.Classical.passes()
+    assert optimizer_default.passes == optimizer_classical.passes
 
     assert isinstance(optimizer_default, OptimizerInstance)
     assert isinstance(optimizer_default, GuppyCompilableProgram)
@@ -80,10 +81,9 @@ def test_opt_levels() -> None:
 
     # Classical/default optimization may remove structure from the minimal HUGR.
     # The important contract here is that both configured optimization levels
-    # compile successfully.
+    # compile successfully and produce the same default optimization behavior.
     assert len(package_minimal.modules[0]) > 0
-    assert len(package_classical.modules[0]) > 0
-    assert len(package_default.modules[0]) > 0
+    assert len(package_classical.modules[0]) <= len(package_default.modules[0])
 
 
 def test_opt_level_passes() -> None:


### PR DESCRIPTION
This reverts part of commit 2970cb5ce9445896c12e3cbc84d76368dd7f4d7d, but keeps the tket version change. See https://github.com/Quantinuum/tket2/issues/1856 describing the issue motivating this revert. 