### PR TITLE
refactor: Remove version guards for Python 3.12 lower bound

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -7,7 +7,6 @@ node straight from the Python AST. We build a CFG, check it, and return a
 
 import ast
 import copy
-import sys
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, ClassVar, cast
 
@@ -31,6 +30,7 @@ from guppylang_internals.tys.parsing import (
     TypeParsingCtx,
     check_function_arg,
     parse_function_arg_annotation,
+    parse_parameter,
     type_from_ast,
     type_with_flags_from_ast,
 )
@@ -48,9 +48,6 @@ from guppylang_internals.tys.ty import (
 
 if TYPE_CHECKING:
     from guppylang_internals.definition.protocol import CheckedProtocolDef
-
-if sys.version_info >= (3, 12):
-    from guppylang_internals.tys.parsing import parse_parameter
 
 
 @dataclass(frozen=True)
@@ -326,10 +323,9 @@ def check_signature(
     # Prepopulate parameter mapping when using Python 3.12 style generic syntax
     if param_var_mapping is None:
         param_var_mapping = {}
-    if sys.version_info >= (3, 12):
-        for i, param_node in enumerate(func_def.type_params):
-            param = parse_parameter(param_node, i, globals, param_var_mapping)
-            param_var_mapping[param.name] = param
+    for i, param_node in enumerate(func_def.type_params):
+        param = parse_parameter(param_node, i, globals, param_var_mapping)
+        param_var_mapping[param.name] = param
 
     # Figure out if this is a method
     self_defn: ProtocolDef | TypeDef | None = None

--- a/guppylang-internals/src/guppylang_internals/definition/protocol.py
+++ b/guppylang-internals/src/guppylang_internals/definition/protocol.py
@@ -1,5 +1,4 @@
 import ast
-import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, ClassVar
@@ -77,19 +76,16 @@ class RawProtocolDef(ProtocolDef, ParsableDef):
         # Look for generic parameters from Python 3.12 style syntax.
         params = []
         params_span: Span | None = None
-        if sys.version_info >= (3, 12):
-            from guppylang_internals.tys.parsing import parse_parameter
+        from guppylang_internals.tys.parsing import parse_parameter
 
-            if cls_def.type_params:
-                first, last = cls_def.type_params[0], cls_def.type_params[-1]
-                params_span = Span(to_span(first).start, to_span(last).end)
-                param_vars_mapping: dict[str, Parameter] = {}
-                for idx, param_node in enumerate(cls_def.type_params):
-                    param = parse_parameter(
-                        param_node, idx, globals, param_vars_mapping
-                    )
-                    param_vars_mapping[param.name] = param
-                    params.append(param)
+        if cls_def.type_params:
+            first, last = cls_def.type_params[0], cls_def.type_params[-1]
+            params_span = Span(to_span(first).start, to_span(last).end)
+            param_vars_mapping: dict[str, Parameter] = {}
+            for idx, param_node in enumerate(cls_def.type_params):
+                param = parse_parameter(param_node, idx, globals, param_vars_mapping)
+                param_vars_mapping[param.name] = param
+                params.append(param)
 
         match cls_def.bases:
             case []:

--- a/guppylang-internals/src/guppylang_internals/definition/util.py
+++ b/guppylang-internals/src/guppylang_internals/definition/util.py
@@ -1,7 +1,6 @@
 import ast
 import inspect
 import linecache
-import sys
 from collections.abc import Iterator, Sequence
 from dataclasses import dataclass
 from types import FrameType
@@ -27,12 +26,10 @@ from guppylang_internals.tys.param import Parameter
 from guppylang_internals.tys.parsing import (
     TypeParsingCtx,
     annotation_nodes,
+    parse_parameter,
     try_parse_defn,
 )
 from guppylang_internals.tys.ty import Type
-
-if sys.version_info >= (3, 12):
-    from guppylang_internals.tys.parsing import parse_parameter
 
 if TYPE_CHECKING:
     from guppylang_internals.definition.alias import ParsedTypeAliasDef
@@ -259,15 +256,14 @@ def extract_generic_params(
     params_span: Span | None = None
 
     # Look for generic parameters from Python 3.12 style syntax
-    if sys.version_info >= (3, 12):
-        if cls_def.type_params:
-            first, last = cls_def.type_params[0], cls_def.type_params[-1]
-            params_span = Span(to_span(first).start, to_span(last).end)
-            param_vars_mapping: dict[str, Parameter] = {}
-            for idx, param_node in enumerate(cls_def.type_params):
-                param = parse_parameter(param_node, idx, globals, param_vars_mapping)
-                param_vars_mapping[param.name] = param
-                params.append(param)
+    if cls_def.type_params:
+        first, last = cls_def.type_params[0], cls_def.type_params[-1]
+        params_span = Span(to_span(first).start, to_span(last).end)
+        param_vars_mapping: dict[str, Parameter] = {}
+        for idx, param_node in enumerate(cls_def.type_params):
+            param = parse_parameter(param_node, idx, globals, param_vars_mapping)
+            param_vars_mapping[param.name] = param
+            params.append(param)
 
     base_params: list[Parameter] = []
     for base in cls_def.bases:

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -1,5 +1,4 @@
 import ast
-import sys
 from collections.abc import Iterator, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from types import ModuleType
@@ -439,120 +438,113 @@ def check_function_arg(
     return FuncInput(ty, flags, name)
 
 
-if sys.version_info >= (3, 12):
+def parse_parameter(
+    node: ast.type_param,
+    idx: int,
+    globals: Globals,
+    param_var_mapping: dict[str, Parameter],
+    allow_free_vars: bool = False,
+) -> Parameter:
+    """Parses a `Variable: Bound` generic type parameter declaration."""
+    if isinstance(node, ast.TypeVarTuple | ast.ParamSpec):
+        raise GuppyError(UnsupportedError(node, "Variadic generic parameters"))
+    assert isinstance(node, ast.TypeVar)
 
-    def parse_parameter(
-        node: ast.type_param,
-        idx: int,
-        globals: Globals,
-        param_var_mapping: dict[str, Parameter],
-        allow_free_vars: bool = False,
-    ) -> Parameter:
-        """Parses a `Variable: Bound` generic type parameter declaration."""
-        if isinstance(node, ast.TypeVarTuple | ast.ParamSpec):
-            raise GuppyError(UnsupportedError(node, "Variadic generic parameters"))
-        assert isinstance(node, ast.TypeVar)
+    match node.bound:
+        # No bound means it's a linear type parameter
+        case None:
+            return TypeParam(
+                idx, node.name, must_be_copyable=False, must_be_droppable=False
+            )
+        # Special `Copy` or `Drop` bounds for types
+        case ast.Name(id="Copy"):
+            return TypeParam(
+                idx, node.name, must_be_copyable=True, must_be_droppable=False
+            )
+        case ast.Name(id="Drop"):
+            return TypeParam(
+                idx, node.name, must_be_copyable=False, must_be_droppable=True
+            )
+        # Copy and drop is annotated as `T: (Copy, Drop)`
+        # TODO: Should we also allow `T: Copy + Drop`? Mypy would complain about it
+        case ast.Tuple(elts=elts):
+            bounds: list[ProtocolInst] = []
+            for elt in elts:
+                match elt:
+                    case ast.Name(id="Copy"):
+                        continue
+                    case ast.Name(id="Drop"):
+                        continue
+                    case _:
+                        if proto_inst := parse_bound(
+                            elt, globals, param_var_mapping, allow_free_vars
+                        ):
+                            bounds.append(proto_inst)
+                        else:
+                            raise GuppyError(UnrecognisedBound(elt, ast.unparse(elt)))
+            return TypeParam(
+                idx,
+                node.name,
+                must_be_copyable=True,
+                must_be_droppable=True,
+                must_implement=bounds,
+            )
 
-        match node.bound:
-            # No bound means it's a linear type parameter
-            case None:
-                return TypeParam(
-                    idx, node.name, must_be_copyable=False, must_be_droppable=False
-                )
-            # Special `Copy` or `Drop` bounds for types
-            case ast.Name(id="Copy"):
-                return TypeParam(
-                    idx, node.name, must_be_copyable=True, must_be_droppable=False
-                )
-            case ast.Name(id="Drop"):
-                return TypeParam(
-                    idx, node.name, must_be_copyable=False, must_be_droppable=True
-                )
-            # Copy and drop is annotated as `T: (Copy, Drop)`
-            # TODO: Should we also allow `T: Copy + Drop`? Mypy would complain about it
-            case ast.Tuple(elts=elts):
-                bounds: list[ProtocolInst] = []
-                for elt in elts:
-                    match elt:
-                        case ast.Name(id="Copy"):
-                            continue
-                        case ast.Name(id="Drop"):
-                            continue
-                        case _:
-                            if proto_inst := parse_bound(
-                                elt, globals, param_var_mapping, allow_free_vars
-                            ):
-                                bounds.append(proto_inst)
-                            else:
-                                raise GuppyError(
-                                    UnrecognisedBound(elt, ast.unparse(elt))
-                                )
+        # Otherwise, it must be either a protocol or a const parameter
+        case bound:
+            if proto_inst := parse_bound(
+                bound, globals, param_var_mapping, allow_free_vars
+            ):
                 return TypeParam(
                     idx,
                     node.name,
                     must_be_copyable=True,
                     must_be_droppable=True,
-                    must_implement=bounds,
+                    must_implement=[proto_inst],
                 )
+            else:
+                # TODO: In the future we might want to allow stuff like
+                #   `def foo[T, XS: array[T, 42]]` and so on
+                ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
+                ty = type_from_ast(bound, ctx)
+                if not ty.copyable or not ty.droppable:
+                    raise GuppyError(LinearConstParamError(bound, ty))
+                return ConstParam(idx, node.name, ty)
 
-            # Otherwise, it must be either a protocol or a const parameter
-            case bound:
-                if proto_inst := parse_bound(
-                    bound, globals, param_var_mapping, allow_free_vars
-                ):
-                    return TypeParam(
-                        idx,
-                        node.name,
-                        must_be_copyable=True,
-                        must_be_droppable=True,
-                        must_implement=[proto_inst],
-                    )
-                else:
-                    # TODO: In the future we might want to allow stuff like
-                    #   `def foo[T, XS: array[T, 42]]` and so on
-                    ctx = TypeParsingCtx(
-                        globals, param_var_mapping, {}, allow_free_vars
-                    )
-                    ty = type_from_ast(bound, ctx)
-                    if not ty.copyable or not ty.droppable:
-                        raise GuppyError(LinearConstParamError(bound, ty))
-                    return ConstParam(idx, node.name, ty)
 
-    def parse_bound(
-        bound: ast.expr,
-        globals: Globals,
-        param_var_mapping: dict[str, Parameter],
-        allow_free_vars: bool,
-    ) -> ProtocolInst | None:
-        from guppylang_internals.definition.protocol import ParsedProtocolDef
+def parse_bound(
+    bound: ast.expr,
+    globals: Globals,
+    param_var_mapping: dict[str, Parameter],
+    allow_free_vars: bool,
+) -> ProtocolInst | None:
+    from guppylang_internals.definition.protocol import ParsedProtocolDef
 
-        ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
+    ctx = TypeParsingCtx(globals, param_var_mapping, {}, allow_free_vars)
 
-        # First, try to see if this is a protocol bound by checking if can find
-        # a protocol definition with this name. In contrast to normal
-        # parameters, protocol parameters could be parametrised themselves.
-        proto_defn = None
-        proto_args = []
-        if isinstance(bound, ast.Subscript):
-            proto_defn = try_parse_defn(bound.value, ctx)
-            arg_nodes = (
-                bound.slice.elts
-                if isinstance(bound.slice, ast.Tuple)
-                else [bound.slice]
-            )
-            # Special case for the `Callable` protocol
-            if isinstance(proto_defn, CallableProtocolDef):
-                sig = _parse_function_type(arg_nodes, bound, ctx, "Callable")
-                return CallableProtocolInst(sig)
-            proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
-        else:
-            proto_defn = try_parse_defn(bound, ctx)
+    # First, try to see if this is a protocol bound by checking if can find
+    # a protocol definition with this name. In contrast to normal
+    # parameters, protocol parameters could be parametrised themselves.
+    proto_defn = None
+    proto_args = []
+    if isinstance(bound, ast.Subscript):
+        proto_defn = try_parse_defn(bound.value, ctx)
+        arg_nodes = (
+            bound.slice.elts if isinstance(bound.slice, ast.Tuple) else [bound.slice]
+        )
+        # Special case for the `Callable` protocol
+        if isinstance(proto_defn, CallableProtocolDef):
+            sig = _parse_function_type(arg_nodes, bound, ctx, "Callable")
+            return CallableProtocolInst(sig)
+        proto_args = [arg_from_ast(arg_node, ctx) for arg_node in arg_nodes]
+    else:
+        proto_defn = try_parse_defn(bound, ctx)
 
-        if isinstance(proto_defn, ParsedProtocolDef):
-            checked_defn = proto_defn.check(globals)
-            inst = checked_defn.check_instantiate(proto_args, bound)
-            return inst
-        return None
+    if isinstance(proto_defn, ParsedProtocolDef):
+        checked_defn = proto_defn.check(globals)
+        inst = checked_defn.check_instantiate(proto_args, bound)
+        return inst
+    return None
 
 
 _type_param = TypeParam(0, "T", False, False)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,9 @@
 import argparse
-import sys
 from pathlib import Path
 
 import guppylang
 
 guppylang.enable_experimental_features()
-
-
-if sys.version_info < (3, 12):
-    # Ignore tests that require Python 3.12 syntax
-    collect_ignore_glob = ["*_py312.py"]
 
 
 def pytest_addoption(parser):

--- a/tests/error/test_self_errors.py
+++ b/tests/error/test_self_errors.py
@@ -12,10 +12,6 @@ files = [
     if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
 ]
 
-if sys.version_info < (3, 12):
-    # Filter out tests that require Python >= 3.12
-    files = [file for file in files if "py312" not in file.name]
-
 # Turn paths into strings, otherwise pytest doesn't display the names
 files = [str(f) for f in files]
 


### PR DESCRIPTION
Backport for https://github.com/Quantinuum/guppylang/pull/1973

(wasn't originally backport nominated but should help avoid merge conflicts with some other fixes and is in line with the drop of 3.10/11 which is in v1)