### PR TITLE
docs: Document expected qubits in emulator API

### DIFF
--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -707,7 +707,7 @@ def expected_qubits(num: int) -> Any:
     .. code-block:: python
 
         from guppylang import guppy
-        from guppylang.decorator import expected_qubit
+        from guppylang.decorator import expected_qubits
 
         @guppy.declare
         @expected_qubits(2)

--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -14,7 +14,7 @@ outputs.
 Basic emulation
 -----------------
 
-Calling ``.emulator`` on a Guppy function compiles it into an
+Calling ``.emulator()`` on a Guppy function compiles it into an
 :py:class:`EmulatorInstance`. The method has a required parameter
 for the number of qubits to allocate. This cannot be inferred from the program
 fully automatically as it can request an arbitrary number of qubits at runtime.

--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -37,8 +37,8 @@ Calling ``.run()`` on the instance runs the emulation, returning an
 
 .. hint::
 
-    You can omit `n_qubits` from the `.emulator` call if you add the `@expected_qubits`
-    decorator to `foo`:
+    You can omit ``n_qubits`` from the ``.emulator()`` call if you add the
+    ``@expected_qubits`` decorator to ``foo``:
 
     .. code-block:: python
 

--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -16,9 +16,8 @@ Basic emulation
 
 Calling ``.emulator`` on a Guppy function compiles it into an
 :py:class:`EmulatorInstance`. The method has a required parameter
-for the number of qubits to allocate. This cannot be
-inferred from the program automatically as it can request an arbitrary number of qubits
-at runtime.
+for the number of qubits to allocate. This cannot be inferred from the program
+fully automatically as it can request an arbitrary number of qubits at runtime.
 
 Calling ``.run()`` on the instance runs the emulation, returning an
 :py:class:`EmulatorResult` object containing the results.
@@ -35,6 +34,22 @@ Calling ``.run()`` on the instance runs the emulation, returning an
         output("q", measure(q))
 
     foo.emulator(n_qubits=1).run()
+
+.. hint::
+
+    You can omit `n_qubits` from the `.emulator` call if you add the `@expected_qubits`
+    decorator to `foo`:
+
+    .. code-block:: python
+
+        from guppylang.decorator import expected_qubits
+
+        @guppy
+        @expected_qubits
+        def foo() -> None:
+            pass # ...
+
+        foo.emulator().run()
 
 Change simulation method
 --------------------------

--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -45,7 +45,7 @@ Calling ``.run()`` on the instance runs the emulation, returning an
         from guppylang.decorator import expected_qubits
 
         @guppy
-        @expected_qubits
+        @expected_qubits(1)
         def foo() -> None:
             pass # ...
 


### PR DESCRIPTION
Part way to https://github.com/Quantinuum/guppy-docs/issues/159 which we should resolve in this repository.

Integrated preview:
<img width="784" height="676" alt="image" src="https://github.com/user-attachments/assets/296edffb-8b88-41bb-b3a5-7d179b873afc" />
