### PR TITLE
feat(stdlib): standard-library BTreeMap collection

### DIFF
--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -41,6 +41,9 @@ dependencies = [
 homepage = "https://github.com/quantinuum/guppylang"
 repository = "https://github.com/quantinuum/guppylang"
 
+[tool.ruff]
+target-version = "py312"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/guppylang/src/guppylang/std/collections/__init__.py
+++ b/guppylang/src/guppylang/std/collections/__init__.py
@@ -1,13 +1,16 @@
-"""Guppy standard library for queues."""
+"""Guppy standard library collections."""
 
+from guppylang.std.collections.btree_map import BTreeMap, empty_btree_map
 from guppylang.std.collections.priority_queue import PriorityQueue, empty_priority_queue
 from guppylang.std.collections.queue import Queue, empty_queue
 from guppylang.std.collections.stack import Stack, empty_stack
 
 __all__ = [
+    "BTreeMap",
     "PriorityQueue",
     "Queue",
     "Stack",
+    "empty_btree_map",
     "empty_priority_queue",
     "empty_queue",
     "empty_stack",

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Self, no_type_check
+
+from guppylang.decorator import guppy
+from guppylang.std.array import array
+from guppylang.std.option import Option, nothing
+from guppylang.std.num import nat
+from guppylang.std.platform import panic
+
+if TYPE_CHECKING:
+    from guppylang.std.lang import owned
+
+
+@guppy.protocol
+class _Ord:
+    """Internal structural protocol for keys in :class:`BTreeMap`.
+
+    TODO: Replace this with a public standard-library ordering API once one is designed.
+    """
+
+    @guppy.require
+    def __lt__(self, other: Self) -> bool: ...
+
+    @guppy.require
+    def __eq__(self, other: Self) -> bool: ...
+
+
+@guppy.struct
+class _Node[K, V]:
+    """A 2-3-4 tree node.
+
+    TODO: Make this fan-out configurable when Guppy supports type-level arithmetic
+    for derived array sizes.
+    """
+
+    _entries: array[Option[tuple[K, V]], 3]
+    _children: array[Option[int], 4]
+    _size: int
+    _leaf: bool
+
+    @guppy
+    @no_type_check
+    def discard_empty[K, V](self: _Node[K, V] @ owned) -> None:
+        if self._size != 0:
+            panic("BTreeMap._Node.discard_empty: node is not empty")
+        for entry in self._entries:
+            entry.unwrap_nothing()
+        for child in self._children:
+            child.unwrap_nothing()
+
+
+@guppy.struct
+class BTreeMap[K, V, MAX_SIZE: nat]:
+    """A fixed-capacity ordered map.
+
+    The public API supports ``int`` and non-NaN ``float`` keys. Keys are stored in a
+    2-3-4 tree, so lookup, insertion, and removal are logarithmic in the number of
+    entries. Values may be linear; use :meth:`discard_empty` after removing or
+    iterating over all entries.
+    """
+
+    _nodes: array[_Node[K, V], MAX_SIZE]
+    _free_nodes: array[int, MAX_SIZE]
+    _free_count: int
+    _root: int
+    _size: int
+
+    @guppy
+    @no_type_check
+    def __len__(self) -> int:
+        """Returns the number of entries in the map."""
+        return self._size
+
+    @guppy
+    @no_type_check
+    def discard_empty[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE] @ owned,
+    ) -> None:
+        """Discards an empty map containing potentially linear values."""
+        if self._size != 0:
+            panic("BTreeMap.discard_empty: map is not empty")
+        for node in self._nodes:
+            node.discard_empty()
+
+
+@guppy
+@no_type_check
+def _empty_node[K, V]() -> _Node[K, V]:
+    return _Node(
+        array(nothing[tuple[K, V]]() for _ in range(3)),
+        array(nothing[int]() for _ in range(4)),
+        0,
+        True,
+    )
+
+
+@guppy
+@no_type_check
+def empty_btree_map[K: _Ord, V, MAX_SIZE: nat]() -> BTreeMap[K, V, MAX_SIZE]:
+    """Constructs an empty fixed-capacity B-tree map."""
+    return BTreeMap(
+        array(_empty_node[K, V]() for _ in range(MAX_SIZE)),
+        array(i for i in range(MAX_SIZE)),
+        int(MAX_SIZE),
+        -1,
+        0,
+    )

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -39,15 +39,20 @@ class _Ord:
 class _Node[K, V]:
     """A 2-3-4 tree node.
 
-    Live entries occupy the prefix ``[0, _size)`` in sorted order. An internal
-    node has exactly ``_size + 1`` live child indices; every remaining slot is
-    ``nothing``. This representation lets entries and child links be moved without
-    cloning a potentially linear value.
+    Live keys and entries occupy the prefix ``[0, _size)`` in sorted order. Keys
+    are deliberately stored separately from their values: comparison can then
+    borrow a copyable key without inspecting an entry that may contain a linear
+    value. An internal node has exactly ``_size + 1`` live child indices; every
+    remaining slot is ``nothing``. This representation lets entries and child
+    links be moved without cloning a potentially linear value.
 
     TODO: Make this fan-out configurable when Guppy supports type-level arithmetic
     for derived array sizes.
     """
 
+    # `_keys[i]` mirrors the key in `_entries[i]`. Keeping this copyable index
+    # separate is what makes lookup and rebalancing valid for linear `V`.
+    _keys: array[Option[K], 3]
     _entries: array[Option[tuple[K, V]], 3]
     _children: array[Option[int], 4]
     _size: int
@@ -58,6 +63,8 @@ class _Node[K, V]:
     def discard_empty[K, V](self: _Node[K, V] @ owned) -> None:
         if self._size != 0:
             panic("BTreeMap._Node.discard_empty: node is not empty")
+        for key in self._keys:
+            key.unwrap_nothing()
         for entry in self._entries:
             entry.unwrap_nothing()
         for child in self._children:
@@ -200,6 +207,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
 @no_type_check
 def _empty_node[K, V]() -> _Node[K, V]:
     return _Node(
+        array(nothing[K]() for _ in range(3)),
         array(nothing[tuple[K, V]]() for _ in range(3)),
         array(nothing[int]() for _ in range(4)),
         0,
@@ -276,10 +284,13 @@ def _remove_leaf_entry[K: _Ord, V, MAX_SIZE: nat](
 ) -> V:
     node = btree_map._nodes.take(node_i)
     _key, value = node._entries[entry_i].take().unwrap()
+    node._keys[entry_i].take().unwrap()
     next_i = entry_i
     while next_i < node._size - 1:
         entry = node._entries[next_i + 1].take().unwrap()
+        key = node._keys[next_i + 1].take().unwrap()
         node._entries[next_i].swap(some(entry)).unwrap_nothing()
+        node._keys[next_i].swap(some(key)).unwrap_nothing()
         next_i += 1
     node._size -= 1
     is_empty_root = node_i == btree_map._root and node._size == 0
@@ -378,9 +389,11 @@ def _remove_internal_from_left[K: _Ord, V, MAX_SIZE: nat](
     predecessor_value = _remove_leaf_descending(btree_map, left_i, predecessor_key)
     parent = btree_map._nodes.take(parent_i)
     _old_key, old_value = parent._entries[entry_i].take().unwrap()
+    parent._keys[entry_i].take().unwrap()
     parent._entries[entry_i].swap(
         some((predecessor_key, predecessor_value))
     ).unwrap_nothing()
+    parent._keys[entry_i].swap(some(predecessor_key)).unwrap_nothing()
     btree_map._nodes.put(parent, parent_i)
     return some(old_value)
 
@@ -394,9 +407,11 @@ def _remove_internal_entry[K: _Ord, V, MAX_SIZE: nat](
     removed = _remove_internal_from_left(btree_map, node_i, entry_i)
     if removed.is_some():
         return removed.unwrap()
+    removed.unwrap_nothing()
     removed = _remove_internal_from_right(btree_map, node_i, entry_i)
     if removed.is_some():
         return removed.unwrap()
+    removed.unwrap_nothing()
 
     parent = btree_map._nodes.take(node_i)
     left_i = parent._children[entry_i].unwrap()
@@ -452,9 +467,11 @@ def _remove_internal_from_right[K: _Ord, V, MAX_SIZE: nat](
     successor_value = _remove_leaf_descending(btree_map, right_i, successor_key)
     parent = btree_map._nodes.take(parent_i)
     _old_key, old_value = parent._entries[entry_i].take().unwrap()
+    parent._keys[entry_i].take().unwrap()
     parent._entries[entry_i].swap(
         some((successor_key, successor_value))
     ).unwrap_nothing()
+    parent._keys[entry_i].swap(some(successor_key)).unwrap_nothing()
     btree_map._nodes.put(parent, parent_i)
     return some(old_value)
 
@@ -518,12 +535,14 @@ def _merge_children[K: _Ord, V, MAX_SIZE: nat](
 
     # Concatenate `left`, the separating parent entry, then `right`. Since both
     # children have one entry, the result fits exactly in a three-entry node.
+    left._keys[left._size].swap(parent._keys[entry_i].take()).unwrap_nothing()
     left._entries[left._size].swap(
         some(parent._entries[entry_i].take().unwrap())
     ).unwrap_nothing()
     left._size += 1
     right_entry_i = 0
     while right_entry_i < right._size:
+        left._keys[left._size].swap(right._keys[right_entry_i].take()).unwrap_nothing()
         left._entries[left._size].swap(
             some(right._entries[right_entry_i].take().unwrap())
         ).unwrap_nothing()
@@ -541,6 +560,9 @@ def _merge_children[K: _Ord, V, MAX_SIZE: nat](
     # parent prefixes to preserve the node representation invariant.
     parent_entry_i = entry_i
     while parent_entry_i < parent._size - 1:
+        parent._keys[parent_entry_i].swap(
+            parent._keys[parent_entry_i + 1].take()
+        ).unwrap_nothing()
         parent._entries[parent_entry_i].swap(
             some(parent._entries[parent_entry_i + 1].take().unwrap())
         ).unwrap_nothing()
@@ -578,6 +600,7 @@ def _borrow_from_left[K: _Ord, V, MAX_SIZE: nat](
     # separator down, and promote the left sibling's largest entry to the parent.
     entry_i = target._size
     while entry_i > 0:
+        target._keys[entry_i].swap(target._keys[entry_i - 1].take()).unwrap_nothing()
         target._entries[entry_i].swap(
             some(target._entries[entry_i - 1].take().unwrap())
         ).unwrap_nothing()
@@ -592,9 +615,11 @@ def _borrow_from_left[K: _Ord, V, MAX_SIZE: nat](
         target._children[0].swap(
             some(left._children[left._size].take().unwrap())
         ).unwrap_nothing()
+    target._keys[0].swap(parent._keys[child_i - 1].take()).unwrap_nothing()
     target._entries[0].swap(
         some(parent._entries[child_i - 1].take().unwrap())
     ).unwrap_nothing()
+    parent._keys[child_i - 1].swap(left._keys[left._size - 1].take()).unwrap_nothing()
     parent._entries[child_i - 1].swap(
         some(left._entries[left._size - 1].take().unwrap())
     ).unwrap_nothing()
@@ -620,6 +645,7 @@ def _borrow_from_right[K: _Ord, V, MAX_SIZE: nat](
 
     # Mirror image of `_borrow_from_left`: append the parent's separator and
     # promote the right sibling's smallest entry after compacting that sibling.
+    target._keys[target._size].swap(parent._keys[child_i].take()).unwrap_nothing()
     target._entries[target._size].swap(
         some(parent._entries[child_i].take().unwrap())
     ).unwrap_nothing()
@@ -633,11 +659,15 @@ def _borrow_from_right[K: _Ord, V, MAX_SIZE: nat](
                 some(right._children[right_child_i + 1].take().unwrap())
             ).unwrap_nothing()
             right_child_i += 1
+    parent._keys[child_i].swap(right._keys[0].take()).unwrap_nothing()
     parent._entries[child_i].swap(
         some(right._entries[0].take().unwrap())
     ).unwrap_nothing()
     right_entry_i = 0
     while right_entry_i < right._size - 1:
+        right._keys[right_entry_i].swap(
+            right._keys[right_entry_i + 1].take()
+        ).unwrap_nothing()
         right._entries[right_entry_i].swap(
             some(right._entries[right_entry_i + 1].take().unwrap())
         ).unwrap_nothing()
@@ -690,8 +720,7 @@ def _node_entry_index[K: _Ord, V](node: _Node[K, V], key: K) -> int:
 @guppy
 @no_type_check
 def _node_key[K: _Ord, V](node: _Node[K, V], entry_i: int) -> K:
-    key, _value = node._entries[entry_i].unwrap()
-    return key
+    return node._keys[entry_i].unwrap()
 
 
 @guppy
@@ -726,6 +755,7 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
     if btree_map._root < 0:
         root_i = _allocate_node(btree_map)
         root = btree_map._nodes.take(root_i)
+        root._keys[0].swap(some(key)).unwrap_nothing()
         root._entries[0].swap(some((key, value))).unwrap_nothing()
         root._size = 1
         btree_map._nodes.put(root, root_i)
@@ -782,9 +812,11 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
     while entry_i > 0:
         if _node_key(node, entry_i - 1).__lt__(key):
             break
+        node._keys[entry_i].swap(node._keys[entry_i - 1].take()).unwrap_nothing()
         entry = node._entries[entry_i - 1].take().unwrap()
         node._entries[entry_i].swap(some(entry)).unwrap_nothing()
         entry_i -= 1
+    node._keys[entry_i].swap(some(key)).unwrap_nothing()
     node._entries[entry_i].swap(some((key, value))).unwrap_nothing()
     node._size += 1
     btree_map._nodes.put(node, node_i)
@@ -815,6 +847,7 @@ def _split_child[K: _Ord, V, MAX_SIZE: nat](
     sibling = btree_map._nodes.take(sibling_i)
 
     sibling._leaf = child._leaf
+    sibling._keys[0].swap(child._keys[2].take()).unwrap_nothing()
     sibling._entries[0].swap(some(child._entries[2].take().unwrap())).unwrap_nothing()
     sibling._size = 1
     child._size = 1
@@ -828,9 +861,13 @@ def _split_child[K: _Ord, V, MAX_SIZE: nat](
 
     parent_entry_i = parent._size
     while parent_entry_i > child_i:
+        parent._keys[parent_entry_i].swap(
+            parent._keys[parent_entry_i - 1].take()
+        ).unwrap_nothing()
         entry = parent._entries[parent_entry_i - 1].take().unwrap()
         parent._entries[parent_entry_i].swap(some(entry)).unwrap_nothing()
         parent_entry_i -= 1
+    parent._keys[child_i].swap(child._keys[1].take()).unwrap_nothing()
     parent._entries[child_i].swap(
         some(child._entries[1].take().unwrap())
     ).unwrap_nothing()

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -97,7 +97,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         """Returns whether the map contains ``key``."""
         _validate_key(key)
         self._query.swap(some(key)).unwrap_nothing()
-        return with_owned(self, _contains_key)
+        return _contains_key(self)
 
     @guppy
     @no_type_check
@@ -107,7 +107,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         """Returns a copy of the value stored for ``key``, if present."""
         _validate_key(key)
         self._query.swap(some(key)).unwrap_nothing()
-        return with_owned(self, _get)
+        return _get(self)
 
     @guppy
     @no_type_check
@@ -117,7 +117,17 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         """Stores ``value`` for ``key`` and returns a displaced value, if any."""
         _validate_key(key)
         self._pending.swap(some((key, value))).unwrap_nothing()
-        return with_owned(self, _insert_pending)
+        return _insert_pending(self)
+
+    @guppy
+    @no_type_check
+    def remove[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE], key: K
+    ) -> Option[V]:
+        """Removes and returns the value stored for ``key``, if present."""
+        _validate_key(key)
+        self._query.swap(some(key)).unwrap_nothing()
+        return with_owned(self, _remove)
 
 
 @guppy
@@ -140,9 +150,9 @@ def _validate_key[K: _Ord](key: K) -> None:
 
 @guppy
 @no_type_check
-def _find_owned[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned, key: K
-) -> tuple[Option[tuple[int, int]], BTreeMap[K, V, MAX_SIZE]]:
+def _find[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], key: K
+) -> Option[tuple[int, int]]:
     node_i = btree_map._root
     while node_i >= 0:
         node = btree_map._nodes.take(node_i)
@@ -154,37 +164,101 @@ def _find_owned[K: _Ord, V, MAX_SIZE: nat](
             next_i = _node_child(node, entry_i)
         btree_map._nodes.put(node, node_i)
         if found:
-            return some((node_i, entry_i)), btree_map
+            return some((node_i, entry_i))
         if is_leaf:
-            return nothing(), btree_map
+            return nothing()
         node_i = next_i
-    return nothing(), btree_map
+    return nothing()
 
 
 @guppy
 @no_type_check
 def _contains_key[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-) -> tuple[bool, BTreeMap[K, V, MAX_SIZE]]:
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> bool:
     key = btree_map._query.take().unwrap()
-    location, btree_map = _find_owned(btree_map, key)
-    return location.is_some(), btree_map
+    return _find(btree_map, key).is_some()
 
 
 @guppy
 @no_type_check
 def _get[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> Option[V]:
     key = btree_map._query.take().unwrap()
-    location, btree_map = _find_owned(btree_map, key)
+    location = _find(btree_map, key)
     if location.is_nothing():
-        return nothing(), btree_map
+        return nothing()
     node_i, entry_i = location.unwrap()
     node = btree_map._nodes.take(node_i)
     value = _node_value(node, entry_i)
     btree_map._nodes.put(node, node_i)
-    return some(value), btree_map
+    return some(value)
+
+
+@guppy
+@no_type_check
+def _remove[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
+    key = btree_map._query.take().unwrap()
+    rebuilt = empty_btree_map[K, V, MAX_SIZE]()
+    root_i = btree_map._root
+    removed, btree_map, rebuilt = _drain_except(btree_map, rebuilt, root_i, key)
+    btree_map._root = -1
+    btree_map._size = 0
+    btree_map.discard_empty()
+    return removed, rebuilt
+
+
+@guppy
+@no_type_check
+def _drain_except[K: _Ord, V, MAX_SIZE: nat](
+    old_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+    new_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+    node_i: int,
+    key: K,
+) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE], BTreeMap[K, V, MAX_SIZE]]:
+    if node_i < 0:
+        return nothing(), old_map, new_map
+    node = old_map._nodes.take(node_i)
+    removed = nothing[V]()
+    entry_i = 0
+    while entry_i < node._size:
+        if not node._leaf:
+            child_i = node._children[entry_i].take().unwrap()
+            child_removed, old_map, new_map = _drain_except(
+                old_map, new_map, child_i, key
+            )
+            if child_removed.is_some():
+                if removed.is_some():
+                    panic("BTreeMap: duplicate key")
+                removed = child_removed
+            else:
+                child_removed.unwrap_nothing()
+        entry_key, entry_value = node._entries[entry_i].take().unwrap()
+        if entry_key.__eq__(key):
+            if removed.is_some():
+                panic("BTreeMap: duplicate key")
+            removed = some(entry_value)
+        else:
+            new_map._pending.swap(some((entry_key, entry_value))).unwrap_nothing()
+            displaced = _insert_pending(new_map)
+            displaced.unwrap_nothing()
+        entry_i += 1
+    if not node._leaf:
+        child_i = node._children[node._size].take().unwrap()
+        child_removed, old_map, new_map = _drain_except(old_map, new_map, child_i, key)
+        if child_removed.is_some():
+            if removed.is_some():
+                panic("BTreeMap: duplicate key")
+            removed = child_removed
+        else:
+            child_removed.unwrap_nothing()
+    node._size = 0
+    node._leaf = True
+    old_map._nodes.put(node, node_i)
+    return removed, old_map, new_map
 
 
 @guppy
@@ -222,41 +296,41 @@ def _node_child[K, V](node: _Node[K, V], child_i: int) -> int:
 @guppy
 @no_type_check
 def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> Option[V]:
     key, value = btree_map._pending.take().unwrap()
-    location, btree_map = _find_owned(btree_map, key)
+    location = _find(btree_map, key)
     if location.is_some():
         node_i, entry_i = location.unwrap()
         node = btree_map._nodes.take(node_i)
         stored_key, old_value = node._entries[entry_i].take().unwrap()
         node._entries[entry_i].swap(some((stored_key, value))).unwrap_nothing()
         btree_map._nodes.put(node, node_i)
-        return some(old_value), btree_map
+        return some(old_value)
     if btree_map._size >= MAX_SIZE:
         panic("BTreeMap.insert: max size reached")
     if btree_map._root < 0:
-        root_i, btree_map = _allocate_node(btree_map)
+        root_i = _allocate_node(btree_map)
         root = btree_map._nodes.take(root_i)
         root._entries[0].swap(some((key, value))).unwrap_nothing()
         root._size = 1
         btree_map._nodes.put(root, root_i)
         btree_map._root = root_i
         btree_map._size = 1
-        return nothing(), btree_map
+        return nothing()
 
     root_i = btree_map._root
     root = btree_map._nodes.take(root_i)
     root_is_full = root._size == 3
     btree_map._nodes.put(root, root_i)
     if root_is_full:
-        new_root_i, btree_map = _allocate_node(btree_map)
+        new_root_i = _allocate_node(btree_map)
         new_root = btree_map._nodes.take(new_root_i)
         new_root._leaf = False
         new_root._children[0].swap(some(root_i)).unwrap_nothing()
         btree_map._nodes.put(new_root, new_root_i)
         btree_map._root = new_root_i
-        btree_map = _split_child(btree_map, new_root_i, 0)
+        _split_child(btree_map, new_root_i, 0)
 
     node_i = btree_map._root
     is_leaf = False
@@ -275,7 +349,7 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
         child_is_full = child._size == 3
         btree_map._nodes.put(child, next_i)
         if child_is_full:
-            btree_map = _split_child(btree_map, node_i, child_i)
+            _split_child(btree_map, node_i, child_i)
             node = btree_map._nodes.take(node_i)
             split_key = _node_key(node, child_i)
             if key.__lt__(split_key):
@@ -297,29 +371,29 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
     node._size += 1
     btree_map._nodes.put(node, node_i)
     btree_map._size += 1
-    return nothing(), btree_map
+    return nothing()
 
 
 @guppy
 @no_type_check
 def _allocate_node[K, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-) -> tuple[int, BTreeMap[K, V, MAX_SIZE]]:
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> int:
     if btree_map._free_count <= 0:
         panic("BTreeMap: node pool exhausted")
     btree_map._free_count -= 1
-    return btree_map._free_nodes[btree_map._free_count], btree_map
+    return btree_map._free_nodes[btree_map._free_count]
 
 
 @guppy
 @no_type_check
 def _split_child[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned, parent_i: int, child_i: int
-) -> BTreeMap[K, V, MAX_SIZE]:
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, child_i: int
+) -> None:
     parent = btree_map._nodes.take(parent_i)
     old_child_i = parent._children[child_i].unwrap()
     child = btree_map._nodes.take(old_child_i)
-    sibling_i, btree_map = _allocate_node(btree_map)
+    sibling_i = _allocate_node(btree_map)
     sibling = btree_map._nodes.take(sibling_i)
 
     sibling._leaf = child._leaf
@@ -353,7 +427,6 @@ def _split_child[K: _Ord, V, MAX_SIZE: nat](
     btree_map._nodes.put(parent, parent_i)
     btree_map._nodes.put(child, old_child_i)
     btree_map._nodes.put(sibling, sibling_i)
-    return btree_map
 
 
 @guppy

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -32,6 +32,11 @@ class _Ord:
 class _Node[K, V]:
     """A 2-3-4 tree node.
 
+    Live entries occupy the prefix ``[0, _size)`` in sorted order. An internal
+    node has exactly ``_size + 1`` live child indices; every remaining slot is
+    ``nothing``. This representation lets entries and child links be moved without
+    cloning a potentially linear value.
+
     TODO: Make this fan-out configurable when Guppy supports type-level arithmetic
     for derived array sizes.
     """
@@ -63,7 +68,11 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     all entries.
     """
 
+    # A fixed pool keeps the whole data structure statically allocated. Nodes are
+    # temporarily taken out of this array for mutation and always put back before
+    # another operation observes the pool.
     _nodes: array[_Node[K, V], MAX_SIZE]
+    # `_free_nodes[:_free_count]` is a stack of currently unused node indices.
     _free_nodes: array[int, MAX_SIZE]
     _free_count: int
     _root: int
@@ -150,7 +159,10 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         is_leaf = node._leaf
         self._nodes.put(node, node_i)
         if is_leaf:
-            return some(_remove_leaf_entry(self, node_i, entry_i))
+            root_i = self._root
+            value = _remove_leaf_descending(self, root_i, key)
+            _collapse_root(self)
+            return some(value)
         self._query.swap(some(key)).unwrap_nothing()
         return with_owned(self, _rebuild_remove)
 
@@ -180,6 +192,9 @@ def _find[K: _Ord, V, MAX_SIZE: nat](
 ) -> Option[tuple[int, int]]:
     node_i = btree_map._root
     while node_i >= 0:
+        # `take` gives exclusive ownership of one node, avoiding aliases into the
+        # pool while its entry/child arrays are inspected. The node is unchanged,
+        # so it is immediately returned before following a child link.
         node = btree_map._nodes.take(node_i)
         entry_i = _node_entry_index(node, key)
         found = entry_i < node._size and key.__eq__(_node_key(node, entry_i))
@@ -257,6 +272,245 @@ def _remove_leaf_entry[K: _Ord, V, MAX_SIZE: nat](
         btree_map._free_nodes[btree_map._free_count] = node_i
         btree_map._free_count += 1
     return value
+
+
+@guppy
+@no_type_check
+def _release_node[K, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int
+) -> None:
+    """Returns an empty node slot to the static pool."""
+    btree_map._free_nodes[btree_map._free_count] = node_i
+    btree_map._free_count += 1
+
+
+@guppy
+@no_type_check
+def _prepare_child[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, child_i: int
+) -> int:
+    """Ensures a child has at least two entries before descent."""
+    parent = btree_map._nodes.take(parent_i)
+    child_node_i = parent._children[child_i].unwrap()
+    child = btree_map._nodes.take(child_node_i)
+    child_size = child._size
+    btree_map._nodes.put(child, child_node_i)
+    parent_size = parent._size
+    btree_map._nodes.put(parent, parent_i)
+    if child_size > 1:
+        return child_node_i
+    if child_i > 0:
+        parent = btree_map._nodes.take(parent_i)
+        left_i = parent._children[child_i - 1].unwrap()
+        left = btree_map._nodes.take(left_i)
+        left_size = left._size
+        btree_map._nodes.put(left, left_i)
+        btree_map._nodes.put(parent, parent_i)
+        if left_size > 1:
+            _borrow_from_left(btree_map, parent_i, child_i)
+            return child_node_i
+    if child_i < parent_size:
+        parent = btree_map._nodes.take(parent_i)
+        right_i = parent._children[child_i + 1].unwrap()
+        right = btree_map._nodes.take(right_i)
+        right_size = right._size
+        btree_map._nodes.put(right, right_i)
+        btree_map._nodes.put(parent, parent_i)
+        if right_size > 1:
+            _borrow_from_right(btree_map, parent_i, child_i)
+            return child_node_i
+    if child_i > 0:
+        return _merge_children(btree_map, parent_i, child_i - 1)
+    return _merge_children(btree_map, parent_i, child_i)
+
+
+@guppy
+@no_type_check
+def _remove_leaf_descending[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int, key: K
+) -> V:
+    node = btree_map._nodes.take(node_i)
+    entry_i = _node_entry_index(node, key)
+    is_leaf = node._leaf
+    btree_map._nodes.put(node, node_i)
+    if is_leaf:
+        return _remove_leaf_entry(btree_map, node_i, entry_i)
+    # Delete top-down: repair a one-entry child *before* descending, so deleting
+    # from its subtree cannot leave it below the 2-3-4-tree minimum occupancy.
+    child_i = _prepare_child(btree_map, node_i, entry_i)
+    return _remove_leaf_descending(btree_map, child_i, key)
+
+
+@guppy
+@no_type_check
+def _collapse_root[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> None:
+    if btree_map._root < 0:
+        return
+    root_i = btree_map._root
+    root = btree_map._nodes.take(root_i)
+    if root._size != 0 or root._leaf:
+        btree_map._nodes.put(root, root_i)
+        return
+    # The root alone may have zero entries. Its only child becomes the new root,
+    # reducing tree height and making the old root slot reusable.
+    new_root_i = root._children[0].take().unwrap()
+    root._leaf = True
+    btree_map._nodes.put(root, root_i)
+    btree_map._root = new_root_i
+    _release_node(btree_map, root_i)
+
+
+@guppy
+@no_type_check
+def _merge_children[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, entry_i: int
+) -> int:
+    """Merges the two minimum-sized children around a parent entry.
+
+    Returns the index of the surviving left child. Callers must only use this when
+    both children have one entry, so the merged node has exactly three entries.
+    """
+    parent = btree_map._nodes.take(parent_i)
+    left_i = parent._children[entry_i].unwrap()
+    right_i = parent._children[entry_i + 1].take().unwrap()
+    left = btree_map._nodes.take(left_i)
+    right = btree_map._nodes.take(right_i)
+    old_left_size = left._size
+
+    # Concatenate `left`, the separating parent entry, then `right`. Since both
+    # children have one entry, the result fits exactly in a three-entry node.
+    left._entries[left._size].swap(
+        some(parent._entries[entry_i].take().unwrap())
+    ).unwrap_nothing()
+    left._size += 1
+    right_entry_i = 0
+    while right_entry_i < right._size:
+        left._entries[left._size].swap(
+            some(right._entries[right_entry_i].take().unwrap())
+        ).unwrap_nothing()
+        left._size += 1
+        right_entry_i += 1
+    if not left._leaf:
+        right_child_i = 0
+        while right_child_i <= right._size:
+            left._children[old_left_size + 1 + right_child_i].swap(
+                some(right._children[right_child_i].take().unwrap())
+            ).unwrap_nothing()
+            right_child_i += 1
+
+    # Removing the separator also removes the right child pointer; compact the
+    # parent prefixes to preserve the node representation invariant.
+    parent_entry_i = entry_i
+    while parent_entry_i < parent._size - 1:
+        parent._entries[parent_entry_i].swap(
+            some(parent._entries[parent_entry_i + 1].take().unwrap())
+        ).unwrap_nothing()
+        parent_entry_i += 1
+    parent_child_i = entry_i + 1
+    while parent_child_i < parent._size:
+        parent._children[parent_child_i].swap(
+            some(parent._children[parent_child_i + 1].take().unwrap())
+        ).unwrap_nothing()
+        parent_child_i += 1
+    parent._size -= 1
+    right._size = 0
+    right._leaf = True
+
+    btree_map._nodes.put(parent, parent_i)
+    btree_map._nodes.put(left, left_i)
+    btree_map._nodes.put(right, right_i)
+    _release_node(btree_map, right_i)
+    return left_i
+
+
+@guppy
+@no_type_check
+def _borrow_from_left[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, child_i: int
+) -> None:
+    """Rotates one entry from the left sibling into ``child_i``."""
+    parent = btree_map._nodes.take(parent_i)
+    left_i = parent._children[child_i - 1].unwrap()
+    target_i = parent._children[child_i].unwrap()
+    left = btree_map._nodes.take(left_i)
+    target = btree_map._nodes.take(target_i)
+
+    # Rotate clockwise: make room at the front of the target, move the parent's
+    # separator down, and promote the left sibling's largest entry to the parent.
+    entry_i = target._size
+    while entry_i > 0:
+        target._entries[entry_i].swap(
+            some(target._entries[entry_i - 1].take().unwrap())
+        ).unwrap_nothing()
+        entry_i -= 1
+    if not target._leaf:
+        child_ref_i = target._size + 1
+        while child_ref_i > 0:
+            target._children[child_ref_i].swap(
+                some(target._children[child_ref_i - 1].take().unwrap())
+            ).unwrap_nothing()
+            child_ref_i -= 1
+        target._children[0].swap(
+            some(left._children[left._size].take().unwrap())
+        ).unwrap_nothing()
+    target._entries[0].swap(
+        some(parent._entries[child_i - 1].take().unwrap())
+    ).unwrap_nothing()
+    parent._entries[child_i - 1].swap(
+        some(left._entries[left._size - 1].take().unwrap())
+    ).unwrap_nothing()
+    left._size -= 1
+    target._size += 1
+
+    btree_map._nodes.put(parent, parent_i)
+    btree_map._nodes.put(left, left_i)
+    btree_map._nodes.put(target, target_i)
+
+
+@guppy
+@no_type_check
+def _borrow_from_right[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, child_i: int
+) -> None:
+    """Rotates one entry from the right sibling into ``child_i``."""
+    parent = btree_map._nodes.take(parent_i)
+    target_i = parent._children[child_i].unwrap()
+    right_i = parent._children[child_i + 1].unwrap()
+    target = btree_map._nodes.take(target_i)
+    right = btree_map._nodes.take(right_i)
+
+    # Mirror image of `_borrow_from_left`: append the parent's separator and
+    # promote the right sibling's smallest entry after compacting that sibling.
+    target._entries[target._size].swap(
+        some(parent._entries[child_i].take().unwrap())
+    ).unwrap_nothing()
+    if not target._leaf:
+        target._children[target._size + 1].swap(
+            some(right._children[0].take().unwrap())
+        ).unwrap_nothing()
+        right_child_i = 0
+        while right_child_i < right._size:
+            right._children[right_child_i].swap(
+                some(right._children[right_child_i + 1].take().unwrap())
+            ).unwrap_nothing()
+            right_child_i += 1
+    parent._entries[child_i].swap(
+        some(right._entries[0].take().unwrap())
+    ).unwrap_nothing()
+    right_entry_i = 0
+    while right_entry_i < right._size - 1:
+        right._entries[right_entry_i].swap(
+            some(right._entries[right_entry_i + 1].take().unwrap())
+        ).unwrap_nothing()
+        right_entry_i += 1
+    right._size -= 1
+    target._size += 1
+
+    btree_map._nodes.put(parent, parent_i)
+    btree_map._nodes.put(target, target_i)
+    btree_map._nodes.put(right, right_i)
 
 
 @guppy
@@ -399,6 +653,8 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
     root_is_full = root._size == 3
     btree_map._nodes.put(root, root_i)
     if root_is_full:
+        # Split before descent. The chosen child is therefore never full when we
+        # reach a leaf, guaranteeing room for the new entry without backtracking.
         new_root_i = _allocate_node(btree_map)
         new_root = btree_map._nodes.take(new_root_i)
         new_root._leaf = False
@@ -424,6 +680,8 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
         child_is_full = child._size == 3
         btree_map._nodes.put(child, next_i)
         if child_is_full:
+            # A split inserts a new separator into the current node; choose the
+            # appropriate half only after observing that separator.
             _split_child(btree_map, node_i, child_i)
             node = btree_map._nodes.take(node_i)
             split_key = _node_key(node, child_i)

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Self, no_type_check
 from guppylang.decorator import guppy
 from guppylang.std.array import array
 from guppylang.std.mem import with_owned
+from guppylang.std.lang import Copy
 from guppylang.std.option import Option, nothing, some
 from guppylang.std.num import nat
 from guppylang.std.platform import panic
@@ -116,7 +117,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
 
     @guppy
     @no_type_check
-    def get[K: _Ord, V, MAX_SIZE: nat](
+    def get[K: _Ord, V: Copy, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE], key: K
     ) -> Option[V]:
         """Returns a copy of the value stored for ``key``, if present."""
@@ -206,7 +207,7 @@ def _contains_key[K: _Ord, V, MAX_SIZE: nat](
 
 @guppy
 @no_type_check
-def _get[K: _Ord, V, MAX_SIZE: nat](
+def _get[K: _Ord, V: Copy, MAX_SIZE: nat](
     btree_map: BTreeMap[K, V, MAX_SIZE],
 ) -> Option[V]:
     key = btree_map._query.take().unwrap()
@@ -356,7 +357,7 @@ def _node_key[K: _Ord, V](node: _Node[K, V], entry_i: int) -> K:
 
 @guppy
 @no_type_check
-def _node_value[K: _Ord, V](node: _Node[K, V], entry_i: int) -> V:
+def _node_value[K: _Ord, V: Copy](node: _Node[K, V], entry_i: int) -> V:
     _key, value = node._entries[entry_i].unwrap()
     return value
 

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -4,7 +4,8 @@ from typing import TYPE_CHECKING, Self, no_type_check
 
 from guppylang.decorator import guppy
 from guppylang.std.array import array
-from guppylang.std.option import Option, nothing
+from guppylang.std.mem import with_owned
+from guppylang.std.option import Option, nothing, some
 from guppylang.std.num import nat
 from guppylang.std.platform import panic
 
@@ -54,10 +55,11 @@ class _Node[K, V]:
 class BTreeMap[K, V, MAX_SIZE: nat]:
     """A fixed-capacity ordered map.
 
-    The public API supports ``int`` and non-NaN ``float`` keys. Keys are stored in a
-    2-3-4 tree, so lookup, insertion, and removal are logarithmic in the number of
-    entries. Values may be linear; use :meth:`discard_empty` after removing or
-    iterating over all entries.
+    The public API supports ``int`` and non-NaN ``float`` keys. Float infinities are
+    valid and ``-0.0`` and ``0.0`` designate the same key. Keys are stored in a 2-3-4
+    tree, so lookup, insertion, and removal are logarithmic in the number of entries.
+    Values may be linear; use :meth:`discard_empty` after removing or iterating over
+    all entries.
     """
 
     _nodes: array[_Node[K, V], MAX_SIZE]
@@ -65,6 +67,8 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     _free_count: int
     _root: int
     _size: int
+    _pending: Option[tuple[K, V]]
+    _query: Option[K]
 
     @guppy
     @no_type_check
@@ -80,8 +84,40 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         """Discards an empty map containing potentially linear values."""
         if self._size != 0:
             panic("BTreeMap.discard_empty: map is not empty")
+        self._pending.unwrap_nothing()
+        self._query.unwrap_nothing()
         for node in self._nodes:
             node.discard_empty()
+
+    @guppy
+    @no_type_check
+    def contains_key[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE], key: K
+    ) -> bool:
+        """Returns whether the map contains ``key``."""
+        _validate_key(key)
+        self._query.swap(some(key)).unwrap_nothing()
+        return with_owned(self, _contains_key)
+
+    @guppy
+    @no_type_check
+    def get[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE], key: K
+    ) -> Option[V]:
+        """Returns a copy of the value stored for ``key``, if present."""
+        _validate_key(key)
+        self._query.swap(some(key)).unwrap_nothing()
+        return with_owned(self, _get)
+
+    @guppy
+    @no_type_check
+    def insert[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE], key: K, value: V @ owned
+    ) -> Option[V]:
+        """Stores ``value`` for ``key`` and returns a displaced value, if any."""
+        _validate_key(key)
+        self._pending.swap(some((key, value))).unwrap_nothing()
+        return with_owned(self, _insert_pending)
 
 
 @guppy
@@ -97,6 +133,231 @@ def _empty_node[K, V]() -> _Node[K, V]:
 
 @guppy
 @no_type_check
+def _validate_key[K: _Ord](key: K) -> None:
+    if not key.__eq__(key):
+        panic("BTreeMap: key must be reflexive")
+
+
+@guppy
+@no_type_check
+def _find_owned[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned, key: K
+) -> tuple[Option[tuple[int, int]], BTreeMap[K, V, MAX_SIZE]]:
+    node_i = btree_map._root
+    while node_i >= 0:
+        node = btree_map._nodes.take(node_i)
+        entry_i = _node_entry_index(node, key)
+        found = entry_i < node._size and key.__eq__(_node_key(node, entry_i))
+        is_leaf = node._leaf
+        next_i = -1
+        if not is_leaf:
+            next_i = _node_child(node, entry_i)
+        btree_map._nodes.put(node, node_i)
+        if found:
+            return some((node_i, entry_i)), btree_map
+        if is_leaf:
+            return nothing(), btree_map
+        node_i = next_i
+    return nothing(), btree_map
+
+
+@guppy
+@no_type_check
+def _contains_key[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+) -> tuple[bool, BTreeMap[K, V, MAX_SIZE]]:
+    key = btree_map._query.take().unwrap()
+    location, btree_map = _find_owned(btree_map, key)
+    return location.is_some(), btree_map
+
+
+@guppy
+@no_type_check
+def _get[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
+    key = btree_map._query.take().unwrap()
+    location, btree_map = _find_owned(btree_map, key)
+    if location.is_nothing():
+        return nothing(), btree_map
+    node_i, entry_i = location.unwrap()
+    node = btree_map._nodes.take(node_i)
+    value = _node_value(node, entry_i)
+    btree_map._nodes.put(node, node_i)
+    return some(value), btree_map
+
+
+@guppy
+@no_type_check
+def _node_entry_index[K: _Ord, V](node: _Node[K, V], key: K) -> int:
+    entry_i = 0
+    while entry_i < node._size:
+        stored_key = _node_key(node, entry_i)
+        if key.__lt__(stored_key) or key.__eq__(stored_key):
+            break
+        entry_i += 1
+    return entry_i
+
+
+@guppy
+@no_type_check
+def _node_key[K: _Ord, V](node: _Node[K, V], entry_i: int) -> K:
+    key, _value = node._entries[entry_i].unwrap()
+    return key
+
+
+@guppy
+@no_type_check
+def _node_value[K: _Ord, V](node: _Node[K, V], entry_i: int) -> V:
+    _key, value = node._entries[entry_i].unwrap()
+    return value
+
+
+@guppy
+@no_type_check
+def _node_child[K, V](node: _Node[K, V], child_i: int) -> int:
+    return node._children[child_i].unwrap()
+
+
+@guppy
+@no_type_check
+def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
+    key, value = btree_map._pending.take().unwrap()
+    location, btree_map = _find_owned(btree_map, key)
+    if location.is_some():
+        node_i, entry_i = location.unwrap()
+        node = btree_map._nodes.take(node_i)
+        stored_key, old_value = node._entries[entry_i].take().unwrap()
+        node._entries[entry_i].swap(some((stored_key, value))).unwrap_nothing()
+        btree_map._nodes.put(node, node_i)
+        return some(old_value), btree_map
+    if btree_map._size >= MAX_SIZE:
+        panic("BTreeMap.insert: max size reached")
+    if btree_map._root < 0:
+        root_i, btree_map = _allocate_node(btree_map)
+        root = btree_map._nodes.take(root_i)
+        root._entries[0].swap(some((key, value))).unwrap_nothing()
+        root._size = 1
+        btree_map._nodes.put(root, root_i)
+        btree_map._root = root_i
+        btree_map._size = 1
+        return nothing(), btree_map
+
+    root_i = btree_map._root
+    root = btree_map._nodes.take(root_i)
+    root_is_full = root._size == 3
+    btree_map._nodes.put(root, root_i)
+    if root_is_full:
+        new_root_i, btree_map = _allocate_node(btree_map)
+        new_root = btree_map._nodes.take(new_root_i)
+        new_root._leaf = False
+        new_root._children[0].swap(some(root_i)).unwrap_nothing()
+        btree_map._nodes.put(new_root, new_root_i)
+        btree_map._root = new_root_i
+        btree_map = _split_child(btree_map, new_root_i, 0)
+
+    node_i = btree_map._root
+    is_leaf = False
+    while not is_leaf:
+        node = btree_map._nodes.take(node_i)
+        is_leaf = node._leaf
+        child_i = 0
+        next_i = -1
+        if not is_leaf:
+            child_i = _node_entry_index(node, key)
+            next_i = _node_child(node, child_i)
+        btree_map._nodes.put(node, node_i)
+        if is_leaf:
+            break
+        child = btree_map._nodes.take(next_i)
+        child_is_full = child._size == 3
+        btree_map._nodes.put(child, next_i)
+        if child_is_full:
+            btree_map = _split_child(btree_map, node_i, child_i)
+            node = btree_map._nodes.take(node_i)
+            split_key = _node_key(node, child_i)
+            if key.__lt__(split_key):
+                next_i = _node_child(node, child_i)
+            else:
+                next_i = _node_child(node, child_i + 1)
+            btree_map._nodes.put(node, node_i)
+        node_i = next_i
+
+    node = btree_map._nodes.take(node_i)
+    entry_i = node._size
+    while entry_i > 0:
+        if _node_key(node, entry_i - 1).__lt__(key):
+            break
+        entry = node._entries[entry_i - 1].take().unwrap()
+        node._entries[entry_i].swap(some(entry)).unwrap_nothing()
+        entry_i -= 1
+    node._entries[entry_i].swap(some((key, value))).unwrap_nothing()
+    node._size += 1
+    btree_map._nodes.put(node, node_i)
+    btree_map._size += 1
+    return nothing(), btree_map
+
+
+@guppy
+@no_type_check
+def _allocate_node[K, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+) -> tuple[int, BTreeMap[K, V, MAX_SIZE]]:
+    if btree_map._free_count <= 0:
+        panic("BTreeMap: node pool exhausted")
+    btree_map._free_count -= 1
+    return btree_map._free_nodes[btree_map._free_count], btree_map
+
+
+@guppy
+@no_type_check
+def _split_child[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned, parent_i: int, child_i: int
+) -> BTreeMap[K, V, MAX_SIZE]:
+    parent = btree_map._nodes.take(parent_i)
+    old_child_i = parent._children[child_i].unwrap()
+    child = btree_map._nodes.take(old_child_i)
+    sibling_i, btree_map = _allocate_node(btree_map)
+    sibling = btree_map._nodes.take(sibling_i)
+
+    sibling._leaf = child._leaf
+    sibling._entries[0].swap(some(child._entries[2].take().unwrap())).unwrap_nothing()
+    sibling._size = 1
+    child._size = 1
+    if not child._leaf:
+        sibling._children[0].swap(
+            some(child._children[2].take().unwrap())
+        ).unwrap_nothing()
+        sibling._children[1].swap(
+            some(child._children[3].take().unwrap())
+        ).unwrap_nothing()
+
+    parent_entry_i = parent._size
+    while parent_entry_i > child_i:
+        entry = parent._entries[parent_entry_i - 1].take().unwrap()
+        parent._entries[parent_entry_i].swap(some(entry)).unwrap_nothing()
+        parent_entry_i -= 1
+    parent._entries[child_i].swap(
+        some(child._entries[1].take().unwrap())
+    ).unwrap_nothing()
+    child_entry_i = parent._size + 1
+    while child_entry_i > child_i + 1:
+        child_ref = parent._children[child_entry_i - 1].take().unwrap()
+        parent._children[child_entry_i].swap(some(child_ref)).unwrap_nothing()
+        child_entry_i -= 1
+    parent._children[child_i + 1].swap(some(sibling_i)).unwrap_nothing()
+    parent._size += 1
+
+    btree_map._nodes.put(parent, parent_i)
+    btree_map._nodes.put(child, old_child_i)
+    btree_map._nodes.put(sibling, sibling_i)
+    return btree_map
+
+
+@guppy
+@no_type_check
 def empty_btree_map[K: _Ord, V, MAX_SIZE: nat]() -> BTreeMap[K, V, MAX_SIZE]:
     """Constructs an empty fixed-capacity B-tree map."""
     return BTreeMap(
@@ -105,4 +366,6 @@ def empty_btree_map[K: _Ord, V, MAX_SIZE: nat]() -> BTreeMap[K, V, MAX_SIZE]:
         int(MAX_SIZE),
         -1,
         0,
+        nothing[tuple[K, V]](),
+        nothing[K](),
     )

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -83,6 +83,9 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
 
     With constant-time key comparison, ``len`` is ``O(1)``; lookup, insertion, and
     removal are ``O(log n)``; and consuming iteration drains the map in ``O(n)``.
+    Static storage is ``O(MAX_SIZE)`` nodes plus an ``O(MAX_SIZE)`` iterator stack;
+    node fan-out and the separate key index trade additional fixed storage for support
+    of linear values.
     """
 
     # A fixed pool keeps the whole data structure statically allocated. Nodes are
@@ -98,7 +101,12 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     # key or value through the map without copying it. They are always `nothing` at
     # API boundaries, which `discard_empty` verifies.
     _pending: Option[tuple[K, V]]
-    _query: Option[K]
+    # Iteration keeps an explicit root-to-leaf path. The arrays are statically sized
+    # by `MAX_SIZE`, though only `O(log n)` frames are live in a balanced tree.
+    _iter_nodes: array[int, MAX_SIZE]
+    _iter_entries: array[int, MAX_SIZE]
+    _iter_depth: int
+    _iter_active: bool
 
     @guppy
     @no_type_check
@@ -113,8 +121,10 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     ) -> BTreeMap[K, V, MAX_SIZE]:
         """Consumes the map, yielding entries in ascending key order.
 
-        Complexity: ``O(n)`` overall.
+        Complexity: ``O(n)`` overall, using ``O(MAX_SIZE)`` static traversal
+        storage (only ``O(log n)`` frames are live).
         """
+        _start_iteration(self)
         return self
 
     @guppy
@@ -133,7 +143,6 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         if self._size != 0:
             panic("BTreeMap.discard_empty: map is not empty")
         self._pending.unwrap_nothing()
-        self._query.unwrap_nothing()
         for node in self._nodes:
             node.discard_empty()
 
@@ -144,8 +153,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     ) -> bool:
         """Returns whether the map contains ``key`` in ``O(log n)`` time."""
         _validate_key(key)
-        self._query.swap(some(key)).unwrap_nothing()
-        return _contains_key(self)
+        return _find(self, key).is_some()
 
     @guppy
     @no_type_check
@@ -160,8 +168,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         Complexity: ``O(log n)``.
         """
         _validate_key(key)
-        self._query.swap(some(key)).unwrap_nothing()
-        return _get(self)
+        return _get(self, key)
 
     @guppy
     @no_type_check
@@ -186,21 +193,12 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
         Complexity: ``O(log n)``.
         """
         _validate_key(key)
-        location = _find(self, key)
-        if location.is_nothing():
+        if self._root < 0:
             return nothing()
-        node_i, entry_i = location.unwrap()
-        node = self._nodes.take(node_i)
-        is_leaf = node._leaf
-        self._nodes.put(node, node_i)
-        if is_leaf:
-            root_i = self._root
-            value = _remove_leaf_descending(self, root_i, key)
-            _collapse_root(self)
-            return some(value)
-        value = _remove_internal_entry(self, node_i, entry_i)
+        root_i = self._root
+        value = _remove_descending(self, root_i, key)
         _collapse_root(self)
-        return some(value)
+        return value
 
 
 @guppy
@@ -254,19 +252,9 @@ def _find[K: _Ord, V, MAX_SIZE: nat](
 
 @guppy
 @no_type_check
-def _contains_key[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE],
-) -> bool:
-    key = btree_map._query.take().unwrap()
-    return _find(btree_map, key).is_some()
-
-
-@guppy
-@no_type_check
 def _get[K: _Ord, V: Copy, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE],
+    btree_map: BTreeMap[K, V, MAX_SIZE], key: K
 ) -> Option[V]:
-    key = btree_map._query.take().unwrap()
     location = _find(btree_map, key)
     if location.is_nothing():
         return nothing()
@@ -368,6 +356,29 @@ def _remove_leaf_descending[K: _Ord, V, MAX_SIZE: nat](
     # from its subtree cannot leave it below the 2-3-4-tree minimum occupancy.
     child_i = _prepare_child(btree_map, node_i, entry_i)
     return _remove_leaf_descending(btree_map, child_i, key)
+
+
+@guppy
+@no_type_check
+def _remove_descending[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int, key: K
+) -> Option[V]:
+    """Finds and removes ``key`` in one top-down traversal."""
+    node = btree_map._nodes.take(node_i)
+    entry_i = _node_entry_index(node, key)
+    found = entry_i < node._size and key.__eq__(_node_key(node, entry_i))
+    is_leaf = node._leaf
+    btree_map._nodes.put(node, node_i)
+    if found:
+        if is_leaf:
+            return some(_remove_leaf_entry(btree_map, node_i, entry_i))
+        return some(_remove_internal_entry(btree_map, node_i, entry_i))
+    if is_leaf:
+        return nothing()
+    # Repair a minimal child before descent. The returned index accounts for a
+    # merge with its left sibling, so it still identifies the key's subtree.
+    child_i = _prepare_child(btree_map, node_i, entry_i)
+    return _remove_descending(btree_map, child_i, key)
 
 
 @guppy
@@ -685,22 +696,97 @@ def _borrow_from_right[K: _Ord, V, MAX_SIZE: nat](
 def _next_entry[K: _Ord, V, MAX_SIZE: nat](
     btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
 ) -> Option[tuple[tuple[K, V], BTreeMap[K, V, MAX_SIZE]]]:
+    if not btree_map._iter_active:
+        _start_iteration(btree_map)
     if btree_map._size == 0:
+        _finish_iteration(btree_map)
         btree_map.discard_empty()
         return nothing()
-    node_i = btree_map._root
-    while True:
+    while btree_map._iter_depth > 0:
+        frame_i = btree_map._iter_depth - 1
+        node_i = btree_map._iter_nodes[frame_i]
+        entry_i = btree_map._iter_entries[frame_i]
         node = btree_map._nodes.take(node_i)
-        is_leaf = node._leaf
-        if is_leaf:
-            first_key = _node_key(node, 0)
+        if entry_i >= node._size:
+            node._size = 0
+            node._leaf = True
             btree_map._nodes.put(node, node_i)
-            break
-        next_i = _node_child(node, 0)
+            _release_node(btree_map, node_i)
+            btree_map._iter_depth -= 1
+            continue
+        is_leaf = node._leaf
+        key, value = node._entries[entry_i].take().unwrap()
+        node._keys[entry_i].take().unwrap()
+        btree_map._iter_entries[frame_i] = entry_i + 1
+        child_i = -1
+        if not is_leaf:
+            child_i = node._children[entry_i + 1].take().unwrap()
         btree_map._nodes.put(node, node_i)
-        node_i = next_i
-    value = btree_map.remove(first_key).unwrap()
-    return some(((first_key, value), btree_map))
+        btree_map._size -= 1
+        if not is_leaf:
+            _push_left_path(btree_map, child_i)
+        return some(((key, value), btree_map))
+    panic("BTreeMap: iteration state corrupt")
+    # `panic` is not modelled as non-returning by the Guppy checker. This path is
+    # unreachable, but consuming the map keeps the fallback type-correct.
+    _finish_iteration(btree_map)
+    btree_map.discard_empty()
+    return nothing()
+
+
+@guppy
+@no_type_check
+def _start_iteration[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> None:
+    if btree_map._iter_active:
+        return
+    btree_map._iter_active = True
+    btree_map._iter_depth = 0
+    root_i = btree_map._root
+    if root_i >= 0:
+        _push_left_path(btree_map, root_i)
+
+
+@guppy
+@no_type_check
+def _push_left_path[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int
+) -> None:
+    """Pushes the unvisited left spine rooted at ``node_i`` onto the iterator."""
+    current_i = node_i
+    while current_i >= 0:
+        frame_i = btree_map._iter_depth
+        btree_map._iter_nodes[frame_i] = current_i
+        btree_map._iter_entries[frame_i] = 0
+        btree_map._iter_depth += 1
+        node = btree_map._nodes.take(current_i)
+        is_leaf = node._leaf
+        next_i = -1
+        if not is_leaf:
+            next_i = node._children[0].take().unwrap()
+        btree_map._nodes.put(node, current_i)
+        if is_leaf:
+            return
+        current_i = next_i
+
+
+@guppy
+@no_type_check
+def _finish_iteration[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE],
+) -> None:
+    """Releases the completed frames still retained by the iterator stack."""
+    while btree_map._iter_depth > 0:
+        btree_map._iter_depth -= 1
+        node_i = btree_map._iter_nodes[btree_map._iter_depth]
+        node = btree_map._nodes.take(node_i)
+        node._size = 0
+        node._leaf = True
+        btree_map._nodes.put(node, node_i)
+        _release_node(btree_map, node_i)
+    btree_map._root = -1
+    btree_map._iter_active = False
 
 
 @guppy
@@ -742,15 +828,17 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
     btree_map: BTreeMap[K, V, MAX_SIZE],
 ) -> Option[V]:
     key, value = btree_map._pending.take().unwrap()
-    location = _find(btree_map, key)
-    if location.is_some():
-        node_i, entry_i = location.unwrap()
-        node = btree_map._nodes.take(node_i)
-        stored_key, old_value = node._entries[entry_i].take().unwrap()
-        node._entries[entry_i].swap(some((stored_key, value))).unwrap_nothing()
-        btree_map._nodes.put(node, node_i)
-        return some(old_value)
     if btree_map._size >= MAX_SIZE:
+        # A full map may still replace an existing value. Do this bounded lookup
+        # before any split so a rejected distinct key leaves the tree untouched.
+        location = _find(btree_map, key)
+        if location.is_some():
+            node_i, entry_i = location.unwrap()
+            node = btree_map._nodes.take(node_i)
+            stored_key, old_value = node._entries[entry_i].take().unwrap()
+            node._entries[entry_i].swap(some((stored_key, value))).unwrap_nothing()
+            btree_map._nodes.put(node, node_i)
+            return some(old_value)
         panic("BTreeMap.insert: max size reached")
     if btree_map._root < 0:
         root_i = _allocate_node(btree_map)
@@ -779,49 +867,50 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
         _split_child(btree_map, new_root_i, 0)
 
     node_i = btree_map._root
-    is_leaf = False
-    while not is_leaf:
+    while True:
         node = btree_map._nodes.take(node_i)
-        is_leaf = node._leaf
-        child_i = 0
-        next_i = -1
-        if not is_leaf:
-            child_i = _node_entry_index(node, key)
-            next_i = _node_child(node, child_i)
+        entry_i = _node_entry_index(node, key)
+        found = entry_i < node._size and key.__eq__(_node_key(node, entry_i))
+        if found:
+            stored_key, old_value = node._entries[entry_i].take().unwrap()
+            node._entries[entry_i].swap(some((stored_key, value))).unwrap_nothing()
+            btree_map._nodes.put(node, node_i)
+            return some(old_value)
+        if node._leaf:
+            insert_i = node._size
+            while insert_i > entry_i:
+                node._keys[insert_i].swap(
+                    node._keys[insert_i - 1].take()
+                ).unwrap_nothing()
+                entry = node._entries[insert_i - 1].take().unwrap()
+                node._entries[insert_i].swap(some(entry)).unwrap_nothing()
+                insert_i -= 1
+            node._keys[entry_i].swap(some(key)).unwrap_nothing()
+            node._entries[entry_i].swap(some((key, value))).unwrap_nothing()
+            node._size += 1
+            btree_map._nodes.put(node, node_i)
+            btree_map._size += 1
+            return nothing()
+
+        next_i = _node_child(node, entry_i)
         btree_map._nodes.put(node, node_i)
-        if is_leaf:
-            break
         child = btree_map._nodes.take(next_i)
         child_is_full = child._size == 3
         btree_map._nodes.put(child, next_i)
         if child_is_full:
             # A split inserts a new separator into the current node; choose the
             # appropriate half only after observing that separator.
-            _split_child(btree_map, node_i, child_i)
+            _split_child(btree_map, node_i, entry_i)
             node = btree_map._nodes.take(node_i)
-            split_key = _node_key(node, child_i)
-            if key.__lt__(split_key):
-                next_i = _node_child(node, child_i)
-            else:
-                next_i = _node_child(node, child_i + 1)
+            entry_i = _node_entry_index(node, key)
+            if entry_i < node._size and key.__eq__(_node_key(node, entry_i)):
+                stored_key, old_value = node._entries[entry_i].take().unwrap()
+                node._entries[entry_i].swap(some((stored_key, value))).unwrap_nothing()
+                btree_map._nodes.put(node, node_i)
+                return some(old_value)
+            next_i = _node_child(node, entry_i)
             btree_map._nodes.put(node, node_i)
         node_i = next_i
-
-    node = btree_map._nodes.take(node_i)
-    entry_i = node._size
-    while entry_i > 0:
-        if _node_key(node, entry_i - 1).__lt__(key):
-            break
-        node._keys[entry_i].swap(node._keys[entry_i - 1].take()).unwrap_nothing()
-        entry = node._entries[entry_i - 1].take().unwrap()
-        node._entries[entry_i].swap(some(entry)).unwrap_nothing()
-        entry_i -= 1
-    node._keys[entry_i].swap(some(key)).unwrap_nothing()
-    node._entries[entry_i].swap(some((key, value))).unwrap_nothing()
-    node._size += 1
-    btree_map._nodes.put(node, node_i)
-    btree_map._size += 1
-    return nothing()
 
 
 @guppy
@@ -829,6 +918,9 @@ def _insert_pending[K: _Ord, V, MAX_SIZE: nat](
 def _allocate_node[K, V, MAX_SIZE: nat](
     btree_map: BTreeMap[K, V, MAX_SIZE],
 ) -> int:
+    # This is defensive: a 2-3-4 tree with at most `MAX_SIZE` entries has no
+    # more than `MAX_SIZE` live nodes, so correct insert/rebalance logic cannot
+    # exhaust the statically sized pool.
     if btree_map._free_count <= 0:
         panic("BTreeMap: node pool exhausted")
     btree_map._free_count -= 1
@@ -895,5 +987,8 @@ def empty_btree_map[K: _Ord, V, MAX_SIZE: nat]() -> BTreeMap[K, V, MAX_SIZE]:
         -1,
         0,
         nothing[tuple[K, V]](),
-        nothing[K](),
+        array(0 for _ in range(MAX_SIZE)),
+        array(0 for _ in range(MAX_SIZE)),
+        0,
+        False,
     )

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -4,7 +4,6 @@ from typing import TYPE_CHECKING, Self, no_type_check
 
 from guppylang.decorator import guppy
 from guppylang.std.array import array
-from guppylang.std.mem import with_owned
 from guppylang.std.lang import Copy
 from guppylang.std.option import Option, nothing, some
 from guppylang.std.num import nat
@@ -75,10 +74,8 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     may be linear; use :meth:`discard_empty` after removing or iterating over all
     entries.
 
-    With constant-time key comparison, ``len`` is ``O(1)`` and lookup, insertion,
-    and a leaf-key removal are ``O(log n)``. Removing an internal key and draining
-    iteration currently rebuild the surviving tree, so their worst-case costs are
-    ``O(n log n)``; this is temporary until in-place internal-key rebalancing lands.
+    With constant-time key comparison, ``len`` is ``O(1)``; lookup, insertion, and
+    removal are ``O(log n)``; and consuming iteration drains the map in ``O(n)``.
     """
 
     # A fixed pool keeps the whole data structure statically allocated. Nodes are
@@ -109,7 +106,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     ) -> BTreeMap[K, V, MAX_SIZE]:
         """Consumes the map, yielding entries in ascending key order.
 
-        Complexity: ``O(n log n)`` overall until internal-key deletion is in place.
+        Complexity: ``O(n)`` overall.
         """
         return self
 
@@ -179,8 +176,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     ) -> Option[V]:
         """Removes and returns the value stored for ``key``, if present.
 
-        Complexity: ``O(log n)`` for a leaf key; ``O(n log n)`` worst case while
-        internal-key deletion uses its temporary rebuild path.
+        Complexity: ``O(log n)``.
         """
         _validate_key(key)
         location = _find(self, key)
@@ -195,16 +191,9 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
             value = _remove_leaf_descending(self, root_i, key)
             _collapse_root(self)
             return some(value)
-        removed = _remove_internal_from_left(self, node_i, entry_i)
-        if removed.is_some():
-            _collapse_root(self)
-            return removed
-        removed = _remove_internal_from_right(self, node_i, entry_i)
-        if removed.is_some():
-            _collapse_root(self)
-            return removed
-        self._query.swap(some(key)).unwrap_nothing()
-        return with_owned(self, _rebuild_remove)
+        value = _remove_internal_entry(self, node_i, entry_i)
+        _collapse_root(self)
+        return some(value)
 
 
 @guppy
@@ -278,21 +267,6 @@ def _get[K: _Ord, V: Copy, MAX_SIZE: nat](
     value = _node_value(node, entry_i)
     btree_map._nodes.put(node, node_i)
     return some(value)
-
-
-@guppy
-@no_type_check
-def _rebuild_remove[K: _Ord, V, MAX_SIZE: nat](
-    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
-    key = btree_map._query.take().unwrap()
-    rebuilt = empty_btree_map[K, V, MAX_SIZE]()
-    root_i = btree_map._root
-    removed, btree_map, rebuilt = _drain_except(btree_map, rebuilt, root_i, key)
-    btree_map._root = -1
-    btree_map._size = 0
-    btree_map.discard_empty()
-    return removed, rebuilt
 
 
 @guppy
@@ -409,6 +383,34 @@ def _remove_internal_from_left[K: _Ord, V, MAX_SIZE: nat](
     ).unwrap_nothing()
     btree_map._nodes.put(parent, parent_i)
     return some(old_value)
+
+
+@guppy
+@no_type_check
+def _remove_internal_entry[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int, entry_i: int
+) -> V:
+    """Deletes an internal entry by borrowing, or recursively merging, its children."""
+    removed = _remove_internal_from_left(btree_map, node_i, entry_i)
+    if removed.is_some():
+        return removed.unwrap()
+    removed = _remove_internal_from_right(btree_map, node_i, entry_i)
+    if removed.is_some():
+        return removed.unwrap()
+
+    parent = btree_map._nodes.take(node_i)
+    left_i = parent._children[entry_i].unwrap()
+    left = btree_map._nodes.take(left_i)
+    left_size = left._size
+    btree_map._nodes.put(left, left_i)
+    btree_map._nodes.put(parent, node_i)
+    merged_i = _merge_children(btree_map, node_i, entry_i)
+    merged = btree_map._nodes.take(merged_i)
+    is_leaf = merged._leaf
+    btree_map._nodes.put(merged, merged_i)
+    if is_leaf:
+        return _remove_leaf_entry(btree_map, merged_i, left_size)
+    return _remove_internal_entry(btree_map, merged_i, left_size)
 
 
 @guppy
@@ -662,67 +664,13 @@ def _next_entry[K: _Ord, V, MAX_SIZE: nat](
         is_leaf = node._leaf
         if is_leaf:
             first_key = _node_key(node, 0)
-            can_remove_in_place = node._size > 1
             btree_map._nodes.put(node, node_i)
             break
         next_i = _node_child(node, 0)
         btree_map._nodes.put(node, node_i)
         node_i = next_i
-    if can_remove_in_place:
-        return some(((first_key, _remove_leaf_entry(btree_map, node_i, 0)), btree_map))
-    btree_map._query.swap(some(first_key)).unwrap_nothing()
-    value, btree_map = _rebuild_remove(btree_map)
-    return some(((first_key, value.unwrap()), btree_map))
-
-
-@guppy
-@no_type_check
-def _drain_except[K: _Ord, V, MAX_SIZE: nat](
-    old_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-    new_map: BTreeMap[K, V, MAX_SIZE] @ owned,
-    node_i: int,
-    key: K,
-) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE], BTreeMap[K, V, MAX_SIZE]]:
-    if node_i < 0:
-        return nothing(), old_map, new_map
-    node = old_map._nodes.take(node_i)
-    removed = nothing[V]()
-    entry_i = 0
-    while entry_i < node._size:
-        if not node._leaf:
-            child_i = node._children[entry_i].take().unwrap()
-            child_removed, old_map, new_map = _drain_except(
-                old_map, new_map, child_i, key
-            )
-            if child_removed.is_some():
-                if removed.is_some():
-                    panic("BTreeMap: duplicate key")
-                removed = child_removed
-            else:
-                child_removed.unwrap_nothing()
-        entry_key, entry_value = node._entries[entry_i].take().unwrap()
-        if entry_key.__eq__(key):
-            if removed.is_some():
-                panic("BTreeMap: duplicate key")
-            removed = some(entry_value)
-        else:
-            new_map._pending.swap(some((entry_key, entry_value))).unwrap_nothing()
-            displaced = _insert_pending(new_map)
-            displaced.unwrap_nothing()
-        entry_i += 1
-    if not node._leaf:
-        child_i = node._children[node._size].take().unwrap()
-        child_removed, old_map, new_map = _drain_except(old_map, new_map, child_i, key)
-        if child_removed.is_some():
-            if removed.is_some():
-                panic("BTreeMap: duplicate key")
-            removed = child_removed
-        else:
-            child_removed.unwrap_nothing()
-    node._size = 0
-    node._leaf = True
-    old_map._nodes.put(node, node_i)
-    return removed, old_map, new_map
+    value = btree_map.remove(first_key).unwrap()
+    return some(((first_key, value), btree_map))
 
 
 @guppy

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -78,6 +78,21 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
 
     @guppy
     @no_type_check
+    def __iter__[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE] @ owned,
+    ) -> BTreeMap[K, V, MAX_SIZE]:
+        """Consumes the map, yielding entries in ascending key order."""
+        return self
+
+    @guppy
+    @no_type_check
+    def __next__[K: _Ord, V, MAX_SIZE: nat](
+        self: BTreeMap[K, V, MAX_SIZE] @ owned,
+    ) -> Option[tuple[tuple[K, V], BTreeMap[K, V, MAX_SIZE]]]:
+        return _next_entry(self)
+
+    @guppy
+    @no_type_check
     def discard_empty[K: _Ord, V, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE] @ owned,
     ) -> None:
@@ -126,8 +141,17 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     ) -> Option[V]:
         """Removes and returns the value stored for ``key``, if present."""
         _validate_key(key)
+        location = _find(self, key)
+        if location.is_nothing():
+            return nothing()
+        node_i, entry_i = location.unwrap()
+        node = self._nodes.take(node_i)
+        is_leaf = node._leaf
+        self._nodes.put(node, node_i)
+        if is_leaf:
+            return some(_remove_leaf_entry(self, node_i, entry_i))
         self._query.swap(some(key)).unwrap_nothing()
-        return with_owned(self, _remove)
+        return with_owned(self, _rebuild_remove)
 
 
 @guppy
@@ -198,7 +222,7 @@ def _get[K: _Ord, V, MAX_SIZE: nat](
 
 @guppy
 @no_type_check
-def _remove[K: _Ord, V, MAX_SIZE: nat](
+def _rebuild_remove[K: _Ord, V, MAX_SIZE: nat](
     btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
 ) -> tuple[Option[V], BTreeMap[K, V, MAX_SIZE]]:
     key = btree_map._query.take().unwrap()
@@ -209,6 +233,56 @@ def _remove[K: _Ord, V, MAX_SIZE: nat](
     btree_map._size = 0
     btree_map.discard_empty()
     return removed, rebuilt
+
+
+@guppy
+@no_type_check
+def _remove_leaf_entry[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int, entry_i: int
+) -> V:
+    node = btree_map._nodes.take(node_i)
+    _key, value = node._entries[entry_i].take().unwrap()
+    next_i = entry_i
+    while next_i < node._size - 1:
+        entry = node._entries[next_i + 1].take().unwrap()
+        node._entries[next_i].swap(some(entry)).unwrap_nothing()
+        next_i += 1
+    node._size -= 1
+    is_empty_root = node_i == btree_map._root and node._size == 0
+    btree_map._nodes.put(node, node_i)
+    btree_map._size -= 1
+    if is_empty_root:
+        btree_map._root = -1
+        btree_map._free_nodes[btree_map._free_count] = node_i
+        btree_map._free_count += 1
+    return value
+
+
+@guppy
+@no_type_check
+def _next_entry[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE] @ owned,
+) -> Option[tuple[tuple[K, V], BTreeMap[K, V, MAX_SIZE]]]:
+    if btree_map._size == 0:
+        btree_map.discard_empty()
+        return nothing()
+    node_i = btree_map._root
+    while True:
+        node = btree_map._nodes.take(node_i)
+        is_leaf = node._leaf
+        if is_leaf:
+            first_key = _node_key(node, 0)
+            can_remove_in_place = node._size > 1
+            btree_map._nodes.put(node, node_i)
+            break
+        next_i = _node_child(node, 0)
+        btree_map._nodes.put(node, node_i)
+        node_i = next_i
+    if can_remove_in_place:
+        return some(((first_key, _remove_leaf_entry(btree_map, node_i, 0)), btree_map))
+    btree_map._query.swap(some(first_key)).unwrap_nothing()
+    value, btree_map = _rebuild_remove(btree_map)
+    return some(((first_key, value.unwrap()), btree_map))
 
 
 @guppy

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -195,6 +195,14 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
             value = _remove_leaf_descending(self, root_i, key)
             _collapse_root(self)
             return some(value)
+        removed = _remove_internal_from_left(self, node_i, entry_i)
+        if removed.is_some():
+            _collapse_root(self)
+            return removed
+        removed = _remove_internal_from_right(self, node_i, entry_i)
+        if removed.is_some():
+            _collapse_root(self)
+            return removed
         self._query.swap(some(key)).unwrap_nothing()
         return with_owned(self, _rebuild_remove)
 
@@ -375,6 +383,97 @@ def _remove_leaf_descending[K: _Ord, V, MAX_SIZE: nat](
     # from its subtree cannot leave it below the 2-3-4-tree minimum occupancy.
     child_i = _prepare_child(btree_map, node_i, entry_i)
     return _remove_leaf_descending(btree_map, child_i, key)
+
+
+@guppy
+@no_type_check
+def _remove_internal_from_left[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, entry_i: int
+) -> Option[V]:
+    """Replaces an internal entry with its predecessor when its child can spare one."""
+    parent = btree_map._nodes.take(parent_i)
+    left_i = parent._children[entry_i].unwrap()
+    left = btree_map._nodes.take(left_i)
+    left_size = left._size
+    btree_map._nodes.put(left, left_i)
+    btree_map._nodes.put(parent, parent_i)
+    if left_size <= 1:
+        return nothing()
+
+    predecessor_key = _rightmost_key(btree_map, left_i)
+    predecessor_value = _remove_leaf_descending(btree_map, left_i, predecessor_key)
+    parent = btree_map._nodes.take(parent_i)
+    _old_key, old_value = parent._entries[entry_i].take().unwrap()
+    parent._entries[entry_i].swap(
+        some((predecessor_key, predecessor_value))
+    ).unwrap_nothing()
+    btree_map._nodes.put(parent, parent_i)
+    return some(old_value)
+
+
+@guppy
+@no_type_check
+def _rightmost_key[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int
+) -> K:
+    current_i = node_i
+    while True:
+        node = btree_map._nodes.take(current_i)
+        size = node._size
+        key = _node_key(node, size - 1)
+        is_leaf = node._leaf
+        next_i = -1
+        if not is_leaf:
+            next_i = _node_child(node, size)
+        btree_map._nodes.put(node, current_i)
+        if is_leaf:
+            return key
+        current_i = next_i
+
+
+@guppy
+@no_type_check
+def _remove_internal_from_right[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], parent_i: int, entry_i: int
+) -> Option[V]:
+    """Replaces an internal entry with its successor when its child can spare one."""
+    parent = btree_map._nodes.take(parent_i)
+    right_i = parent._children[entry_i + 1].unwrap()
+    right = btree_map._nodes.take(right_i)
+    right_size = right._size
+    btree_map._nodes.put(right, right_i)
+    btree_map._nodes.put(parent, parent_i)
+    if right_size <= 1:
+        return nothing()
+
+    successor_key = _leftmost_key(btree_map, right_i)
+    successor_value = _remove_leaf_descending(btree_map, right_i, successor_key)
+    parent = btree_map._nodes.take(parent_i)
+    _old_key, old_value = parent._entries[entry_i].take().unwrap()
+    parent._entries[entry_i].swap(
+        some((successor_key, successor_value))
+    ).unwrap_nothing()
+    btree_map._nodes.put(parent, parent_i)
+    return some(old_value)
+
+
+@guppy
+@no_type_check
+def _leftmost_key[K: _Ord, V, MAX_SIZE: nat](
+    btree_map: BTreeMap[K, V, MAX_SIZE], node_i: int
+) -> K:
+    current_i = node_i
+    while True:
+        node = btree_map._nodes.take(current_i)
+        key = _node_key(node, 0)
+        is_leaf = node._leaf
+        next_i = -1
+        if not is_leaf:
+            next_i = _node_child(node, 0)
+        btree_map._nodes.put(node, current_i)
+        if is_leaf:
+            return key
+        current_i = next_i
 
 
 @guppy

--- a/guppylang/src/guppylang/std/collections/btree_map.py
+++ b/guppylang/src/guppylang/std/collections/btree_map.py
@@ -18,6 +18,14 @@ if TYPE_CHECKING:
 class _Ord:
     """Internal structural protocol for keys in :class:`BTreeMap`.
 
+    This is deliberately private: public callers are only promised ``int`` and
+    non-NaN ``float`` keys. Protocol bounds currently also make a key copyable and
+    droppable, which is what permits comparisons while the map retains its key.
+
+    Implementations must make ``__lt__`` and ``__eq__`` describe the same ordering.
+    In particular, equal keys must not be ordered, and every accepted key must equal
+    itself. The latter is checked at each public operation to reject ``NaN``.
+
     TODO: Replace this with a public standard-library ordering API once one is designed.
     """
 
@@ -63,9 +71,14 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
 
     The public API supports ``int`` and non-NaN ``float`` keys. Float infinities are
     valid and ``-0.0`` and ``0.0`` designate the same key. Keys are stored in a 2-3-4
-    tree, so lookup, insertion, and removal are logarithmic in the number of entries.
-    Values may be linear; use :meth:`discard_empty` after removing or iterating over
-    all entries.
+    tree, so lookup and insertion are logarithmic in the number of entries. Values
+    may be linear; use :meth:`discard_empty` after removing or iterating over all
+    entries.
+
+    With constant-time key comparison, ``len`` is ``O(1)`` and lookup, insertion,
+    and a leaf-key removal are ``O(log n)``. Removing an internal key and draining
+    iteration currently rebuild the surviving tree, so their worst-case costs are
+    ``O(n log n)``; this is temporary until in-place internal-key rebalancing lands.
     """
 
     # A fixed pool keeps the whole data structure statically allocated. Nodes are
@@ -77,13 +90,16 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     _free_count: int
     _root: int
     _size: int
+    # These transient slots bridge public operations and helpers that need to move a
+    # key or value through the map without copying it. They are always `nothing` at
+    # API boundaries, which `discard_empty` verifies.
     _pending: Option[tuple[K, V]]
     _query: Option[K]
 
     @guppy
     @no_type_check
     def __len__(self) -> int:
-        """Returns the number of entries in the map."""
+        """Returns the number of entries in the map in ``O(1)`` time."""
         return self._size
 
     @guppy
@@ -91,7 +107,10 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     def __iter__[K: _Ord, V, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE] @ owned,
     ) -> BTreeMap[K, V, MAX_SIZE]:
-        """Consumes the map, yielding entries in ascending key order."""
+        """Consumes the map, yielding entries in ascending key order.
+
+        Complexity: ``O(n log n)`` overall until internal-key deletion is in place.
+        """
         return self
 
     @guppy
@@ -119,7 +138,7 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     def contains_key[K: _Ord, V, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE], key: K
     ) -> bool:
-        """Returns whether the map contains ``key``."""
+        """Returns whether the map contains ``key`` in ``O(log n)`` time."""
         _validate_key(key)
         self._query.swap(some(key)).unwrap_nothing()
         return _contains_key(self)
@@ -129,7 +148,13 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     def get[K: _Ord, V: Copy, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE], key: K
     ) -> Option[V]:
-        """Returns a copy of the value stored for ``key``, if present."""
+        """Returns a copy of the value stored for ``key``, if present.
+
+        The ``Copy`` bound is essential: the map retains its value, so a linear value
+        can only be obtained by ``remove`` or consuming iteration.
+
+        Complexity: ``O(log n)``.
+        """
         _validate_key(key)
         self._query.swap(some(key)).unwrap_nothing()
         return _get(self)
@@ -139,7 +164,10 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     def insert[K: _Ord, V, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE], key: K, value: V @ owned
     ) -> Option[V]:
-        """Stores ``value`` for ``key`` and returns a displaced value, if any."""
+        """Stores ``value`` for ``key`` and returns a displaced value, if any.
+
+        Complexity: ``O(log n)``.
+        """
         _validate_key(key)
         self._pending.swap(some((key, value))).unwrap_nothing()
         return _insert_pending(self)
@@ -149,7 +177,11 @@ class BTreeMap[K, V, MAX_SIZE: nat]:
     def remove[K: _Ord, V, MAX_SIZE: nat](
         self: BTreeMap[K, V, MAX_SIZE], key: K
     ) -> Option[V]:
-        """Removes and returns the value stored for ``key``, if present."""
+        """Removes and returns the value stored for ``key``, if present.
+
+        Complexity: ``O(log n)`` for a leaf key; ``O(n log n)`` worst case while
+        internal-key deletion uses its temporary rebuild path.
+        """
         _validate_key(key)
         location = _find(self, key)
         if location.is_nothing():
@@ -181,6 +213,10 @@ def _empty_node[K, V]() -> _Node[K, V]:
 @guppy
 @no_type_check
 def _validate_key[K: _Ord](key: K) -> None:
+    # Comparisons are dispatched explicitly rather than using operators because the
+    # private protocol is the source of these methods. This guard is shared by every
+    # public key operation, preventing a non-reflexive value (notably NaN) from
+    # entering the tree and making a later search path ambiguous.
     if not key.__eq__(key):
         panic("BTreeMap: key must be reflexive")
 
@@ -593,6 +629,8 @@ def _drain_except[K: _Ord, V, MAX_SIZE: nat](
 @guppy
 @no_type_check
 def _node_entry_index[K: _Ord, V](node: _Node[K, V], key: K) -> int:
+    # Lower-bound search: it returns either the matching entry or the child interval
+    # that can contain the key. Equality must stop the scan, not advance past it.
     entry_i = 0
     while entry_i < node._size:
         stored_key = _node_key(node, entry_i)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ miette-py = { workspace = true }
 # hugr = { git = "https://github.com/quantinuum/hugr", subdirectory = "hugr-py", rev = "a4da8ef" }
 # tket = { git = "https://github.com/quantinuum/tket2", subdirectory = "tket-py", rev = "cdb47dd" }
 
+[tool.ruff]
+target-version = "py312"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -209,12 +209,12 @@ def test_btree_map_iterates_in_ascending_key_order(run_int_fn) -> None:
 def test_btree_map_iteration_consumes_linear_values(run_int_fn) -> None:
     @guppy
     def main() -> int:
-        btree_map: BTreeMap[int, qubit, 3] = empty_btree_map()
-        marked = qubit()
-        x_gate(marked)
-        btree_map.insert(2, qubit()).unwrap_nothing()
-        btree_map.insert(0, qubit()).unwrap_nothing()
-        btree_map.insert(1, marked).unwrap_nothing()
+        btree_map: BTreeMap[int, qubit, 10] = empty_btree_map()
+        for i in range(10):
+            value = qubit()
+            if i == 4:
+                x_gate(value)
+            btree_map.insert(9 - i, value).unwrap_nothing()
 
         result = 0
         position = 1
@@ -224,8 +224,8 @@ def test_btree_map_iteration_consumes_linear_values(run_int_fn) -> None:
             position += 1
         return result
 
-    # The marked linear value has key 1, so ordered draining measures it second.
-    run_int_fn(main, 2, num_qubits=3)
+    # The marked linear value has key 5, so ordered draining measures it sixth.
+    run_int_fn(main, 6, num_qubits=10)
 
 
 def test_btree_map_supports_private_structural_ordering(run_int_fn) -> None:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -13,6 +13,8 @@ from guppylang.std.collections import (
 )
 import pytest
 from guppylang.emulator import EmulatorError
+from guppylang.std.quantum import qubit
+from guppylang_internals.error import GuppyError
 
 
 # `_Ord` is intentionally private. These structs exercise its current structural
@@ -64,6 +66,17 @@ def test_btree_map_insert_and_lookup(run_int_fn) -> None:
         return btree_map.get(7).unwrap() + 100 * len(btree_map)
 
     run_int_fn(main, 1014)
+
+
+def test_btree_map_get_rejects_linear_values() -> None:
+    @guppy
+    def main() -> None:
+        btree_map: BTreeMap[int, qubit, 1] = empty_btree_map()
+        btree_map.insert(0, qubit()).unwrap_nothing()
+        btree_map.get(0).unwrap().measure()
+
+    with pytest.raises(GuppyError, match="copyable type"):
+        main.compile_function()
 
 
 def test_btree_map_replaces_at_capacity(run_int_fn) -> None:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -1,3 +1,5 @@
+from typing import Self
+
 from guppylang import guppy
 from guppylang.std.collections import (
     BTreeMap,
@@ -11,6 +13,34 @@ from guppylang.std.collections import (
 )
 import pytest
 from guppylang.emulator import EmulatorError
+
+
+# `_Ord` is intentionally private. These structs exercise its current structural
+# compatibility only; exposing a public ordering protocol remains a TODO.
+@guppy.struct(frozen=True)
+class _CustomOrdKey:
+    value: int
+
+    @guppy
+    def __lt__(self, other: Self) -> bool:
+        return self.value < other.value
+
+    @guppy
+    def __eq__(self, other: Self) -> bool:
+        return self.value == other.value
+
+
+@guppy.struct(frozen=True)
+class _NonReflexiveKey:
+    value: int
+
+    @guppy
+    def __lt__(self, other: Self) -> bool:
+        return self.value < other.value
+
+    @guppy
+    def __eq__(self, other: Self) -> bool:
+        return self.value < other.value
 
 
 def test_btree_map_empty(run_int_fn) -> None:
@@ -116,6 +146,28 @@ def test_btree_map_iterates_in_ascending_key_order(run_int_fn) -> None:
         return result
 
     run_int_fn(main, sum((i + 1) * (10 * i + 9 - i) for i in range(10)))
+
+
+def test_btree_map_supports_private_structural_ordering(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[_CustomOrdKey, int, 3] = empty_btree_map()
+        btree_map.insert(_CustomOrdKey(2), 20).unwrap_nothing()
+        btree_map.insert(_CustomOrdKey(1), 10).unwrap_nothing()
+        return btree_map.get(_CustomOrdKey(1)).unwrap()
+
+    run_int_fn(main, 10)
+
+
+def test_btree_map_rejects_non_reflexive_private_key(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[_NonReflexiveKey, int, 1] = empty_btree_map()
+        btree_map.insert(_NonReflexiveKey(1), 1).unwrap_nothing()
+        return 0
+
+    with pytest.raises(EmulatorError, match="key must be reflexive"):
+        run_int_fn(main, 0)
 
 
 def test_stack(run_int_fn) -> None:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -71,6 +71,37 @@ def test_btree_map_rejects_nan_key(run_int_fn) -> None:
         run_int_fn(main, 0)
 
 
+def test_btree_map_remove_and_reinsert(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 10] = empty_btree_map()
+        for i in range(10):
+            btree_map.insert(i, i).unwrap_nothing()
+        removed = btree_map.remove(5).unwrap()
+        btree_map.remove(10).unwrap_nothing()
+        for i in range(5):
+            btree_map.remove(i).unwrap()
+        btree_map.insert(10, 20).unwrap_nothing()
+        return 100 * len(btree_map) + 10 * removed + btree_map.get(10).unwrap()
+
+    run_int_fn(main, 570)
+
+
+def test_btree_map_remove_all_and_discard_empty(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 10] = empty_btree_map()
+        for i in range(10):
+            btree_map.insert(i, i).unwrap_nothing()
+        for i in range(10):
+            btree_map.remove(i).unwrap()
+        size = len(btree_map)
+        btree_map.discard_empty()
+        return size
+
+    run_int_fn(main, 0)
+
+
 def test_stack(run_int_fn) -> None:
     @guppy
     def main() -> int:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -24,6 +24,53 @@ def test_btree_map_empty(run_int_fn) -> None:
     run_int_fn(main, 0)
 
 
+def test_btree_map_insert_and_lookup(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 10] = empty_btree_map()
+        for i in range(10):
+            btree_map.insert(i, i * 2).unwrap_nothing()
+        btree_map.get(10).unwrap_nothing()
+        return btree_map.get(7).unwrap() + 100 * len(btree_map)
+
+    run_int_fn(main, 1014)
+
+
+def test_btree_map_replaces_at_capacity(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 4] = empty_btree_map()
+        for i in range(4):
+            btree_map.insert(i, i).unwrap_nothing()
+        displaced = btree_map.insert(2, 10).unwrap()
+        return 100 * len(btree_map) + 10 * displaced + btree_map.get(2).unwrap()
+
+    run_int_fn(main, 430)
+
+
+def test_btree_map_float_keys_and_signed_zero(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[float, int, 3] = empty_btree_map()
+        btree_map.insert(-0.0, 1).unwrap_nothing()
+        displaced = btree_map.insert(0.0, 2).unwrap()
+        btree_map.insert(1.0 / 0.0, 3).unwrap_nothing()
+        return 100 * len(btree_map) + 10 * displaced + btree_map.get(-0.0).unwrap()
+
+    run_int_fn(main, 212)
+
+
+def test_btree_map_rejects_nan_key(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[float, int, 1] = empty_btree_map()
+        btree_map.insert(0.0 / 0.0, 1).unwrap_nothing()
+        return 0
+
+    with pytest.raises(EmulatorError, match="key must be reflexive"):
+        run_int_fn(main, 0)
+
+
 def test_stack(run_int_fn) -> None:
     @guppy
     def main() -> int:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -102,6 +102,22 @@ def test_btree_map_remove_all_and_discard_empty(run_int_fn) -> None:
     run_int_fn(main, 0)
 
 
+def test_btree_map_iterates_in_ascending_key_order(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 10] = empty_btree_map()
+        for i in range(10):
+            btree_map.insert(9 - i, i).unwrap_nothing()
+        result = 0
+        multiplier = 1
+        for key, value in btree_map:
+            result += multiplier * (10 * key + value)
+            multiplier += 1
+        return result
+
+    run_int_fn(main, sum((i + 1) * (10 * i + 9 - i) for i in range(10)))
+
+
 def test_stack(run_int_fn) -> None:
     @guppy
     def main() -> int:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -1,6 +1,8 @@
 from guppylang import guppy
 from guppylang.std.collections import (
+    BTreeMap,
     Stack,
+    empty_btree_map,
     empty_stack,
     PriorityQueue,
     empty_priority_queue,
@@ -9,6 +11,17 @@ from guppylang.std.collections import (
 )
 import pytest
 from guppylang.emulator import EmulatorError
+
+
+def test_btree_map_empty(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 3] = empty_btree_map()
+        size = len(btree_map)
+        btree_map.discard_empty()
+        return size
+
+    run_int_fn(main, 0)
 
 
 def test_stack(run_int_fn) -> None:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -56,6 +56,18 @@ def test_btree_map_empty(run_int_fn) -> None:
     run_int_fn(main, 0)
 
 
+def test_btree_map_iterates_empty(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 3] = empty_btree_map()
+        result = 0
+        for _key, _value in btree_map:
+            result += 1
+        return result
+
+    run_int_fn(main, 0)
+
+
 def test_btree_map_insert_and_lookup(run_int_fn) -> None:
     @guppy
     def main() -> int:
@@ -89,6 +101,19 @@ def test_btree_map_replaces_at_capacity(run_int_fn) -> None:
         return 100 * len(btree_map) + 10 * displaced + btree_map.get(2).unwrap()
 
     run_int_fn(main, 430)
+
+
+def test_btree_map_rejects_distinct_key_at_capacity(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 3] = empty_btree_map()
+        for i in range(3):
+            btree_map.insert(i, i).unwrap_nothing()
+        btree_map.insert(3, 3).unwrap_nothing()
+        return 0
+
+    with pytest.raises(EmulatorError, match=r"BTreeMap.insert: max size reached"):
+        run_int_fn(main, 0)
 
 
 def test_btree_map_float_keys_and_signed_zero(run_int_fn) -> None:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -13,7 +13,7 @@ from guppylang.std.collections import (
 )
 import pytest
 from guppylang.emulator import EmulatorError
-from guppylang.std.quantum import qubit
+from guppylang.std.quantum import qubit, x as x_gate
 from guppylang_internals.error import GuppyError
 
 
@@ -145,6 +145,51 @@ def test_btree_map_remove_all_and_discard_empty(run_int_fn) -> None:
     run_int_fn(main, 0)
 
 
+def test_btree_map_deletion_rebalances_and_collapses_root(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 20] = empty_btree_map()
+        for i in range(20):
+            btree_map.insert(i, i).unwrap_nothing()
+
+        total = 0
+        # Deleting from both outer ranges makes top-down deletion borrow from both
+        # sides where possible, then merge minimum-sized siblings as they empty.
+        for i in range(7):
+            total += btree_map.remove(i).unwrap()
+        for i in range(7):
+            total += btree_map.remove(19 - i).unwrap()
+        for i in range(7, 13):
+            total += btree_map.remove(i).unwrap()
+
+        btree_map.discard_empty()
+        return total
+
+    run_int_fn(main, sum(range(20)))
+
+
+def test_btree_map_reuses_nodes_after_deletion(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, int, 10] = empty_btree_map()
+        for i in range(10):
+            btree_map.insert(i, i).unwrap_nothing()
+        for i in range(10):
+            btree_map.remove(i).unwrap()
+
+        # A second full tree must be able to allocate every slot released by the
+        # first tree, including nodes released by merges and root collapse.
+        for i in range(10):
+            btree_map.insert(10 + i, 10 + i).unwrap_nothing()
+        total = 0
+        for i in range(10):
+            total += btree_map.remove(10 + i).unwrap()
+        btree_map.discard_empty()
+        return total
+
+    run_int_fn(main, sum(range(10, 20)))
+
+
 def test_btree_map_iterates_in_ascending_key_order(run_int_fn) -> None:
     @guppy
     def main() -> int:
@@ -159,6 +204,28 @@ def test_btree_map_iterates_in_ascending_key_order(run_int_fn) -> None:
         return result
 
     run_int_fn(main, sum((i + 1) * (10 * i + 9 - i) for i in range(10)))
+
+
+def test_btree_map_iteration_consumes_linear_values(run_int_fn) -> None:
+    @guppy
+    def main() -> int:
+        btree_map: BTreeMap[int, qubit, 3] = empty_btree_map()
+        marked = qubit()
+        x_gate(marked)
+        btree_map.insert(2, qubit()).unwrap_nothing()
+        btree_map.insert(0, qubit()).unwrap_nothing()
+        btree_map.insert(1, marked).unwrap_nothing()
+
+        result = 0
+        position = 1
+        for _key, value in btree_map:
+            if value.measure():
+                result += position
+            position += 1
+        return result
+
+    # The marked linear value has key 1, so ordered draining measures it second.
+    run_int_fn(main, 2, num_qubits=3)
 
 
 def test_btree_map_supports_private_structural_ordering(run_int_fn) -> None:

--- a/tests/integration/std/test_collections.py
+++ b/tests/integration/std/test_collections.py
@@ -76,7 +76,7 @@ def test_btree_map_get_rejects_linear_values() -> None:
         btree_map.get(0).unwrap().measure()
 
     with pytest.raises(GuppyError, match="copyable type"):
-        main.compile_function()
+        main.check()
 
 
 def test_btree_map_replaces_at_capacity(run_int_fn) -> None:


### PR DESCRIPTION
Closes #2082

Codex made

## Summary

- Add a `BTreeMap` collection to the Guppy standard library
- Export the collection through `std.collections`
- Add integration coverage and project configuration updates

## Testing

- Added integration tests for `BTreeMap` behavior

## Open questions
- Should this PR introduce the Ord protocol publicly?
- Tests are very slow - revisit after august'26 performance improvements