### PR TITLE
fix: Make most builtin functions + struct constructors daggerable

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -115,15 +115,13 @@ class BBUnitaryChecker(ast.NodeVisitor):
         # need to check that if we are in dagger (or unitary) context, the function
         # is daggerable.
         is_classic_fun = self._check_args(node.args)
-        is_a_valid_call = (
-            self.flags in call_ty.unitary_flags
-            if not is_classic_fun
-            else (
-                True
-                if UnitaryFlags.Dagger not in self.flags
-                else UnitaryFlags.Dagger in call_ty.unitary_flags
-            )
-        )
+        if is_classic_fun:
+            if UnitaryFlags.Dagger not in self.flags:
+                is_a_valid_call = True
+            else:
+                is_a_valid_call = UnitaryFlags.Dagger in call_ty.unitary_flags
+        else:
+            is_a_valid_call = self.flags in call_ty.unitary_flags
 
         if not is_a_valid_call:
             from guppylang_internals.definition.custom import CustomFunctionDef

--- a/guppylang-internals/src/guppylang_internals/definition/struct.py
+++ b/guppylang-internals/src/guppylang_internals/definition/struct.py
@@ -49,6 +49,7 @@ from guppylang_internals.tys.ty import (
     InputFlags,
     StructType,
     Type,
+    UnitaryFlags,
 )
 
 
@@ -230,6 +231,7 @@ class CheckedStructDef(TypeDef, CompiledDef):
                 defn=self, args=[p.to_bound(i) for i, p in enumerate(self.params)]
             ),
             params=self.params,
+            unitary_flags=UnitaryFlags.Dagger,
         )
         constructor_def = CustomFunctionDef(
             id=DefId.fresh(),

--- a/guppylang/src/guppylang/std/angles.py
+++ b/guppylang/src/guppylang/std/angles.py
@@ -31,47 +31,47 @@ class angle:
 
     halfturns: float
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __add__(self: "angle", other: "angle") -> "angle":
         return angle(self.halfturns + other.halfturns)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __sub__(self: "angle", other: "angle") -> "angle":
         return angle(self.halfturns - other.halfturns)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __mul__(self: "angle", other: float) -> "angle":
         return angle(self.halfturns * other)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __rmul__(self: "angle", other: float) -> "angle":
         return angle(self.halfturns * other)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __truediv__(self: "angle", other: float) -> "angle":
         return angle(self.halfturns / other)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __rtruediv__(self: "angle", other: float) -> "angle":
         return angle(other / self.halfturns)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __neg__(self: "angle") -> "angle":
         return angle(-self.halfturns)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __float__(self: "angle") -> float:
         return self.halfturns * py(math.pi)
 
-    @guppy
+    @guppy(daggerable=True)
     @no_type_check
     def __eq__(self: "angle", other: "angle") -> bool:
         return self.halfturns == other.halfturns

--- a/guppylang/src/guppylang/std/array.py
+++ b/guppylang/src/guppylang/std/array.py
@@ -31,6 +31,7 @@ from guppylang_internals.std._internal.compiler.frozenarray import (
     FrozenarrayGetitemCompiler,
 )
 from guppylang_internals.tys.builtin import array_type_def, frozenarray_type_def
+from guppylang_internals.tys.ty import UnitaryFlags
 
 from guppylang import guppy
 from guppylang.std.err import Result, err, ok
@@ -59,10 +60,16 @@ _n = TypeVar("_n")
 class array(builtins.list[_T], Generic[_T, _n]):
     """Sequence of homogeneous values with statically known fixed length."""
 
-    @custom_function(ArrayGetitemCompiler(), checker=ArrayIndexChecker())
+    @custom_function(
+        ArrayGetitemCompiler(),
+        checker=ArrayIndexChecker(),
+    )
     def __getitem__(self: array[L, n], idx: int) -> L: ...
 
-    @custom_function(ArraySetitemCompiler(), checker=ArrayIndexChecker())
+    @custom_function(
+        ArraySetitemCompiler(),
+        checker=ArrayIndexChecker(),
+    )
     def __setitem__(self: array[L, n], idx: int, value: L @ owned) -> None: ...
 
     @guppy
@@ -70,7 +77,12 @@ class array(builtins.list[_T], Generic[_T, _n]):
     def __len__(self: array[L, n]) -> int:
         return n
 
-    @custom_function(NewArrayCompiler(), NewArrayChecker(), higher_order_value=False)
+    @custom_function(
+        NewArrayCompiler(),
+        NewArrayChecker(),
+        higher_order_value=False,
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __new__(): ...
 
     # `__new__` will be overwritten below to provide actual runtime behaviour for
@@ -83,11 +95,17 @@ class array(builtins.list[_T], Generic[_T, _n]):
     def __iter__(self: array[L, n] @ owned) -> SizedIter[ArrayIter[L, n], n]:
         return SizedIter(ArrayIter(self, 0))
 
-    @custom_function(CopyInoutCompiler(), ArrayCopyChecker())
+    @custom_function(
+        CopyInoutCompiler(), ArrayCopyChecker(), unitary_flags=UnitaryFlags.Dagger
+    )
     def copy(self: array[T, n]) -> array[T, n]:
         """Copy an array instance. Will only work if T is a copyable type."""
 
-    @custom_function(ArrayIsBorrowedCompiler(), checker=ArrayIndexChecker())
+    @custom_function(
+        ArrayIsBorrowedCompiler(),
+        checker=ArrayIndexChecker(),
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def is_borrowed(self: array[L, n], idx: int) -> bool:
         """Checks if an element has been taken out of the array.
 
@@ -105,7 +123,10 @@ class array(builtins.list[_T], Generic[_T, _n]):
             output("a", qs.is_borrowed(3))  # False
         """
 
-    @custom_function(ArrayGetitemCompiler(), checker=ArrayIndexChecker())
+    @custom_function(
+        ArrayGetitemCompiler(),
+        checker=ArrayIndexChecker(),
+    )
     def take(self: array[L, n], idx: int) -> L:
         """Takes an element out of the array.
 
@@ -165,7 +186,8 @@ class array(builtins.list[_T], Generic[_T, _n]):
         return some(self.take(idx))
 
     @custom_function(
-        ArraySetitemCompiler(elem_first=True), checker=ArrayIndexChecker(expr_index=2)
+        ArraySetitemCompiler(elem_first=True),
+        checker=ArrayIndexChecker(expr_index=2),
     )
     def put(self: array[L, n], elem: L @ owned, idx: int) -> None:
         """Puts an element back into the array if it has been taken out previously.

--- a/guppylang/src/guppylang/std/bool.py
+++ b/guppylang/src/guppylang/std/bool.py
@@ -11,6 +11,7 @@ from guppylang_internals.definition.custom import NoopCompiler
 from guppylang_internals.std._internal.checker import DunderChecker, ReversingChecker
 from guppylang_internals.std._internal.util import logic_op
 from guppylang_internals.tys.builtin import bool_type_def
+from guppylang_internals.tys.ty import UnitaryFlags
 
 from guppylang import guppy
 from guppylang.std.num import nat
@@ -29,7 +30,7 @@ class bool:
     @hugr_op(logic_op("And"))
     def __and__(self: bool, other: bool) -> bool: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __bool__(self: bool) -> bool: ...
 
     @hugr_op(logic_op("Eq"))
@@ -53,7 +54,11 @@ class bool:
         #  See https://github.com/quantinuum/guppylang/issues/707
         return nat(1) if self else nat(0)
 
-    @custom_function(checker=DunderChecker("__bool__"), higher_order_value=False)
+    @custom_function(
+        checker=DunderChecker("__bool__"),
+        higher_order_value=False,
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __new__(x): ...
 
     @hugr_op(logic_op("Or"))
@@ -62,11 +67,11 @@ class bool:
     @hugr_op(logic_op("Xor"))
     def __xor__(self: bool, other: bool) -> bool: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rand__(self: bool, other: bool) -> bool: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __ror__(self: bool, other: bool) -> bool: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rxor__(self: bool, other: bool) -> bool: ...

--- a/guppylang/src/guppylang/std/either.py
+++ b/guppylang/src/guppylang/std/either.py
@@ -14,6 +14,7 @@ from guppylang_internals.std._internal.compiler.either import (
     either_to_hugr,
 )
 from guppylang_internals.tys.param import TypeParam
+from guppylang_internals.tys.ty import UnitaryFlags
 
 from guppylang import guppy
 from guppylang.std.lang import owned
@@ -30,17 +31,17 @@ _params = [TypeParam(0, "L", False, False), TypeParam(1, "L", False, False)]
 class Either[L, R]:
     """Represents a union of either a `left` or a `right` value."""
 
-    @custom_function(EitherTestCompiler(0))
+    @custom_function(EitherTestCompiler(0), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def is_left(self: "Either[L, R]") -> bool:
         """Returns `True` for a `left` value."""
 
-    @custom_function(EitherTestCompiler(1))
+    @custom_function(EitherTestCompiler(1), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def is_right(self: "Either[L, R]") -> bool:
         """Returns `True` for a `right` value."""
 
-    @custom_function(EitherToOptionCompiler(0))
+    @custom_function(EitherToOptionCompiler(0), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def try_into_left(self: "Either[L, Droppable]" @ owned) -> Option[L]:
         """Returns the wrapped value if `self` is a `left` value, or `nothing`
@@ -49,7 +50,7 @@ class Either[L, R]:
         This operation is only allowed if the `right` variant wraps a droppable type.
         """
 
-    @custom_function(EitherToOptionCompiler(1))
+    @custom_function(EitherToOptionCompiler(1), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def try_into_right(self: "Either[Droppable, R]" @ owned) -> Option[R]:
         """Returns the wrapped value if `self` is a `right` value, or `nothing`
@@ -75,13 +76,13 @@ class Either[L, R]:
         """
 
 
-@custom_function(EitherConstructor(0))
+@custom_function(EitherConstructor(0), unitary_flags=UnitaryFlags.Dagger)
 @no_type_check
 def left(val: L @ owned) -> Either[L, R]:
     """Constructs a `left` either value."""
 
 
-@custom_function(EitherConstructor(1))
+@custom_function(EitherConstructor(1), unitary_flags=UnitaryFlags.Dagger)
 @no_type_check
 def right[L, R](val: R @ owned) -> Either[L, R]:
     """Constructs a `right` either value."""

--- a/guppylang/src/guppylang/std/err.py
+++ b/guppylang/src/guppylang/std/err.py
@@ -11,6 +11,7 @@ from guppylang_internals.std._internal.compiler.either import (
     either_to_hugr,
 )
 from guppylang_internals.tys.param import TypeParam
+from guppylang_internals.tys.ty import UnitaryFlags
 
 from guppylang import guppy
 from guppylang.std.either import Either
@@ -26,12 +27,12 @@ _params = [TypeParam(0, "T", False, False), TypeParam(1, "E", False, False)]
 class Result[T, E]:
     """Represents a union of either an `ok(T)` or an `err(E)` value."""
 
-    @custom_function(EitherTestCompiler(0))
+    @custom_function(EitherTestCompiler(0), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def is_ok(self: "Result[T, E]") -> bool:
         """Returns `True` for an `ok` value."""
 
-    @custom_function(EitherTestCompiler(1))
+    @custom_function(EitherTestCompiler(1), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def is_err(self: "Result[T, E]") -> bool:
         """Returns `True` for an `err` value."""
@@ -52,19 +53,19 @@ class Result[T, E]:
         Panics if `self` is an `ok` value.
         """
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def into_either(self: "Result[T, E]" @ owned) -> Either[T, E]:
         """Casts a `Result` value into an `Either` value."""
 
 
-@custom_function(EitherConstructor(0))
+@custom_function(EitherConstructor(0), unitary_flags=UnitaryFlags.Dagger)
 @no_type_check
 def ok(val: T @ owned) -> Result[T, E]:
     """Constructs an `ok` result value."""
 
 
-@custom_function(EitherConstructor(1))
+@custom_function(EitherConstructor(1), unitary_flags=UnitaryFlags.Dagger)
 @no_type_check
 def err[T, E](err: E @ owned) -> Result[T, E]:
     """Constructs an `err` result value."""

--- a/guppylang/src/guppylang/std/num.py
+++ b/guppylang/src/guppylang/std/num.py
@@ -19,6 +19,7 @@ from guppylang_internals.std._internal.util import (
     unsupported_op,
 )
 from guppylang_internals.tys.builtin import float_type_def, int_type_def, nat_type_def
+from guppylang_internals.tys.ty import UnitaryFlags
 
 from guppylang import guppy
 
@@ -27,13 +28,13 @@ from guppylang import guppy
 class nat:
     """A 64-bit unsigned integer."""
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __abs__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("iadd"))
+    @hugr_op(int_op("iadd"), unitary_flags=UnitaryFlags.Dagger)
     def __add__(self: nat, other: nat) -> nat: ...
 
-    @hugr_op(int_op("iand"))
+    @hugr_op(int_op("iand"), unitary_flags=UnitaryFlags.Dagger)
     def __and__(self: nat, other: nat) -> nat: ...
 
     @guppy
@@ -41,115 +42,122 @@ class nat:
     def __bool__(self: nat) -> bool:
         return self != 0
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __ceil__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("idivmod_u", n_vars=2))
+    @hugr_op(int_op("idivmod_u", n_vars=2), unitary_flags=UnitaryFlags.Dagger)
     def __divmod__(self: nat, other: nat) -> tuple[nat, nat]: ...
 
-    @hugr_op(int_op("ieq"))
+    @hugr_op(int_op("ieq"), unitary_flags=UnitaryFlags.Dagger)
     def __eq__(self: nat, other: nat) -> bool: ...
 
-    @hugr_op(int_op("convert_u", hugr.std.int.CONVERSIONS_EXTENSION))
+    @hugr_op(
+        int_op("convert_u", hugr.std.int.CONVERSIONS_EXTENSION),
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __float__(self: nat) -> float: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __floor__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("idiv_u"))
+    @hugr_op(int_op("idiv_u"), unitary_flags=UnitaryFlags.Dagger)
     def __floordiv__(self: nat, other: nat) -> nat: ...
 
-    @hugr_op(int_op("ige_u"))
+    @hugr_op(int_op("ige_u"), unitary_flags=UnitaryFlags.Dagger)
     def __ge__(self: nat, other: nat) -> bool: ...
 
-    @hugr_op(int_op("igt_u"))
+    @hugr_op(int_op("igt_u"), unitary_flags=UnitaryFlags.Dagger)
     def __gt__(self: nat, other: nat) -> bool: ...
 
-    @hugr_op(int_op("iu_to_s"))
+    @hugr_op(int_op("iu_to_s"), unitary_flags=UnitaryFlags.Dagger)
     def __int__(self: nat) -> int: ...
 
-    @hugr_op(int_op("inot"))
+    @hugr_op(int_op("inot"), unitary_flags=UnitaryFlags.Dagger)
     def __invert__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("ile_u"))
+    @hugr_op(int_op("ile_u"), unitary_flags=UnitaryFlags.Dagger)
     def __le__(self: nat, other: nat) -> bool: ...
 
-    @hugr_op(int_op("ishl"))
+    @hugr_op(int_op("ishl"), unitary_flags=UnitaryFlags.Dagger)
     def __lshift__(self: nat, other: nat) -> nat: ...
 
-    @hugr_op(int_op("ilt_u"))
+    @hugr_op(int_op("ilt_u"), unitary_flags=UnitaryFlags.Dagger)
     def __lt__(self: nat, other: nat) -> bool: ...
 
-    @hugr_op(int_op("imod_u"))
+    @hugr_op(int_op("imod_u"), unitary_flags=UnitaryFlags.Dagger)
     def __mod__(self: nat, other: nat) -> nat: ...
 
-    @hugr_op(int_op("imul"))
+    @hugr_op(int_op("imul"), unitary_flags=UnitaryFlags.Dagger)
     def __mul__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __nat__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("ine"))
+    @hugr_op(int_op("ine"), unitary_flags=UnitaryFlags.Dagger)
     def __ne__(self: nat, other: nat) -> bool: ...
 
-    @custom_function(checker=DunderChecker("__nat__"), higher_order_value=False)
+    @custom_function(
+        checker=DunderChecker("__nat__"),
+        higher_order_value=False,
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __new__(x): ...
 
-    @hugr_op(int_op("ior"))
+    @hugr_op(int_op("ior"), unitary_flags=UnitaryFlags.Dagger)
     def __or__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __pos__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("ipow"))
+    @hugr_op(int_op("ipow"), unitary_flags=UnitaryFlags.Dagger)
     def __pow__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __radd__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rand__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rdivmod__(self: nat, other: nat) -> tuple[nat, nat]: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rfloordiv__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rlshift__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rmod__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rmul__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __ror__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __round__(self: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rpow__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rrshift__(self: nat, other: nat) -> nat: ...
 
-    @hugr_op(int_op("ishr"))
+    @hugr_op(int_op("ishr"), unitary_flags=UnitaryFlags.Dagger)
     def __rshift__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rsub__(self: nat, other: nat) -> nat: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rtruediv__(self: nat, other: nat) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rxor__(self: nat, other: nat) -> nat: ...
 
-    @hugr_op(int_op("isub"))
+    @hugr_op(int_op("isub"), unitary_flags=UnitaryFlags.Dagger)
     def __sub__(self: nat, other: nat) -> nat: ...
 
     @guppy
@@ -157,10 +165,10 @@ class nat:
     def __truediv__(self: nat, other: nat) -> float:
         return float(self) / float(other)
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __trunc__(self: nat) -> nat: ...
 
-    @hugr_op(int_op("ixor"))
+    @hugr_op(int_op("ixor"), unitary_flags=UnitaryFlags.Dagger)
     def __xor__(self: nat, other: nat) -> nat: ...
 
 
@@ -168,13 +176,15 @@ class nat:
 class int:
     """A 64-bit signed integer."""
 
-    @hugr_op(int_op("iabs"))  # TODO: Maybe wrong? (signed vs unsigned!)
+    @hugr_op(
+        int_op("iabs"), unitary_flags=UnitaryFlags.Dagger
+    )  # TODO: Maybe wrong? (signed vs unsigned!)
     def __abs__(self: int) -> int: ...
 
-    @hugr_op(int_op("iadd"))
+    @hugr_op(int_op("iadd"), unitary_flags=UnitaryFlags.Dagger)
     def __add__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("iand"))
+    @hugr_op(int_op("iand"), unitary_flags=UnitaryFlags.Dagger)
     def __and__(self: int, other: int) -> int: ...
 
     @guppy
@@ -185,64 +195,71 @@ class int:
     @custom_function(NoopCompiler())
     def __ceil__(self: int) -> int: ...
 
-    @hugr_op(int_op("idivmod_s"))
+    @hugr_op(int_op("idivmod_s"), unitary_flags=UnitaryFlags.Dagger)
     def __divmod__(self: int, other: int) -> tuple[int, int]: ...
 
-    @hugr_op(int_op("ieq"))
+    @hugr_op(int_op("ieq"), unitary_flags=UnitaryFlags.Dagger)
     def __eq__(self: int, other: int) -> bool: ...
 
-    @hugr_op(int_op("convert_s", hugr.std.int.CONVERSIONS_EXTENSION))
+    @hugr_op(
+        int_op("convert_s", hugr.std.int.CONVERSIONS_EXTENSION),
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __float__(self: int) -> float: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __floor__(self: int) -> int: ...
 
-    @hugr_op(int_op("idiv_s"))
+    @hugr_op(int_op("idiv_s"), unitary_flags=UnitaryFlags.Dagger)
     def __floordiv__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("ige_s"))
+    @hugr_op(int_op("ige_s"), unitary_flags=UnitaryFlags.Dagger)
     def __ge__(self: int, other: int) -> bool: ...
 
-    @hugr_op(int_op("igt_s"))
+    @hugr_op(int_op("igt_s"), unitary_flags=UnitaryFlags.Dagger)
     def __gt__(self: int, other: int) -> bool: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __int__(self: int) -> int: ...
 
-    @hugr_op(int_op("inot"))
+    @hugr_op(int_op("inot"), unitary_flags=UnitaryFlags.Dagger)
     def __invert__(self: int) -> int: ...
 
-    @hugr_op(int_op("ile_s"))
+    @hugr_op(int_op("ile_s"), unitary_flags=UnitaryFlags.Dagger)
     def __le__(self: int, other: int) -> bool: ...
 
-    @hugr_op(int_op("ishl"))  # TODO: RHS is unsigned
+    @hugr_op(int_op("ishl"), unitary_flags=UnitaryFlags.Dagger)  # TODO: RHS is unsigned
     def __lshift__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("ilt_s"))
+    @hugr_op(int_op("ilt_s"), unitary_flags=UnitaryFlags.Dagger)
     def __lt__(self: int, other: int) -> bool: ...
 
-    @hugr_op(int_op("imod_s"))
+    @hugr_op(int_op("imod_s"), unitary_flags=UnitaryFlags.Dagger)
     def __mod__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("imul"))
+    @hugr_op(int_op("imul"), unitary_flags=UnitaryFlags.Dagger)
     def __mul__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("is_to_u"))
+    @hugr_op(int_op("is_to_u"), unitary_flags=UnitaryFlags.Dagger)
     def __nat__(self: int) -> nat: ...
 
-    @hugr_op(int_op("ine"))
+    @hugr_op(int_op("ine"), unitary_flags=UnitaryFlags.Dagger)
     def __ne__(self: int, other: int) -> bool: ...
 
-    @hugr_op(int_op("ineg"))
+    @hugr_op(int_op("ineg"), unitary_flags=UnitaryFlags.Dagger)
     def __neg__(self: int) -> int: ...
 
-    @custom_function(checker=DunderChecker("__int__"), higher_order_value=False)
+    @custom_function(
+        checker=DunderChecker("__int__"),
+        higher_order_value=False,
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __new__(x): ...
 
-    @hugr_op(int_op("ior"))
+    @hugr_op(int_op("ior"), unitary_flags=UnitaryFlags.Dagger)
     def __or__(self: int, other: int) -> int: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __pos__(self: int) -> int: ...
 
     @guppy
@@ -255,55 +272,59 @@ class int:
             )
         return self.__pow_impl(exponent)
 
-    @hugr_op(int_op("ipow"))
+    @hugr_op(int_op("ipow"), unitary_flags=UnitaryFlags.Dagger)
     def __pow_impl(self: int, exponent: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __radd__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rand__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rdivmod__(self: int, other: int) -> tuple[int, int]: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rfloordiv__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())  # TODO: RHS is unsigned
+    @custom_function(
+        checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger
+    )  # TODO: RHS is unsigned
     def __rlshift__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rmod__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rmul__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __ror__(self: int, other: int) -> int: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __round__(self: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rpow__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())  # TODO: RHS is unsigned
+    @custom_function(
+        checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger
+    )  # TODO: RHS is unsigned
     def __rrshift__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("ishr"))  # TODO: RHS is unsigned
+    @hugr_op(int_op("ishr"), unitary_flags=UnitaryFlags.Dagger)  # TODO: RHS is unsigned
     def __rshift__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rsub__(self: int, other: int) -> int: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rtruediv__(self: int, other: int) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rxor__(self: int, other: int) -> int: ...
 
-    @hugr_op(int_op("isub"))
+    @hugr_op(int_op("isub"), unitary_flags=UnitaryFlags.Dagger)
     def __sub__(self: int, other: int) -> int: ...
 
     @guppy
@@ -311,10 +332,10 @@ class int:
     def __truediv__(self: int, other: int) -> float:
         return float(self) / float(other)
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __trunc__(self: int) -> int: ...
 
-    @hugr_op(int_op("ixor"))
+    @hugr_op(int_op("ixor"), unitary_flags=UnitaryFlags.Dagger)
     def __xor__(self: int, other: int) -> int: ...
 
 
@@ -322,10 +343,10 @@ class int:
 class float:
     """An IEEE754 double-precision floating point value."""
 
-    @hugr_op(float_op("fabs"))
+    @hugr_op(float_op("fabs"), unitary_flags=UnitaryFlags.Dagger)
     def __abs__(self: float) -> float: ...
 
-    @hugr_op(float_op("fadd"))
+    @hugr_op(float_op("fadd"), unitary_flags=UnitaryFlags.Dagger)
     def __add__(self: float, other: float) -> float: ...
 
     @guppy
@@ -333,7 +354,7 @@ class float:
     def __bool__(self: float) -> bool:
         return self != 0.0
 
-    @hugr_op(float_op("fceil"))
+    @hugr_op(float_op("fceil"), unitary_flags=UnitaryFlags.Dagger)
     def __ceil__(self: float) -> float: ...
 
     @guppy
@@ -341,13 +362,13 @@ class float:
     def __divmod__(self: float, other: float) -> tuple[float, float]:
         return self // other, self.__mod__(other)
 
-    @hugr_op(float_op("feq"))
+    @hugr_op(float_op("feq"), unitary_flags=UnitaryFlags.Dagger)
     def __eq__(self: float, other: float) -> bool: ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __float__(self: float) -> float: ...
 
-    @hugr_op(float_op("ffloor"))
+    @hugr_op(float_op("ffloor"), unitary_flags=UnitaryFlags.Dagger)
     def __floor__(self: float) -> float: ...
 
     @guppy
@@ -355,24 +376,25 @@ class float:
     def __floordiv__(self: float, other: float) -> float:
         return (self / other).__floor__()
 
-    @hugr_op(float_op("fge"))
+    @hugr_op(float_op("fge"), unitary_flags=UnitaryFlags.Dagger)
     def __ge__(self: float, other: float) -> bool: ...
 
-    @hugr_op(float_op("fgt"))
+    @hugr_op(float_op("fgt"), unitary_flags=UnitaryFlags.Dagger)
     def __gt__(self: float, other: float) -> bool: ...
 
     @custom_function(
         UnwrapOpCompiler(
             # Use `int_op` to instantiate type arg with 64-bit integer.
             int_op("trunc_s", hugr.std.int.CONVERSIONS_EXTENSION),
-        )
+        ),
+        unitary_flags=UnitaryFlags.Dagger,
     )
     def __int__(self: float) -> int: ...
 
-    @hugr_op(float_op("fle"))
+    @hugr_op(float_op("fle"), unitary_flags=UnitaryFlags.Dagger)
     def __le__(self: float, other: float) -> bool: ...
 
-    @hugr_op(float_op("flt"))
+    @hugr_op(float_op("flt"), unitary_flags=UnitaryFlags.Dagger)
     def __lt__(self: float, other: float) -> bool: ...
 
     @guppy
@@ -380,70 +402,81 @@ class float:
     def __mod__(self: float, other: float) -> float:
         return self - (self // other) * other
 
-    @hugr_op(float_op("fmul"))
+    @hugr_op(float_op("fmul"), unitary_flags=UnitaryFlags.Dagger)
     def __mul__(self: float, other: float) -> float: ...
 
     @custom_function(
         UnwrapOpCompiler(
             # Use `int_op` to instantiate type arg with 64-bit integer.
             int_op("trunc_u", hugr.std.int.CONVERSIONS_EXTENSION),
-        )
+        ),
+        unitary_flags=UnitaryFlags.Dagger,
     )
     def __nat__(self: float) -> nat: ...
 
-    @hugr_op(float_op("fne"))
+    @hugr_op(float_op("fne"), unitary_flags=UnitaryFlags.Dagger)
     def __ne__(self: float, other: float) -> bool: ...
 
-    @hugr_op(float_op("fneg"))
+    @hugr_op(float_op("fneg"), unitary_flags=UnitaryFlags.Dagger)
     def __neg__(self: float) -> float: ...
 
-    @custom_function(checker=DunderChecker("__float__"), higher_order_value=False)
+    @custom_function(
+        checker=DunderChecker("__float__"),
+        higher_order_value=False,
+        unitary_flags=UnitaryFlags.Dagger,
+    )
     def __new__(x): ...
 
-    @custom_function(NoopCompiler())
+    @custom_function(NoopCompiler(), unitary_flags=UnitaryFlags.Dagger)
     def __pos__(self: float) -> float: ...
 
-    @hugr_op(float_op("fpow"))  # TODO
+    @hugr_op(float_op("fpow"), unitary_flags=UnitaryFlags.Dagger)  # TODO
     def __pow__(self: float, other: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __radd__(self: float, other: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rdivmod__(self: float, other: float) -> tuple[float, float]: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rfloordiv__(self: float, other: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rmod__(self: float, other: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rmul__(self: float, other: float) -> float: ...
 
-    @hugr_op(float_op("fround"))  # TODO
+    @hugr_op(float_op("fround"), unitary_flags=UnitaryFlags.Dagger)  # TODO
     def __round__(self: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rpow__(self: float, other: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rsub__(self: float, other: float) -> float: ...
 
-    @custom_function(checker=ReversingChecker())
+    @custom_function(checker=ReversingChecker(), unitary_flags=UnitaryFlags.Dagger)
     def __rtruediv__(self: float, other: float) -> float: ...
 
-    @hugr_op(float_op("fsub"))
+    @hugr_op(float_op("fsub"), unitary_flags=UnitaryFlags.Dagger)
     def __sub__(self: float, other: float) -> float: ...
 
-    @hugr_op(float_op("fdiv"))
+    @hugr_op(float_op("fdiv"), unitary_flags=UnitaryFlags.Dagger)
     def __truediv__(self: float, other: float) -> float: ...
 
-    @hugr_op(unsupported_op("trunc_s"))  # TODO `trunc_s` returns an option
+    @hugr_op(
+        unsupported_op("trunc_s"), unitary_flags=UnitaryFlags.Dagger
+    )  # TODO `trunc_s` returns an option
     def __trunc__(self: float) -> float: ...
 
 
-@custom_function(checker=DunderChecker("__abs__"), higher_order_value=False)
+@custom_function(
+    checker=DunderChecker("__abs__"),
+    higher_order_value=False,
+    unitary_flags=UnitaryFlags.Dagger,
+)
 def abs(x): ...
 
 
@@ -451,7 +484,8 @@ def abs(x): ...
 @hugr_op(
     external_op(
         "bytecast_int64_to_float64", args=[], ext=hugr.std.int.CONVERSIONS_EXTENSION
-    )
+    ),
+    unitary_flags=UnitaryFlags.Dagger,
 )
 def bytecast_nat_to_float(n: nat) -> float: ...
 
@@ -459,26 +493,41 @@ def bytecast_nat_to_float(n: nat) -> float: ...
 @hugr_op(
     external_op(
         "bytecast_float64_to_int64", args=[], ext=hugr.std.int.CONVERSIONS_EXTENSION
-    )
+    ),
+    unitary_flags=UnitaryFlags.Dagger,
 )
 def bytecast_float_to_nat(f: float) -> nat: ...
 
 
 @custom_function(
-    checker=DunderChecker("__divmod__", num_args=2), higher_order_value=False
+    checker=DunderChecker("__divmod__", num_args=2),
+    higher_order_value=False,
+    unitary_flags=UnitaryFlags.Dagger,
 )
 def divmod(x, y): ...
 
 
-@custom_function(checker=DunderChecker("__len__"), higher_order_value=False)
+@custom_function(
+    checker=DunderChecker("__len__"),
+    higher_order_value=False,
+    unitary_flags=UnitaryFlags.Dagger,
+)
 def len(x): ...
 
 
-@custom_function(checker=DunderChecker("__pow__", num_args=2), higher_order_value=False)
+@custom_function(
+    checker=DunderChecker("__pow__", num_args=2),
+    higher_order_value=False,
+    unitary_flags=UnitaryFlags.Dagger,
+)
 def pow(x, y): ...
 
 
-@custom_function(checker=DunderChecker("__round__"), higher_order_value=False)
+@custom_function(
+    checker=DunderChecker("__round__"),
+    higher_order_value=False,
+    unitary_flags=UnitaryFlags.Dagger,
+)
 def round(x): ...
 
 

--- a/guppylang/src/guppylang/std/option.py
+++ b/guppylang/src/guppylang/std/option.py
@@ -10,6 +10,7 @@ from guppylang_internals.std._internal.compiler.option import (
     OptionUnwrapNothingCompiler,
 )
 from guppylang_internals.tys.builtin import option_type_def
+from guppylang_internals.tys.ty import UnitaryFlags
 
 from guppylang import guppy
 from guppylang.std.lang import owned
@@ -22,12 +23,12 @@ L = guppy.type_var("T", copyable=False, droppable=False)
 class Option(Generic[L]):  # type: ignore[misc]
     """Represents an optional value."""
 
-    @custom_function(OptionTestCompiler(0))
+    @custom_function(OptionTestCompiler(0), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def is_nothing(self: "Option[L]") -> bool:
         """Returns `True` if the option is a `nothing` value."""
 
-    @custom_function(OptionTestCompiler(1))
+    @custom_function(OptionTestCompiler(1), unitary_flags=UnitaryFlags.Dagger)
     @no_type_check
     def is_some(self: "Option[L]") -> bool:
         """Returns `True` if the option is a `some` value."""
@@ -62,7 +63,7 @@ class Option(Generic[L]):  # type: ignore[misc]
         return self.swap(nothing())
 
 
-@custom_function(OptionConstructor(0))
+@custom_function(OptionConstructor(0), unitary_flags=UnitaryFlags.Dagger)
 @no_type_check
 def nothing() -> Option[L]:
     """Constructs a `nothing` optional value."""

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -587,3 +587,35 @@ def test_hugr_stability():
         hashes.add(sig)
 
     assert len(hashes) == 1
+
+
+def test_std(validate):
+    from guppylang.std.err import Result, ok
+    from guppylang.std.option import Option
+
+    y = 42
+
+    n = guppy.nat_var("n")
+
+    @guppy.comptime(daggerable=True)
+    def test(r: Result[int, qubit] @ owned) -> tuple[float, Option[qubit]]:
+        b = r.is_ok()
+        e = r.into_either()
+        b = e.is_right()
+        o = e.try_into_right()
+        b = o.is_some()
+        return 1 + 2.0 - 3 * 4 // y, o
+
+    @guppy.comptime(daggerable=True)
+    def test_arr() -> array[int, n]:
+        x = array(y // y for i in range(n)).copy()
+        return x
+
+    @guppy
+    def main() -> None:
+        test_arr[3]()
+        r = ok[int, qubit](42)
+        _, oq = test(r)
+        oq.unwrap_nothing()
+
+    validate(main.compile())


### PR DESCRIPTION
Backport of https://github.com/Quantinuum/guppylang/pull/2140