### PR TITLE
feat: re-enable non-local edges (revert #962)

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -682,16 +682,14 @@ class BBLinearityChecker(ast.NodeVisitor):
             # Recursively check the remaining generators
             self._check_comprehension(gens, elt)
 
-            # Look for any variables that are used from the outer scope. This is so we
-            # can feed them through the loop. Note that we could also use non-local
-            # edges, but we can't handle them in lower parts of the stack yet :/
-            # TODO: Reinstate use of non-local edges.
-            #  See https://github.com/quantinuum/guppylang/issues/963
+            # Look for any variables that are *borrowed* from the outer scope. These
+            # must be fed through the loop since we mutate them. Copyable values that
+            # are merely used rely on non-local edges instead of being threaded in.
             gen.used_outer_places = []
             for x, use in inner_scope.used_parent.items():
-                place = inner_scope[x]
-                gen.used_outer_places.append(place)
                 if use.kind == UseKind.BORROW:
+                    place = inner_scope[x]
+                    gen.used_outer_places.append(place)
                     # Since `x` was borrowed, we know that is now also assigned in the
                     # inner scope since it gets reassigned in the local scope after the
                     # borrow expires.

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -194,18 +194,24 @@ def choose_vars_for_tuple_sum(
         [[v.ty.to_hugr(dfg.ctx) for v in var_row] for var_row in output_vars]
     )
 
-    # We pass all values into the conditional instead of relying on non-local edges.
-    # This is because we can't handle them in lower parts of the stack yet :/
-    # TODO: Reinstate use of non-local edges.
-    #  See https://github.com/quantinuum/guppylang/issues/963
-    all_vars = {v.id: dfg[v] for var_row in output_vars for v in var_row}
-    all_vars_wires = list(all_vars.values())
-    all_vars_idxs = {x: i for i, x in enumerate(all_vars.keys())}
+    # Non-copyable types must be passed into the conditional since we can't use
+    # inter-graph (non-local) edges to feed them in implicitly. Copyable values are
+    # read directly from the enclosing DFG via non-local edges instead of being
+    # threaded through the conditional's input signature.
+    non_copyable = {
+        v.id: dfg[v] for var_row in output_vars for v in var_row if not v.ty.copyable
+    }
+    non_copyable_wires = list(non_copyable.values())
+    non_copyable_idxs = {x: i for i, x in enumerate(non_copyable.keys())}
 
-    with dfg.builder.add_conditional(unit_sum, *all_vars_wires) as conditional:
+    with dfg.builder.add_conditional(unit_sum, *non_copyable_wires) as conditional:
         for i, var_row in enumerate(output_vars):
             case = conditional.add_case(i)
-            outputs = [case.inputs()[all_vars_idxs[v.id]] for v in var_row]
+            case_inputs = case.inputs()
+            outputs = [
+                dfg[v] if v.ty.copyable else case_inputs[non_copyable_idxs[v.id]]
+                for v in var_row
+            ]
             tag = case.add_op(ops.Tag(i, sum_type), *outputs)
             case.set_outputs(tag)
         return conditional


### PR DESCRIPTION
Reverts the temporary #962 hack now that qis-compiler (0.4.x) lowers non-local edges again — see Quantinuum/hugr#3169.

Non-copyable places go back on non-local edges instead of being packed through the `Conditional`/`TailLoop` signatures. Partial win on its own (alloca −2.3–3.9x, opt-2 compile −1.6–2.3x on an `or`-chain); the CFG block-signature O(W²) is handled in the PR stacked on top.
