### PR TITLE
chore: Upgrade pytest-notebook to fix compatibility with latest pytest

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ test = [
   "pytest-codspeed>=5.0.3",
   "pytest-cov>=5.0.0,<8",
   "pytest-forked>=1.6.0",
-  "pytest-notebook >=0.10.0,<0.11",
+  "pytest-notebook>=0.11.0",
   "pytest-snapshot >=0.9.0,<1",
   "pytest-xdist>=3.8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ lint = ["mypy~=2.1.0", "pre-commit>=4.6.0,<5", "ruff~=0.15.21"]
 test = [
   "ipykernel>=6.29.5,<8",
   "miette-py",
-  "pytest>=8.4.2,<9.1.0",
+  "pytest>=8.4.2",
   "pytest-benchmark>=5.1.0",
   "pytest-codspeed>=5.0.3",
   "pytest-cov>=5.0.0,<8",

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,7 @@ dev = [
     { name = "pytest-codspeed", specifier = ">=5.0.3" },
     { name = "pytest-cov", specifier = ">=5.0.0,<8" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
-    { name = "pytest-notebook", specifier = ">=0.10.0,<0.11" },
+    { name = "pytest-notebook", specifier = ">=0.11.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0,<1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = "~=0.15.21" },
@@ -56,7 +56,7 @@ test = [
     { name = "pytest-codspeed", specifier = ">=5.0.3" },
     { name = "pytest-cov", specifier = ">=5.0.0,<8" },
     { name = "pytest-forked", specifier = ">=1.6.0" },
-    { name = "pytest-notebook", specifier = ">=0.10.0,<0.11" },
+    { name = "pytest-notebook", specifier = ">=0.11.0" },
     { name = "pytest-snapshot", specifier = ">=0.9.0,<1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
 ]
@@ -2245,7 +2245,7 @@ wheels = [
 
 [[package]]
 name = "pytest-notebook"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -2255,9 +2255,9 @@ dependencies = [
     { name = "nbformat" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3e/03/8ea56929a6e0675d2c420555b3092c9a74a9a04e70417bcfe5b4b5ef1413/pytest_notebook-0.10.0.tar.gz", hash = "sha256:0a38a73b04c40137402b5f39a053395b418028cb3994a04dbcffe603c7b2a646", size = 3414910, upload-time = "2023-11-28T19:31:19.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/e9/7a675397afeef0e2b40c492124c88d56be4e9ef4987ab806ff198678d649/pytest_notebook-0.11.0.tar.gz", hash = "sha256:008aaa999421174e7945f1a0d8fa7a46bc9d84d961ce23182120be12baa17f8a", size = 3427246, upload-time = "2026-07-19T17:49:41.826Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/31/7ed17c3f929b0b7537ceaab0d06c7ce1d2ec56ddd9dd69306f8bfcd515e8/pytest_notebook-0.10.0-py3-none-any.whl", hash = "sha256:482ab2f8fbac6ecb417226e9b7e68476332262a03f555e49d89a164ee16581f6", size = 37694, upload-time = "2023-11-28T19:31:17.611Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ee/ad577a3c5a4d8ae894a9b67011e2c9edfd961e7e21dba0d3f2c4cf12e0ac/pytest_notebook-0.11.0-py3-none-any.whl", hash = "sha256:424418c3d8a34868f75a00e35ce3393b34ed2a0fe72f065d34f817938e896d84", size = 40087, upload-time = "2026-07-19T17:49:40.061Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ dev = [
     { name = "mypy", specifier = "~=2.1.0" },
     { name = "networkx", specifier = ">=2.6,<4" },
     { name = "pre-commit", specifier = ">=4.6.0,<5" },
-    { name = "pytest", specifier = ">=8.4.2,<9.1.0" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-codspeed", specifier = ">=5.0.3" },
     { name = "pytest-cov", specifier = ">=5.0.0,<8" },
@@ -51,7 +51,7 @@ lint = [
 test = [
     { name = "ipykernel", specifier = ">=6.29.5,<8" },
     { name = "miette-py", editable = "miette-py" },
-    { name = "pytest", specifier = ">=8.4.2,<9.1.0" },
+    { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-benchmark", specifier = ">=5.1.0" },
     { name = "pytest-codspeed", specifier = ">=5.0.3" },
     { name = "pytest-cov", specifier = ">=5.0.0,<8" },


### PR DESCRIPTION
Recently, `pytest-notebook` released a new version providing proper support for `pytest>=9.0.0` (including the version `9.1.0` which dropped a few deprecated symbols). By upgrading, we can loosen our bound on pytest.

Closes #1861