### PR TITLE
feat: de-thread copyable CFG values via non-local Dom edges

### DIFF
--- a/guppylang-internals/src/guppylang_internals/cfg/analysis.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/analysis.py
@@ -7,6 +7,9 @@ from guppylang_internals.cfg.bb import BB, VariableStats, VId
 # Type variable for the lattice domain
 T = TypeVar("T")
 
+# Type variable for basic blocks (used by the structural analyses below)
+BBT = TypeVar("BBT", bound=BB)
+
 # Analysis result is a mapping from basic blocks to lattice values
 Result = dict[BB, T]
 
@@ -230,3 +233,89 @@ class AssignmentAnalysis(ForwardAnalysis[AssignmentDomain[VId]], Generic[VId]):
         """Runs the analysis and unpacks the definite- and maybe-assignment results."""
         res = self.run(bbs)
         return {bb: res[bb][0] for bb in res}, {bb: res[bb][1] for bb in res}
+
+
+def reverse_postorder(entry: BBT) -> list[BBT]:
+    """Returns the basic blocks reachable from `entry` in reverse postorder.
+
+    In reverse postorder every block appears before all blocks it strictly
+    dominates, which makes it a convenient order for propagating values from a
+    definition to its (dominated) uses.
+    """
+    visited: set[BBT] = {entry}
+    postorder: list[BBT] = []
+    stack: list[tuple[BBT, Iterable[BBT]]] = [(entry, iter(entry.successors))]
+    while stack:
+        bb, succs = stack[-1]
+        for succ in succs:
+            if succ not in visited:
+                visited.add(succ)
+                stack.append((succ, iter(succ.successors)))
+                break
+        else:
+            postorder.append(bb)
+            stack.pop()
+    postorder.reverse()
+    return postorder
+
+
+def compute_dominators(entry: BBT) -> dict[BBT, frozenset[BBT]]:
+    """Computes the dominator set of every basic block reachable from `entry`.
+
+    A block `d` *dominates* a block `b` if every path from the entry to `b` goes
+    through `d` (every block dominates itself). Uses the standard iterative
+    data-flow fixpoint:
+
+        dom(entry) = {entry}
+        dom(b)     = {b} | intersection(dom(p) for p in preds(b))
+    """
+    rpo = reverse_postorder(entry)
+    all_bbs: set[BBT] = set(rpo)
+    dom: dict[BBT, set[BBT]] = {bb: set(all_bbs) for bb in rpo}
+    dom[entry] = {entry}
+    changed = True
+    while changed:
+        changed = False
+        for bb in rpo:
+            if bb is entry:
+                continue
+            preds = [p for p in bb.predecessors if p in all_bbs]
+            new_dom = set(all_bbs)
+            for pred in preds:
+                new_dom &= dom[pred]
+            new_dom.add(bb)
+            if new_dom != dom[bb]:
+                dom[bb] = new_dom
+                changed = True
+    return {bb: frozenset(doms) for bb, doms in dom.items()}
+
+
+def loop_blocks(entry: BBT) -> set[BBT]:
+    """Returns the basic blocks that lie within a natural loop.
+
+    A block is in a loop if it belongs to the body of some back-edge `n -> h`
+    (an edge whose head `h` dominates its tail `n`). Such blocks may execute more
+    than once per execution of a dominating definition, which matters for
+    analyses that deliver a value along a non-local edge.
+    """
+    dominators = compute_dominators(entry)
+    result: set[BBT] = set()
+    for bb in dominators:
+        for succ in bb.successors:
+            # `bb -> succ` is a back-edge iff its head `succ` dominates `bb`.
+            if succ in dominators and succ in dominators[bb]:
+                result |= _natural_loop_body(succ, bb)
+    return result
+
+
+def _natural_loop_body(header: BBT, tail: BBT) -> set[BBT]:
+    """The body of the natural loop of back-edge `tail -> header`."""
+    body: set[BBT] = {header, tail}
+    stack: list[BBT] = [tail]
+    while stack:
+        bb = stack.pop()
+        for pred in bb.predecessors:
+            if pred not in body:
+                body.add(pred)
+                stack.append(pred)
+    return body

--- a/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/cfg_compiler.py
@@ -1,18 +1,25 @@
+import ast
 import functools
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass, field
 
 from hugr import Wire, ops
 from hugr import tys as ht
 from hugr.build import cfg as hc
 from hugr.hugr.node_port import ToNode
 
+from guppylang_internals.cfg.analysis import (
+    compute_dominators,
+    loop_blocks,
+    reverse_postorder,
+)
 from guppylang_internals.checker.cfg_checker import (
     CheckedBB,
     CheckedCFG,
     Row,
     Signature,
 )
-from guppylang_internals.checker.core import Place, Variable
+from guppylang_internals.checker.core import Place, PlaceId, Variable
 from guppylang_internals.compiler.builder import BlockBuilder, DFBuilder
 from guppylang_internals.compiler.core import (
     CompilerContext,
@@ -22,7 +29,226 @@ from guppylang_internals.compiler.core import (
 )
 from guppylang_internals.compiler.expr_compiler import ExprCompiler
 from guppylang_internals.compiler.stmt_compiler import StmtCompiler
-from guppylang_internals.tys.ty import type_to_row
+from guppylang_internals.nodes import (
+    ArrayUnpack,
+    IterableUnpack,
+    ModifiedBlock,
+    PlaceNode,
+    TupleUnpack,
+    UnpackPattern,
+)
+from guppylang_internals.std._internal.compiler.tket_exts import MEASUREMENT_EXTENSION
+from guppylang_internals.tys.ty import StructType, TupleType, type_to_row
+
+_MEASUREMENT_HUGR_TYPE: ht.Type = ht.ExtType(
+    MEASUREMENT_EXTENSION.get_type("Measurement")
+)
+
+
+def _is_dethreadable_place(place: Place, ctx: CompilerContext) -> bool:
+    """Whether a place is a candidate for non-local (Dom-edge) de-threading.
+
+    We bypass block signatures for *copyable scalar* variables: copyable so the
+    value can be duplicated across a non-local edge, and scalar (not a struct or
+    tuple) so that its wire is stored directly and delivering it never inserts
+    extra pack/unpack ops. Linear values must stay threaded (they can't be
+    duplicated), and return variables are handled separately by the exit block.
+
+    Copyability is checked at the *Hugr* level too, not just guppy's
+    `Type.copyable`, so a value that lowers to a linear Hugr type is never
+    de-threaded.
+
+    `Measurement` is the known edge case we explicitly exclude (see the comment
+    on the check below): it is copyable in the surface language but the Helios QIS
+    lowering treats it as linear on a non-local edge.
+    """
+    if not (
+        isinstance(place, Variable)
+        and not is_return_var(place.name)
+        and place.ty.copyable
+        and not isinstance(place.ty, StructType | TupleType)
+    ):
+        return False
+    hugr_ty = place.ty.to_hugr(ctx)
+    # `Measurement` is really a *future* that guppy auto-copies at the surface
+    # level (so `Type.copyable` and the Hugr type bound both report copyable), yet
+    # the Helios QIS lowering still treats it as linear and rejects it on a
+    # non-local edge ("Cannot add nonlocal edge for linear type"). Exclude it as a
+    # narrow, type-specific carve-out rather than a general type restriction.
+    # TODO: Drop this carve-out once Quantinuum/tket2#1883 (type-scoped
+    # LocalizeEdges for linearised non-local edges) lands.
+    return (
+        hugr_ty.type_bound() == ht.TypeBound.Copyable
+        and hugr_ty != _MEASUREMENT_HUGR_TYPE
+    )
+
+
+def _target_place_ids(target: ast.expr) -> Iterator[PlaceId]:
+    """Yields the place ids assigned by an assignment target expression."""
+    match target:
+        case PlaceNode(place=place):
+            yield place.id
+        case TupleUnpack(pattern=pattern) | ArrayUnpack(pattern=pattern):
+            yield from _pattern_place_ids(pattern)
+        case IterableUnpack(pattern=pattern):
+            yield from _pattern_place_ids(pattern)
+        case ast.Tuple(elts=elts) | ast.List(elts=elts):
+            for elt in elts:
+                yield from _target_place_ids(elt)
+        case ast.Starred(value=value):
+            yield from _target_place_ids(value)
+        case _:
+            return
+
+
+def _pattern_place_ids(pattern: UnpackPattern) -> Iterator[PlaceId]:
+    for elt in pattern.left:
+        yield from _target_place_ids(elt)
+    if pattern.starred is not None:
+        yield from _target_place_ids(pattern.starred)
+    for elt in pattern.right:
+        yield from _target_place_ids(elt)
+
+
+def _assigned_place_ids(bb: CheckedBB[Place]) -> set[PlaceId]:
+    """The place ids that are (re)assigned by the statements of a basic block.
+
+    This walks assignment targets directly, since the checked statements use
+    `PlaceNode` targets that the name-based `VariableStats` visitor doesn't see.
+    Crucially it catches loop-carried reassignments (a place that a block both
+    reads and writes), which the block signature alone cannot distinguish from a
+    pass-through. Over-approximating here is safe: an extra apparent definition
+    only makes us keep threading a place.
+    """
+    assigned: set[PlaceId] = set()
+
+    def visit(stmt: ast.stmt) -> None:
+        match stmt:
+            case ast.Assign(targets=targets):
+                for target in targets:
+                    assigned.update(_target_place_ids(target))
+            case ast.AnnAssign(target=target) | ast.AugAssign(target=target):
+                assigned.update(_target_place_ids(target))
+            case ModifiedBlock(body=body):
+                for inner in body:
+                    visit(inner)
+            case _:
+                return
+
+    for stmt in bb.statements:
+        visit(stmt)
+    return assigned
+
+
+@dataclass(frozen=True)
+class DethreadInfo:
+    """Result of the de-threading analysis for a CFG.
+
+    Records which places should be delivered via non-local Dom edges instead of
+    being threaded through block signatures, together with the (unique) block
+    that defines each such place.
+    """
+
+    #: The `PlaceId`s that should bypass block signatures.
+    ids: frozenset[PlaceId] = field(default_factory=frozenset)
+    #: The unique defining block for each de-threaded place.
+    def_block: dict[PlaceId, CheckedBB[Place]] = field(default_factory=dict)
+    #: A representative `Place` object for each de-threaded id.
+    place: dict[PlaceId, Place] = field(default_factory=dict)
+
+    def defined_in(self, bb: CheckedBB[Place]) -> list[Place]:
+        """The de-threaded places whose definition lives in `bb`."""
+        return [self.place[i] for i, d in self.def_block.items() if d is bb]
+
+
+def compute_dethread_info(cfg: CheckedCFG[Place], ctx: CompilerContext) -> DethreadInfo:
+    """Determines which copyable places can be de-threaded via Dom edges.
+
+    A place is de-threaded when it is a copyable scalar variable with a *single*
+    definition whose block *strictly dominates* every block in which the place is
+    live. In guppy's reducible CFGs this is exactly the "live but unused in this
+    block" pass-through case (e.g. the booleans of a short-circuiting `or` chain)
+    that otherwise blows up block signatures to O(W^2).
+    """
+    dominators = compute_dominators(cfg.entry_bb)
+    # Blocks inside a loop may execute multiple times. Delivering a value into
+    # such a block via a single non-local edge from a dominating definition is
+    # semantically fine for copyable values, but some backends (e.g. the Helios
+    # QIS lowering) cannot lower a non-local edge whose target executes more than
+    # once for resource-like copyable types. Staying conservative here also keeps
+    # us clearly correct, so we never de-thread a value used inside a loop.
+    in_loop = loop_blocks(cfg.entry_bb)
+
+    # Collect, per place id: the blocks where it is live-in, the blocks that
+    # define it, and a representative place object.
+    live_in: dict[PlaceId, set[CheckedBB[Place]]] = {}
+    defs: dict[PlaceId, set[CheckedBB[Place]]] = {}
+    place_obj: dict[PlaceId, Place] = {}
+    eligible: set[PlaceId] = set()
+
+    def note(place: Place) -> None:
+        if place.id not in place_obj:
+            place_obj[place.id] = place
+            if _is_dethreadable_place(place, ctx):
+                eligible.add(place.id)
+
+    for bb in cfg.bbs:
+        if bb not in dominators:
+            # Unreachable block that wasn't visited from the entry: ignore it.
+            continue
+        in_ids = {p.id for p in bb.sig.input_row}
+        for place in bb.sig.input_row:
+            note(place)
+            live_in.setdefault(place.id, set()).add(bb)
+        # The entry block defines its inputs (the function arguments).
+        if bb is cfg.entry_bb:
+            for place in bb.sig.input_row:
+                defs.setdefault(place.id, set()).add(bb)
+        # A block defines every place that is live on the way out but wasn't live
+        # on the way in...
+        for row in bb.sig.output_rows:
+            for place in row:
+                note(place)
+                if place.id not in in_ids:
+                    defs.setdefault(place.id, set()).add(bb)
+        # ...as well as every place it (re)assigns via a statement. The latter is
+        # essential for loop-carried values, which a block both reads and writes
+        # (so they show up in both its input and output rows and are invisible to
+        # the signature check above).
+        for pid in _assigned_place_ids(bb):
+            defs.setdefault(pid, set()).add(bb)
+
+    ids: set[PlaceId] = set()
+    def_block: dict[PlaceId, CheckedBB[Place]] = {}
+    # Places that are live into the exit block are CFG outputs (return values).
+    # The exit's expected input types are fixed independently of the block
+    # signatures, so these must always be delivered by normal threading.
+    exit_ids = {p.id for p in cfg.exit_bb.sig.input_row}
+    for pid in eligible - exit_ids:
+        def_blocks = defs.get(pid, set())
+        if len(def_blocks) != 1:
+            # No definition, or multiple (e.g. phi-merge on divergent branches):
+            # keep threading to stay correct.
+            continue
+        (definition,) = def_blocks
+        # The definition must strictly dominate every block where the place is
+        # live (so a Dom edge from the definition is always valid), and no use may
+        # sit inside a loop (see `in_loop` above).
+        uses = live_in.get(pid, set())
+        if any(use in in_loop for use in uses):
+            continue
+        if all(
+            use is definition or definition in dominators.get(use, frozenset())
+            for use in uses
+        ):
+            ids.add(pid)
+            def_block[pid] = definition
+
+    return DethreadInfo(
+        ids=frozenset(ids),
+        def_block=def_block,
+        place={pid: place_obj[pid] for pid in ids},
+    )
 
 
 def compile_cfg(
@@ -57,9 +283,28 @@ def compile_cfg(
         builder.parent_node, len(out_tys)
     )
 
+    # Figure out which copyable values can bypass block signatures via Dom edges.
+    dethread = compute_dethread_info(cfg, ctx)
+    # Wires of de-threaded places, keyed by place id, populated as their defining
+    # block is compiled. Blocks are compiled in reverse postorder so that a
+    # definition is always compiled before the (dominated) blocks that use it.
+    dethreaded_wires: dict[PlaceId, Wire] = {}
+
+    ordered_bbs = reverse_postorder(cfg.entry_bb)
+    seen = set(ordered_bbs)
+    ordered_bbs += [bb for bb in cfg.bbs if bb not in seen]
+
     blocks: dict[CheckedBB[Place], ToNode] = {}
-    for bb in cfg.bbs:
-        blocks[bb] = compile_bb(bb, builder, container, bb == cfg.entry_bb, ctx)
+    for bb in ordered_bbs:
+        blocks[bb] = compile_bb(
+            bb,
+            builder,
+            container,
+            bb == cfg.entry_bb,
+            ctx,
+            dethread,
+            dethreaded_wires,
+        )
     for bb in cfg.bbs:
         for i, succ in enumerate(bb.successors):
             builder.branch(blocks[bb][i], blocks[succ])
@@ -73,11 +318,18 @@ def compile_bb(
     outer: DFBuilder,
     is_entry: bool,
     ctx: CompilerContext,
+    dethread: DethreadInfo | None = None,
+    dethreaded_wires: dict[PlaceId, Wire] | None = None,
 ) -> ToNode:
     """Compiles a single basic block to Hugr.
 
     If the basic block is the output block, returns `None`.
     """
+    if dethread is None:
+        dethread = DethreadInfo()
+    if dethreaded_wires is None:
+        dethreaded_wires = {}
+
     # The exit BB is completely empty
     if bb.is_exit:
         assert len(bb.statements) == 0
@@ -86,6 +338,14 @@ def compile_bb(
     # Unreachable BBs (besides the exit) should have been removed by now
     assert bb.reachable
 
+    def keep(place: Place) -> bool:
+        return place.id not in dethread.ids
+
+    # De-threaded places bypass the block signature. The entry block keeps its
+    # full input row since that is the function signature; other blocks drop the
+    # de-threaded places, which are instead pulled in via Dom edges.
+    output_rows = [[p for p in row if keep(p)] for row in bb.sig.output_rows]
+
     # Otherwise, we use a regular `Block` node
     hugr_block: hc.Block
     inputs: Sequence[Place]
@@ -93,14 +353,25 @@ def compile_bb(
         inputs = bb.sig.input_row
         hugr_block = builder.add_entry()
     else:
-        inputs = sort_vars(bb.sig.input_row)
+        inputs = sort_vars([p for p in bb.sig.input_row if keep(p)])
         hugr_block = builder.add_block(*(v.ty.to_hugr(ctx) for v in inputs))
     block = BlockBuilder(hugr_block, builder, outer)
     # Add input node and compile the statements
     dfg = DFContainer(block, ctx)
     for v, wire in zip(inputs, block.input_node, strict=True):
         dfg[v] = wire
+    # Supply de-threaded places that are live here but defined in a dominating
+    # block by referencing that block's wire. hugr-py turns this into a non-local
+    # Dom edge when the value is actually used.
+    for place in bb.sig.input_row:
+        if place.id in dethread.ids and dethread.def_block.get(place.id) is not bb:
+            dfg[place] = dethreaded_wires[place.id]
     dfg = StmtCompiler(ctx).compile_stmts(bb.statements, dfg)
+
+    # Record wires for de-threaded places defined in this block so that dominated
+    # blocks can pull them in.
+    for place in dethread.defined_in(bb):
+        dethreaded_wires[place.id] = dfg[place]
 
     # If we branch, we also have to compile the branch predicate
     if len(bb.successors) > 1:
@@ -117,7 +388,7 @@ def compile_bb(
     if len(bb.successors) == 1:
         # The easy case is if we don't branch: We just output all variables that are
         # specified by the signature
-        [outputs] = bb.sig.output_rows
+        [outputs] = output_rows
     else:
         # CFG building ensures that branching BBs don't branch to the exit (exit jumps
         # must always be unconditional)
@@ -125,7 +396,7 @@ def compile_bb(
 
         # If we branch and the branches use the same places, then we can use a
         # regular output
-        first, *rest = bb.sig.output_rows
+        first, *rest = output_rows
         if all({p.id for p in first} == {p.id for p in r} for r in rest):
             outputs = first
         else:
@@ -138,8 +409,7 @@ def compile_bb(
             branch_port = choose_vars_for_tuple_sum(
                 unit_sum=branch_port,
                 output_vars=[
-                    [v for v in sort_vars(row) if v.ty.droppable]
-                    for row in bb.sig.output_rows
+                    [v for v in sort_vars(row) if v.ty.droppable] for row in output_rows
                 ],
                 dfg=dfg,
             )

--- a/tests/integration/test_nonlocal_dethread.py
+++ b/tests/integration/test_nonlocal_dethread.py
@@ -1,0 +1,221 @@
+"""Tests for non-local (Dom-edge) de-threading of copyable values across CFG
+basic blocks.
+
+For a short-circuiting ``if b0 or b1 or ... or b(W-1):`` chain, guppy used to
+thread every still-live boolean through the input/output signature of every
+intervening basic block, giving O(W^2) total block-signature width (and O(W^2)
+LLVM struct packing). Copyable values whose single definition strictly dominates
+all their uses should instead be delivered via non-local Dom edges, keeping each
+block signature O(1) and the total O(W).
+
+Besides the positive O(W) win, these tests pin down that the gate stays
+*conservative*: a value that is reassigned on one branch (multiple definitions)
+or that is live across a loop back-edge must stay threaded, so a future
+too-aggressive gate cannot silently bypass a value it shouldn't. The
+array-packed variant is kept as a control so the block-width measurement can't be
+fooled by single-wire packing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+from pathlib import Path
+
+from hugr import ops
+
+import guppylang_internals.compiler.cfg_compiler as cfg_compiler
+
+
+def _compile_src(src: str, fn_name: str = "f", *, capture: bool = False):
+    """Compile a guppy function from source, optionally capturing which places
+    were de-threaded.
+
+    Returns ``(package, dethreaded_names)`` where ``dethreaded_names`` is the set
+    of variable names delivered via Dom edges (empty when ``capture`` is False).
+    """
+    dethreaded_names: set[str] = set()
+    original = cfg_compiler.compute_dethread_info
+
+    def spy(cfg, ctx):
+        info = original(cfg, ctx)
+        for place_id in info.ids:
+            dethreaded_names.add(info.place[place_id].name)
+        return info
+
+    if capture:
+        cfg_compiler.compute_dethread_info = spy
+    try:
+        tmp = Path(tempfile.mkdtemp()) / "mod.py"
+        tmp.write_text(src)
+        spec = importlib.util.spec_from_file_location(tmp.stem, tmp)
+        assert spec is not None
+        assert spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        pkg = getattr(mod, fn_name).compile_function()
+    finally:
+        cfg_compiler.compute_dethread_info = original
+    return pkg, dethreaded_names
+
+
+def _or_chain_src(w: int) -> str:
+    """``if b0 or b1 or ... or b(W-1):`` over W separate scalar bools.
+
+    The booleans are derived *inside* the function (as in the real user code,
+    where they come from separate measurements) so that they are all defined in
+    the entry block rather than being function parameters. This keeps W
+    *separate* scalar booleans (not an array, which would pack them into a single
+    wire and hide the threading) while exercising the cross-block threading that
+    the entry function signature would otherwise mask.
+    """
+    defs = "\n".join(f"    b{i} = x > {i}" for i in range(w))
+    terms = " or ".join(f"b{i}" for i in range(w))
+    return f"""
+from guppylang.decorator import guppy
+
+
+@guppy
+def f(x: int) -> int:
+{defs}
+    if {terms}:
+        return 1
+    return 0
+"""
+
+
+def _array_or_chain_src(w: int) -> str:
+    """The same or-chain but with the bools packed into a single array wire."""
+    elems = ", ".join(f"x > {i}" for i in range(w))
+    terms = " or ".join(f"bs[{i}]" for i in range(w))
+    return f"""
+from guppylang.decorator import guppy
+from guppylang.std.builtins import array
+
+
+@guppy
+def f(x: int) -> int:
+    bs = array({elems})
+    if {terms}:
+        return 1
+    return 0
+"""
+
+
+def _compile_or_chain(w: int):
+    pkg, _ = _compile_src(_or_chain_src(w))
+    return pkg
+
+
+def _block_input_widths(pkg) -> list[int]:
+    hugr = pkg.modules[0]
+    return [
+        len(data.op.inputs)
+        for _node, data in hugr.nodes()
+        if isinstance(data.op, ops.DataflowBlock)
+    ]
+
+
+def test_or_chain_block_signatures_are_linear():
+    """The per-block signature widths for an or-chain must stay O(1), so the
+    total stays O(W) rather than the previous triangular O(W^2)."""
+    for w in (8, 16, 32):
+        widths = _block_input_widths(_compile_or_chain(w))
+        assert widths, "expected some DataflowBlocks in the or-chain CFG"
+        # De-threaded: no boolean is carried through a block signature it doesn't
+        # need, so every block signature is a small constant width.
+        assert max(widths) <= 2, (
+            f"W={w}: max block-input width {max(widths)} grows with W "
+            f"(widths={sorted(widths)})"
+        )
+        # Total across all blocks is linear in W, not quadratic.
+        assert sum(widths) <= 2 * w, (
+            f"W={w}: total block-input width {sum(widths)} looks super-linear "
+            f"(widths={sorted(widths)})"
+        )
+
+
+def test_or_chain_bools_are_dethreaded():
+    """The single-def, dominating or-chain booleans are the values we expect to
+    deliver via Dom edges.
+
+    ``b0`` is consumed in the entry block (it is the first branch predicate) so it
+    never crosses a block signature and is not a de-thread candidate. Every later
+    bool ``b1..b(W-1)`` is defined in the entry block yet used in a later block,
+    so each must be de-threaded rather than threaded through the chain."""
+    w = 8
+    _pkg, dethreaded = _compile_src(_or_chain_src(w), capture=True)
+    expected = {f"b{i}" for i in range(1, w)}
+    assert expected <= dethreaded, (
+        f"expected every crossing or-chain bool to be de-threaded, "
+        f"missing {sorted(expected - dethreaded)} (de-threaded={sorted(dethreaded)})"
+    )
+
+
+def test_reassigned_bool_stays_threaded():
+    """A bool reassigned on one branch has multiple definitions, so no single
+    block dominates all uses: it must stay threaded (never de-threaded)."""
+    src = """
+from guppylang.decorator import guppy
+
+
+@guppy
+def f(x: int) -> int:
+    b = x > 0
+    if x > 3:
+        b = x > 10
+    if b:
+        return 1
+    return 0
+"""
+    _pkg, dethreaded = _compile_src(src, capture=True)
+    assert "b" not in dethreaded, (
+        f"reassigned bool `b` must stay threaded, but it was de-threaded "
+        f"(de-threaded={sorted(dethreaded)})"
+    )
+
+
+def test_loop_carried_bool_stays_threaded():
+    """A value live across a loop back-edge must stay threaded: de-threading it
+    would deliver it once from the dominator, but the conservative gate keeps it
+    on the block signatures."""
+    src = """
+from guppylang.decorator import guppy
+
+
+@guppy
+def f(x: int) -> int:
+    b = x > 0
+    acc = 0
+    i = 0
+    while i < 5:
+        if b:
+            acc = acc + 1
+        i = i + 1
+    return acc
+"""
+    _pkg, dethreaded = _compile_src(src, capture=True)
+    assert "b" not in dethreaded, (
+        f"loop-carried bool `b` must stay threaded, but it was de-threaded "
+        f"(de-threaded={sorted(dethreaded)})"
+    )
+
+
+def test_array_packed_or_chain_is_a_control():
+    """Non-regression control: when the bools are packed into a single array
+    wire there is no per-bool threading to remove, so block widths are already
+    O(1). This keeps the width-based measurement honest — small widths here come
+    from packing, not from de-threading."""
+    for w in (8, 16, 32):
+        pkg, dethreaded = _compile_src(_array_or_chain_src(w), capture=True)
+        widths = _block_input_widths(pkg)
+        assert widths, "expected some DataflowBlocks in the array or-chain CFG"
+        assert max(widths) <= 2, (
+            f"W={w}: array-packed max block-input width {max(widths)} unexpectedly "
+            f"grows with W (widths={sorted(widths)})"
+        )
+        # The single array wire is not a de-threadable scalar, so nothing named
+        # `bs` is delivered via a Dom edge.
+        assert "bs" not in dethreaded


### PR DESCRIPTION
Stacked on #2090.

Copyable values live across CFG blocks but only used past a dominating block were threaded through every intervening block signature — O(W²) in the width of e.g. an `if a or b or ...:` chain, which blows up LLVM (SLP/SCCP) to ~90min compiles in the worst cases.

Emit a non-local Dom edge from the defining block instead, gated on a strict single-def-dominates-all-uses check (linear, multi-def and loop-carried values stay threaded). Block-signature width goes O(W²)→O(W); on a 16×`if` / 48-bool repro opt-2 compile drops 20s→2.2s.

`Measurement` is carved out — it's future-like and the Helios QIS lowers it to a linear type, which can't ride a non-local edge. Tracked in Quantinuum/tket2#1883.
