### PR TITLE
fix: Preserve generic parameters in modifier blocks

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/modifier_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/modifier_checker.py
@@ -53,7 +53,7 @@ def check_modified_block(
         cfg,
         inputs,
         NoneType(),
-        {},
+        ctx.generic_param_inst,
         "__modified__()",
         globals,
         # We pass the first modifier node for better error messages in the cfg checker

--- a/tests/integration/test_modifier_py312.py
+++ b/tests/integration/test_modifier_py312.py
@@ -1,7 +1,28 @@
 from guppylang.decorator import guppy
 
-from guppylang.std.builtins import Controllable, Daggerable, Unitary, control, dagger
+from guppylang.std.array import array
+from guppylang.std.builtins import (
+    Controllable,
+    Daggerable,
+    Unitary,
+    control,
+    dagger,
+    nat,
+)
 from guppylang.std.quantum import h, qubit
+
+
+def test_generic_nat_in_dagger(validate):
+    @guppy
+    def apply_dagger[n: nat](qs: array[qubit, n]) -> None:
+        with dagger:
+            h(qs[n - 1])
+
+    @guppy
+    def main(qs: array[qubit, 2]) -> None:
+        apply_dagger(qs)
+
+    validate(main.compile_function())
 
 
 def test_higher_order_daggerable_callable(validate):


### PR DESCRIPTION
Fixes #2079.
