### PR TITLE
docs: Fix broken code blocks in emulator docs

### DIFF
--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -192,6 +192,7 @@ Bind parameter values using keyword arguments to :py:meth:`EmulatorInstance.run`
     entry_args.emulator(n_qubits=1).run(theta=1.5, k=[3])
 
 .. code-block:: python
+
     # output
     EmulatorResult(results=[QsysShot(entries=[('doubled', 3.0), ('k1', 4)])])
 
@@ -208,6 +209,7 @@ mappings to run the program with for each shot:
     ])
 
 .. code-block:: python
+
     # output
     EmulatorResult(results=[
         QsysShot(entries=[('doubled', 3.0), ('k1', 4)]),
@@ -242,6 +244,7 @@ code with the same compilation target, make sure the `platform` argument matches
 standard library used:
 
 .. code-block:: python
+
     from guppylang.std.qsystem.sol import phased_xx
     from guppylang.std.angles import pi
 


### PR DESCRIPTION
Sphinx requires an empty line after a `code-block::` directive.

These blocks were'n being rendered at all in the guppy docs.