### PR TITLE
chore: Remove 3.10/3.11 classifiers from guppylang-internals `pyproject.toml`

### DIFF
--- a/guppylang-internals/pyproject.toml
+++ b/guppylang-internals/pyproject.toml
@@ -21,8 +21,6 @@ classifiers = [
     "Topic :: Software Development :: Compilers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
Backport for https://github.com/Quantinuum/guppylang/pull/2085