### PR TITLE
fix!: Stop treating protocol bounds as always copyable and droppable

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -435,8 +435,8 @@ def parse_self_arg_proto(
     )
     self_ty_placeholder = ExistentialTypeVar.fresh(
         "Self",
-        copyable=True,
-        droppable=True,
+        copyable=False,
+        droppable=False,
     )
     assert ctx.self_ty is None
     ctx = replace(ctx, self_ty=self_ty_placeholder)
@@ -445,7 +445,7 @@ def parse_self_arg_proto(
     # If the user just annotates `self: Self` then we can fall back to the case where
     # no annotation is provided at all
     if user_ty == self_ty_placeholder:
-        return handle_implicit_self_arg_proto(arg, self_defn, ctx)
+        return handle_implicit_self_arg_proto(arg, self_defn, ctx, user_flags)
 
     # Annotations like `self: Foo[Self]` are not allowed (would be an infinite type)
     if self_ty_placeholder in user_ty.unsolved_vars:
@@ -478,7 +478,7 @@ def handle_implicit_self_arg_proto(
     arg: ast.arg,
     self_defn: "CheckedProtocolDef",
     ctx: TypeParsingCtx,
-    flags: InputFlags = InputFlags.NoFlags,
+    flags: InputFlags | None = None,
 ) -> FuncInput:
     """Handle the case of a protocol method that leaves the protocol type implicit.
     Add a type parameter to the function which implements the protocol, and the self
@@ -497,15 +497,15 @@ def handle_implicit_self_arg_proto(
     ctx.param_var_mapping.update({param.name: param for param in self_defn.params})
     self_args = [param.to_bound() for param in self_defn.params]
     proto_inst = self_defn.check_instantiate(self_args, loc=arg)
-    self_arg = BoundTypeVar("self", len(self_args), True, True, (proto_inst,))
+    self_arg = BoundTypeVar("self", len(self_args), False, False, (proto_inst,))
     ctx.param_var_mapping["self"] = TypeParam(
         idx=len(self_defn.params),
         name="self",
-        must_be_copyable=True,
-        must_be_droppable=True,
+        must_be_copyable=False,
+        must_be_droppable=False,
         must_implement=[proto_inst],
     )
-    return FuncInput(self_arg, InputFlags.NoFlags)
+    return FuncInput(self_arg, flags or InputFlags.Inout)
 
 
 def handle_implicit_self_arg(

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -865,7 +865,15 @@ def immediate_child_places(place: Place) -> list[Place]:
 
 def is_inout_var(place: Place) -> TypeGuard[Variable]:
     """Checks whether a place is a borrowed variable."""
-    return isinstance(place, Variable) and InputFlags.Inout in place.flags
+    return (
+        isinstance(place, Variable)
+        and InputFlags.Inout in place.flags
+        # Only affine types are considered for inout. Normally, copyable types wouldn't
+        # have an inout flag, however it can show up when generic functions are
+        # instantiated with protocol instances that are copyable. In those cases, we
+        # just consider the variable as not inout.
+        and not place.ty.copyable
+    )
 
 
 def has_explicit_copy(ty: Type) -> bool:

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -317,8 +317,8 @@ def _arg_from_proto(
         param = TypeParam(
             len(ctx.param_var_mapping),
             proto_defn.name,
-            must_be_copyable=True,
-            must_be_droppable=True,
+            must_be_copyable=False,
+            must_be_droppable=False,
             must_implement=[inst],
         )
         # Create a fresh parameter to represent this protocol bound. If we see another
@@ -469,12 +469,14 @@ def parse_parameter(
         # TODO: Should we also allow `T: Copy + Drop`? Mypy would complain about it
         case ast.Tuple(elts=elts):
             bounds: list[ProtocolInst] = []
+            must_be_copyable = False
+            must_be_droppable = False
             for elt in elts:
                 match elt:
                     case ast.Name(id="Copy"):
-                        continue
+                        must_be_copyable = True
                     case ast.Name(id="Drop"):
-                        continue
+                        must_be_droppable = True
                     case _:
                         if proto_inst := parse_bound(
                             elt, globals, param_var_mapping, allow_free_vars
@@ -485,8 +487,8 @@ def parse_parameter(
             return TypeParam(
                 idx,
                 node.name,
-                must_be_copyable=True,
-                must_be_droppable=True,
+                must_be_copyable=must_be_copyable,
+                must_be_droppable=must_be_droppable,
                 must_implement=bounds,
             )
 
@@ -498,8 +500,8 @@ def parse_parameter(
                 return TypeParam(
                     idx,
                     node.name,
-                    must_be_copyable=True,
-                    must_be_droppable=True,
+                    must_be_copyable=False,
+                    must_be_droppable=False,
                     must_implement=[proto_inst],
                 )
             else:

--- a/tests/error/protocol_errors_py312/borrowed_by_default.err
+++ b/tests/error/protocol_errors_py312/borrowed_by_default.err
@@ -1,0 +1,15 @@
+Error: Not owned (at $FILE:11:8)
+   | 
+ 9 | @guppy
+10 | def foo(x: Proto) -> None:
+11 |     y = x
+   |         ^ Cannot move `x` since `foo` doesn't own it
+
+Help:
+   | 
+ 9 | @guppy
+10 | def foo(x: Proto) -> None:
+   |         -------- Argument `x` is only borrowed. Consider taking ownership:
+   |                  `x: Proto @owned`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/protocol_errors_py312/borrowed_by_default.py
+++ b/tests/error/protocol_errors_py312/borrowed_by_default.py
@@ -1,0 +1,17 @@
+from guppylang import guppy
+from guppylang.std.lang import owned
+
+
+@guppy.protocol
+class Proto:
+    """Empty protocol"""
+
+@guppy
+def foo(x: Proto) -> None:
+    y = x
+
+@guppy
+def main() -> None:
+    foo(42)
+
+main.compile()

--- a/tests/error/protocol_errors_py312/noncopyable_by_default.err
+++ b/tests/error/protocol_errors_py312/noncopyable_by_default.err
@@ -1,0 +1,15 @@
+Error: Copy violation (at $FILE:12:8)
+   | 
+10 | def foo(x: Proto @ owned) -> None:
+11 |     a = x
+12 |     b = x
+   |         ^ Variable `x` with non-copyable type `Proto` cannot be moved
+   |           ...
+
+Note:
+   | 
+10 | def foo(x: Proto @ owned) -> None:
+11 |     a = x
+   |         - Variable `x` already moved here
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/protocol_errors_py312/noncopyable_by_default.py
+++ b/tests/error/protocol_errors_py312/noncopyable_by_default.py
@@ -1,0 +1,18 @@
+from guppylang import guppy
+from guppylang.std.lang import owned
+
+
+@guppy.protocol
+class Proto:
+    """Empty protocol"""
+
+@guppy
+def foo(x: Proto @ owned) -> None:
+    a = x
+    b = x
+
+@guppy
+def main() -> None:
+    foo(42)
+
+main.compile()

--- a/tests/error/protocol_errors_py312/nondroppable_by_default.err
+++ b/tests/error/protocol_errors_py312/nondroppable_by_default.err
@@ -1,0 +1,10 @@
+Error: Drop violation (at $FILE:10:8)
+   | 
+ 8 | 
+ 9 | @guppy
+10 | def foo(x: Proto @ owned) -> None:
+   |         ^^^^^^^^^^^^^^^^ Variable `x` with non-droppable type `Proto` is leaked
+
+Help: Make sure that `x` is consumed or returned to avoid the leak
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/protocol_errors_py312/nondroppable_by_default.py
+++ b/tests/error/protocol_errors_py312/nondroppable_by_default.py
@@ -1,0 +1,17 @@
+from guppylang import guppy
+from guppylang.std.lang import owned
+
+
+@guppy.protocol
+class Proto:
+    """Empty protocol"""
+
+@guppy
+def foo(x: Proto @ owned) -> None:
+    return
+
+@guppy
+def main() -> None:
+    foo(42)
+
+main.compile()

--- a/tests/integration/test_callable_py312.py
+++ b/tests/integration/test_callable_py312.py
@@ -1,11 +1,12 @@
 from collections.abc import Callable
 
 from guppylang.decorator import guppy
+from guppylang.std.lang import Copy, Drop
 
 
 def test_struct(validate):
     @guppy.struct
-    class MyStruct[F: Callable[[int], int]]:
+    class MyStruct[F: (Callable[[int], int], Copy, Drop)]:
         f: F
 
         @guppy
@@ -30,7 +31,7 @@ def test_struct(validate):
 
 def test_struct_generic(validate):
     @guppy.struct
-    class MyStruct[S, T, F: Callable[[S], T]]:
+    class MyStruct[S, T, F: (Callable[[S], T], Copy, Drop)]:
         f: F
         x: S
 

--- a/tests/integration/test_protocol_py312.py
+++ b/tests/integration/test_protocol_py312.py
@@ -1,8 +1,9 @@
 import pytest
 from typing import Self
 from guppylang.decorator import guppy
-from guppylang.std.builtins import nat
-from guppylang.std.lang import Copy, Drop
+from guppylang.std.builtins import array, nat
+from guppylang.std.lang import Copy, Drop, owned
+from guppylang.std.quantum import discard, qubit
 
 
 def test_def():
@@ -208,7 +209,7 @@ def test_multi(validate):
         def bar(self: "Bar[T]", t: T @ owned) -> T: ...
 
     @guppy
-    def baz[T: (Foo[nat], Bar[nat])](t: T) -> nat:
+    def baz[T: (Foo[nat], Bar[nat], Copy, Drop)](t: T) -> nat:
         return t.bar(t.foo(42))
 
     @guppy.struct(frozen=True)
@@ -483,3 +484,96 @@ def test_double_fn(validate):
         q.discard()
 
     validate(call_two.compile())
+
+
+def test_linear(validate):
+    @guppy.protocol
+    class Proto:
+        @guppy.require
+        def borrowed(self) -> int: ...
+
+        @guppy.require
+        def owned(self: Self @ owned) -> int: ...
+
+    @guppy.struct(frozen=True)
+    class ClassicalType:
+        x: int
+
+        @guppy
+        def borrowed(self) -> int:
+            return self.x
+
+        @guppy
+        def owned(self) -> int:
+            return self.x
+
+    @guppy.struct
+    class AffineType:
+        xs: array[int, 10]
+
+        @guppy
+        def borrowed(self) -> int:
+            return self.xs[0]
+
+        @guppy
+        def owned(self: Self @ owned) -> int:
+            return self.xs[0]
+
+    @guppy.struct
+    class LinearType:
+        q: qubit
+
+        @guppy
+        def borrowed(self) -> int:
+            return 0
+
+        @guppy
+        def owned(self: Self @ owned) -> int:
+            discard(self.q)
+            return 0
+
+    @guppy
+    def foo_borrowed(x: Proto) -> int:
+        return x.borrowed()
+
+    @guppy
+    def foo_owned(x: Proto @ owned) -> int:
+        return x.owned()
+
+    @guppy
+    def main(x: ClassicalType, y: AffineType @ owned, z: LinearType @ owned) -> int:
+        return (
+            foo_borrowed(x)
+            + foo_owned(x)
+            + foo_borrowed(y)
+            + foo_owned(y)
+            + foo_borrowed(z)
+            + foo_owned(z)
+        )
+
+    validate(main.compile_function())
+
+
+def test_copy_drop(validate):
+    @guppy.protocol
+    class Proto:
+        """Empty protocol"""
+
+    @guppy
+    def copy[T: (Proto, Copy)](x: T) -> tuple[T, T]:
+        return x, x
+
+    @guppy
+    def drop[T: (Proto, Drop)](x: T @ owned) -> None:
+        pass
+
+    @guppy
+    def copy_drop[T: (Proto, Copy, Drop)](x: T, y: T) -> tuple[T, T]:
+        return x, x
+
+    @guppy
+    def main() -> int:
+        drop(array(1.0))
+        return copy(42)[0] + copy_drop(1, 2)[1]
+
+    validate(main.compile_function())


### PR DESCRIPTION
Backport for https://github.com/Quantinuum/guppylang/pull/2096

BREAKING CHANGE: Protocol arguments are now non-copyable and non-droppable by default. Add an explicit `Copy` or `Drop` bound to make them copyable or droppable.