### PR TITLE
fix: address missing API docs members from the std.collections module

### DIFF
--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -16,7 +16,9 @@ class _DummyGuppy:
         return f
 
     def struct(self, *args: Any, **kwargs: Any) -> Any:
-        return self
+        if args:
+            return args[0]
+        return lambda cls: cls
 
     def enum(self, cls: Any) -> Any:
         return cls

--- a/guppylang/src/guppylang/std/collections/__init__.py
+++ b/guppylang/src/guppylang/std/collections/__init__.py
@@ -1,4 +1,4 @@
-"""Guppy standard library for queues."""
+"""Guppy standard library module for collections."""
 
 from guppylang.std.collections.priority_queue import PriorityQueue, empty_priority_queue
 from guppylang.std.collections.queue import Queue, empty_queue


### PR DESCRIPTION
Backport for https://github.com/Quantinuum/guppylang/pull/2137