### PR TITLE
fix: address missing API docs members from the std.collections module.

### DIFF
--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -16,7 +16,9 @@ class _DummyGuppy:
         return f
 
     def struct(self, *args: Any, **kwargs: Any) -> Any:
-        return self
+        if args:
+            return args[0]
+        return lambda cls: cls
 
     def enum(self, cls: Any) -> Any:
         return cls

--- a/guppylang/src/guppylang/std/collections/__init__.py
+++ b/guppylang/src/guppylang/std/collections/__init__.py
@@ -1,4 +1,4 @@
-"""Guppy standard library for queues."""
+"""Guppy standard library for collections."""
 
 from guppylang.std.collections.priority_queue import PriorityQueue, empty_priority_queue
 from guppylang.std.collections.queue import Queue, empty_queue

--- a/guppylang/src/guppylang/std/collections/__init__.py
+++ b/guppylang/src/guppylang/std/collections/__init__.py
@@ -1,4 +1,4 @@
-"""Guppy standard library for collections."""
+"""Guppy standard library module for collections."""
 
 from guppylang.std.collections.priority_queue import PriorityQueue, empty_priority_queue
 from guppylang.std.collections.queue import Queue, empty_queue


### PR DESCRIPTION
closes https://github.com/Quantinuum/guppy-docs/issues/179

required a fix to the dummy decorator which we use for sphinx.

Disclosure: I used chatgpt to help me pin down the source of this omission and then built the docs using this commit ref to ensure the fix worked.


<img width="724" height="383" alt="Screenshot 2026-08-03 at 11 59 55" src="https://github.com/user-attachments/assets/f87277d1-3c80-41dd-8456-69a64dff5ba4" />
