### PR TITLE
fix: False type error when checking `Callable` protocol

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tys/builtin.py
+++ b/guppylang-internals/src/guppylang_internals/tys/builtin.py
@@ -204,7 +204,7 @@ class CallableProtocolDef(CheckedProtocolDef):
 class CallableProtocolInst(ProtocolInst):
     """Protocol instance associated with the builtin `Callable` protocol."""
 
-    sig: FunctionType = field(hash=False)
+    sig: FunctionType = field(compare=False, hash=False)
 
     def __init__(self, sig: FunctionType):
         assert not sig.parametrized

--- a/guppylang-internals/src/guppylang_internals/tys/protocol.py
+++ b/guppylang-internals/src/guppylang_internals/tys/protocol.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING
 
 from guppylang_internals.definition.common import DefId
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
 @dataclass(frozen=True)
 class ProtocolInst:
-    type_args: tuple[Argument, ...]
+    type_args: tuple[Argument, ...] = field(hash=False, compare=False)
     def_id: DefId
 
     def transform(self, transformer: Transformer) -> "ProtocolInst":

--- a/tests/integration/test_callable_py312.py
+++ b/tests/integration/test_callable_py312.py
@@ -50,3 +50,26 @@ def test_struct_generic(validate):
         return MyStruct(foo, 42).call() + MyStruct(bar[bool], False).call()
 
     validate(main.compile_function())
+
+
+def test_higher_order(validate):
+    from guppylang.std.builtins import array, nat
+    from guppylang.std.quantum import qubit, discard_array
+
+    @guppy
+    def higher_order[n: nat](
+        qs: array[qubit, n], func: Callable[[array[qubit, n]], None]
+    ) -> None:
+        pass
+
+    @guppy
+    def generic[n: nat](qs: array[qubit, n]) -> None:
+        pass
+
+    @guppy
+    def main() -> None:
+        qs = array(qubit() for _ in range(3))
+        higher_order(qs, generic[3])
+        discard_array(qs)
+
+    main.compile()


### PR DESCRIPTION
We should only actually be checking these signatures against each other using `unify`. The python equality comes up when we're comparing e.g. two `ExistentialTypeVar`s that both implement `Callable` at not-obviously-the-same signature.

We _could_ make sure to update the callable signatures wrt the current context, but I think all we actually care about in this case is
* Are they the same `ExistentialTypeVar` (the same id)
* Do they implement the same signatures (i.e. does it implement _some_ Callable), though even this seems like overkill!

By the same logic, we shouldn't compare the type args to protocols either (fixing the new test requires both changes)

The relevant lines that were failing are these checks in `expr_checker`:
https://github.com/Quantinuum/guppylang/blob/0573a82cec38af580694ed58067f6c5b6004490e/guppylang-internals/src/guppylang_internals/checker/expr_checker.py#L1382