### PR TITLE
fix: Unitary checker skips invalid function calls in arguments

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -89,12 +89,12 @@ class BBUnitaryChecker(ast.NodeVisitor):
         for stmt in statements:
             self.visit(stmt)
 
-    def _check_classical_args(self, args: list[ast.expr]) -> bool:
+    def _check_args(self, args: list[ast.expr]) -> bool:
+        """Recursively checks the arguments of a call.
+        Returns True if the call is classical"""
         for arg in args:
             self.visit(arg)
-            if contain_qubit_ty(get_type(arg)):
-                return False
-        return True
+        return all(not contain_qubit_ty(get_type(arg)) for arg in args)
 
     def _check_call(
         self, node: AnyCall, call_ty: FunctionType, func: CallableDef | None = None
@@ -114,7 +114,7 @@ class BBUnitaryChecker(ast.NodeVisitor):
         # function's unitary flags. Otherwise, if the function is classical, we only
         # need to check that if we are in dagger (or unitary) context, the function
         # is daggerable.
-        is_classic_fun = self._check_classical_args(node.args)
+        is_classic_fun = self._check_args(node.args)
         is_a_valid_call = (
             self.flags in call_ty.unitary_flags
             if not is_classic_fun

--- a/tests/error/modifier_errors/nested_call_in_control.err
+++ b/tests/error/modifier_errors/nested_call_in_control.err
@@ -1,0 +1,11 @@
+Error: Control constraint violation (at $FILE:19:24)
+   | 
+17 | def test(q: qubit, c: qubit) -> None:
+18 |     with control(c):
+19 |         rx(q, angle(1 / classical_helper(2, c)))
+   |                         ^^^^^^^^^^^^^^^^^^^^^^ This function cannot be called in a controllable context
+
+Help: Consider adding the flag `(controllable=True)` to the decorator of the
+function `classical_helper`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/nested_call_in_control.py
+++ b/tests/error/modifier_errors/nested_call_in_control.py
@@ -1,0 +1,22 @@
+from guppylang import guppy
+from guppylang.std.builtins import control
+from guppylang.std.quantum import angle, h, measure, qubit, rx
+
+
+@guppy
+def classical_helper(n: int, c: qubit) -> int:
+    q = qubit()
+    h(q)
+    if measure(q):
+        return n * 2
+    else:
+        return n
+
+
+@guppy
+def test(q: qubit, c: qubit) -> None:
+    with control(c):
+        rx(q, angle(1 / classical_helper(2, c)))
+
+
+test.compile_function()

--- a/tests/error/modifier_errors/nested_call_in_dagger.err
+++ b/tests/error/modifier_errors/nested_call_in_dagger.err
@@ -1,0 +1,11 @@
+Error: Dagger constraint violation (at $FILE:19:24)
+   | 
+17 | def test(q: qubit) -> None:
+18 |     with dagger:
+19 |         rx(q, angle(1 / classical_helper(2)))
+   |                         ^^^^^^^^^^^^^^^^^^^ This function cannot be called in a daggerable context
+
+Help: Consider adding the flag `(daggerable=True)` to the decorator of the
+function `classical_helper`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/nested_call_in_dagger.py
+++ b/tests/error/modifier_errors/nested_call_in_dagger.py
@@ -1,0 +1,22 @@
+from guppylang import guppy
+from guppylang.std.builtins import dagger
+from guppylang.std.quantum import angle, h, measure, qubit, rx
+
+
+@guppy
+def classical_helper(n: int) -> int:
+    q = qubit()
+    h(q)
+    if measure(q):
+        return n * 2
+    else:
+        return n
+
+
+@guppy
+def test(q: qubit) -> None:
+    with dagger:
+        rx(q, angle(1 / classical_helper(2)))
+
+
+test.compile_function()

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -17,7 +17,7 @@ from guppylang.std.builtins import (
     power,
 )
 from guppylang.std.num import nat
-from guppylang.std.quantum import angle, cx, discard, h, qubit, rx, discard_array
+from guppylang.std.quantum import cx, discard, discard_array, h, qubit
 
 
 def test_dagger_simple(validate):
@@ -48,18 +48,22 @@ def test_subscript_dagger(validate):
 
 
 def test_assignment_in_dagger(validate):
+    @guppy(daggerable=True)
+    def foo(x: int) -> int:
+        return x
+
     @guppy
     def main() -> None:
         q = qubit()
         c = qubit()
         y = 1
         with dagger:
-            x = 5
-            rx(q, angle(1 / x))
+            x = foo(y)
+            h(q)
         with dagger:
             y = 2
             with control(c):
-                rx(q, angle(1 / y))
+                h(q)
 
         discard(q)
         discard(c)

--- a/tests/metadata/test_modifier_metadata.py
+++ b/tests/metadata/test_modifier_metadata.py
@@ -33,8 +33,9 @@ def test_unitary_metadata_dagger_only():
     @guppy
     def main() -> None:
         t = qubit()
+        a = angle(1 / 3)
         with dagger:
-            rx(t, angle(1 / 3))
+            rx(t, a)
         discard(t)
 
     # For test sake we need the original unmodified HUGR
@@ -62,10 +63,11 @@ def test_unitary_metadata_power_dagger_control():
     def main() -> None:
         c1 = qubit()
         t = qubit()
-        with power(3):  # noqa: SIM117
-            with dagger:
+        with power(3):
+            a = angle(1 / 3)
+            with dagger:  # noqa: SIM117
                 with control(c1):
-                    rx(t, angle(1 / 3))
+                    rx(t, a)
         discard(c1)
         discard(t)
 
@@ -86,10 +88,11 @@ def test_unitary_metadata_dagger_power_control():
     def main() -> None:
         c1 = qubit()
         t = qubit()
+        a = angle(1 / 3)
         with dagger:  # noqa: SIM117
             with power(3):
                 with control(c1):
-                    rx(t, angle(1 / 3))
+                    rx(t, a)
         discard(c1)
         discard(t)
 
@@ -110,10 +113,11 @@ def test_unitary_metadata_control_dagger_power():
     def main() -> None:
         c1 = qubit()
         t = qubit()
+        a = angle(1 / 3)
         with control(c1):  # noqa: SIM117
             with dagger:
                 with power(3):
-                    rx(t, angle(1 / 3))
+                    rx(t, a)
         discard(c1)
         discard(t)
 
@@ -134,10 +138,11 @@ def test_unitary_metadata_power_control_dagger():
     def main() -> None:
         c1 = qubit()
         t = qubit()
+        a = angle(1 / 3)
         with power(3):  # noqa: SIM117
             with control(c1):
                 with dagger:
-                    rx(t, angle(1 / 3))
+                    rx(t, a)
         discard(c1)
         discard(t)
 
@@ -158,10 +163,11 @@ def test_unitary_metadata_dagger_control_power():
     def main() -> None:
         c1 = qubit()
         t = qubit()
+        a = angle(1 / 3)
         with dagger:  # noqa: SIM117
             with control(c1):
                 with power(3):
-                    rx(t, angle(1 / 3))
+                    rx(t, a)
         discard(c1)
         discard(t)
 
@@ -182,10 +188,11 @@ def test_unitary_metadata_control_power_dagger():
     def main() -> None:
         c1 = qubit()
         t = qubit()
+        a = angle(1 / 3)
         with control(c1):  # noqa: SIM117
             with power(3):
                 with dagger:
-                    rx(t, angle(1 / 3))
+                    rx(t, a)
         discard(c1)
         discard(t)
 


### PR DESCRIPTION
Backport for https://github.com/Quantinuum/guppylang/pull/2081