### PR TITLE
fix!: Type args to Either/Result factory methods `right`/`err` same way round

### DIFF
--- a/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/compiler/either.py
@@ -61,13 +61,7 @@ class EitherConstructor(EitherCompiler, CustomCallCompiler):
 
     def compile(self, args: list[Wire]) -> list[Wire]:
         ty = self.either_ty
-        if self.tag == 1:
-            # In the `right` case, the type args are swapped around since `R` occurs
-            # first in the signature :(
-            ty.variant_rows = [ty.variant_rows[1], ty.variant_rows[0]]
-        # For the same reason, the type of the input corresponds to the first type
-        # variable
-        inp_arg = self.type_args[0]
+        inp_arg = self.type_args[self.tag]
         assert isinstance(inp_arg, TypeArg)
         [inp] = args
         # Unpack the single input into a row

--- a/guppylang/src/guppylang/std/either.py
+++ b/guppylang/src/guppylang/std/either.py
@@ -3,7 +3,7 @@
 Type `Either[L, R]` represents a value of either typr `L` ("left") or `R` ("right").
 """
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type
 from guppylang_internals.std._internal.compiler.either import (
@@ -27,7 +27,7 @@ _params = [TypeParam(0, "L", False, False), TypeParam(1, "L", False, False)]
 
 
 @custom_type(either_to_hugr, params=_params)
-class Either(Generic[L, R]):  # type: ignore[misc]
+class Either[L, R]:
     """Represents a union of either a `left` or a `right` value."""
 
     @custom_function(EitherTestCompiler(0))
@@ -83,5 +83,5 @@ def left(val: L @ owned) -> Either[L, R]:
 
 @custom_function(EitherConstructor(1))
 @no_type_check
-def right(val: R @ owned) -> Either[L, R]:
+def right[L, R](val: R @ owned) -> Either[L, R]:
     """Constructs a `right` either value."""

--- a/guppylang/src/guppylang/std/err.py
+++ b/guppylang/src/guppylang/std/err.py
@@ -1,6 +1,6 @@
 """Error handling with the `Result` type."""
 
-from typing import Generic, no_type_check
+from typing import no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type
 from guppylang_internals.definition.custom import NoopCompiler
@@ -23,7 +23,7 @@ _params = [TypeParam(0, "T", False, False), TypeParam(1, "E", False, False)]
 
 
 @custom_type(either_to_hugr, params=_params)
-class Result(Generic[T, E]):  # type: ignore[misc]
+class Result[T, E]:
     """Represents a union of either an `ok(T)` or an `err(E)` value."""
 
     @custom_function(EitherTestCompiler(0))
@@ -66,5 +66,5 @@ def ok(val: T @ owned) -> Result[T, E]:
 
 @custom_function(EitherConstructor(1))
 @no_type_check
-def err(err: E @ owned) -> Result[T, E]:
+def err[T, E](err: E @ owned) -> Result[T, E]:
     """Constructs an `err` result value."""

--- a/ruff.toml
+++ b/ruff.toml
@@ -86,6 +86,7 @@ ignore = [
 [per-file-target-version]
 "tests/*/*_py312.py" = "py312"
 "guppylang/src/guppylang/std/either.py" = "py312"
+"guppylang/src/guppylang/std/err.py" = "py312"
 
 # [pydocstyle]
 # convention = "google"

--- a/ruff.toml
+++ b/ruff.toml
@@ -85,6 +85,7 @@ ignore = [
 
 [per-file-target-version]
 "tests/*/*_py312.py" = "py312"
+"guppylang/src/guppylang/std/either.py" = "py312"
 
 # [pydocstyle]
 # convention = "google"

--- a/tests/integration/std/test_either.py
+++ b/tests/integration/std/test_either.py
@@ -1,12 +1,11 @@
 from guppylang.decorator import guppy
+from guppylang.emulator import EmulatorError
 from guppylang.std.array import array
 from guppylang.std.either import Either, left, right
 from guppylang.std.platform import panic, output
+from guppylang.std.quantum import qubit
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from guppylang.std.quantum import qubit
+import pytest
 
 
 def test_left(run_int_fn):
@@ -23,7 +22,8 @@ def test_left(run_int_fn):
 def test_right(run_int_fn):
     @guppy
     def main() -> int:
-        x: Either[qubit, int] = right(100)
+        # Note the type args to `right` are reversed relative to `left`
+        x: Either[qubit, int] = right[int, qubit](100)
         is_left = 1 if x.is_left() else 0
         is_right = 10 if x.is_right() else 0
         return is_left + is_right + x.unwrap_right()
@@ -87,3 +87,34 @@ def test_either_comprehension(validate):
             return right(0)
 
     validate(main.compile_function())
+
+
+def test_comptime_unwrap_left(run_int_fn):
+    @guppy
+    def max(i: int, f: float) -> Either[int, float]:
+        # Note the type args to `right` are reversed relative to `left`
+        return left[int, float](i) if float(i) > f else right[float, int](f)
+
+    @guppy.comptime
+    def main(i: int) -> int:
+        return max(i, 3.14).unwrap_left()
+
+    run_int_fn(main, 4, args=[4])
+    with pytest.raises(EmulatorError):
+        run_int_fn(main, 0xDEADBEEF, args=[3])
+
+
+def test_comptime_into_right(run_int_fn):
+    @guppy.comptime
+    def foo(e: Either[float, int]) -> int:
+        return e.try_into_right().unwrap()
+
+    @guppy
+    def main(i: int) -> int:
+        r: Either[float, int] = right[int, float](i)  # type args reversed
+        e = left[float, int](3.14) if i < 0 else r
+        return foo(e)
+
+    run_int_fn(main, 3, args=[3])
+    with pytest.raises(EmulatorError, match=r"Option.unwrap: value is `Nothing`"):
+        run_int_fn(main, 0xDEADBEEF, args=[-3])

--- a/tests/integration/std/test_either.py
+++ b/tests/integration/std/test_either.py
@@ -22,8 +22,7 @@ def test_left(run_int_fn):
 def test_right(run_int_fn):
     @guppy
     def main() -> int:
-        # Note the type args to `right` are reversed relative to `left`
-        x: Either[qubit, int] = right[int, qubit](100)
+        x: Either[qubit, int] = right[qubit, int](100)
         is_left = 1 if x.is_left() else 0
         is_right = 10 if x.is_right() else 0
         return is_left + is_right + x.unwrap_right()
@@ -92,8 +91,7 @@ def test_either_comprehension(validate):
 def test_comptime_unwrap_left(run_int_fn):
     @guppy
     def max(i: int, f: float) -> Either[int, float]:
-        # Note the type args to `right` are reversed relative to `left`
-        return left[int, float](i) if float(i) > f else right[float, int](f)
+        return left[int, float](i) if float(i) > f else right[int, float](f)
 
     @guppy.comptime
     def main(i: int) -> int:
@@ -111,7 +109,7 @@ def test_comptime_into_right(run_int_fn):
 
     @guppy
     def main(i: int) -> int:
-        r: Either[float, int] = right[int, float](i)  # type args reversed
+        r: Either[float, int] = right[float, int](i)
         e = left[float, int](3.14) if i < 0 else r
         return foo(e)
 

--- a/tests/integration/std/test_err.py
+++ b/tests/integration/std/test_err.py
@@ -30,6 +30,18 @@ def test_err(run_int_fn):
     run_int_fn(main, expected=110)
 
 
+def test_explicit_typeargs(run_int_fn):
+    @guppy
+    def foo(i: int) -> Result[int, ()]:
+        return ok[int, ()](i) if i > 0 else err[int, ()](())
+
+    def main() -> int:
+        foo(-1).unwrap_err()
+        return foo(2).unwrap()
+
+    run_int_fn(main, expected=2)
+
+
 def test_rows():
     """Make sure that Hugr generations correctly handles rows inside sums.
 


### PR DESCRIPTION
[First commit](97d138e9479d7467d8fae28c65b0dca6b948f782) adds tests of explicit type args to `right`, which have to be the wrong way round to get the tests to [pass](https://github.com/Quantinuum/guppylang/actions/runs/30568185841/).

(Yes, these tests are perhaps a little synthetic. But with type inference only working within basic blocks, not across them, there are more complex cases where manually specifying type args is the *only* way to make something compile...)

Declaring the type params "the correct way round" is only possible in/after python 3.12, but since we have said that is now the minimum supported version, we can do that.... and Result is also affected/corrected.

The "downside" is that although we don't support python 3.10, we still have `ruff` checking against this in `ruff.toml`, and fixing that...is a much bigger PR. But also only visible to developers of guppy, whereas this affects those *using* guppy. So for now I've whitelisted std/either.py and std/err.py for ruff to check against py312, and left the rest for [a cleanup issue](#2119).

closes #2113 

BREAKING CHANGE: Either and Result no longer inherit Generic, and calls to `right` or `err` with explicit type args will need the args reversed