### PR TITLE
fix: docstring formatting

### DIFF
--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -213,7 +213,8 @@ class GuppyCompilableProgram(Protocol):
 
         Args:
             debug_mode: Whether to add debug information to the compiled package. This
-            may be useful for debugging, but will increase the size of the HUGR package.
+                may be useful for debugging, but will increase the size of the HUGR
+                package.
         Returns:
             Package: The compiled package object.
         Raises:
@@ -226,7 +227,8 @@ class GuppyCompilableProgram(Protocol):
 
         Args:
             debug_mode: Whether to add debug information to the compiled package. This
-            may be useful for debugging, but will increase the size of the HUGR package.
+                may be useful for debugging, but will increase the size of the HUGR
+                package.
         Returns:
             Package: The compiled package object.
         Raises:
@@ -403,7 +405,8 @@ class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P
 
         Args:
             debug_mode: Whether to add debug information to the compiled package. This
-            may be useful for debugging, but will increase the size of the HUGR package.
+                may be useful for debugging, but will increase the size of the HUGR
+                package.
         Returns:
             Package: The compiled package object.
         Raises:
@@ -419,7 +422,8 @@ class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P
 
         Args:
             debug_mode: Whether to add debug information to the compiled package. This
-            may be useful for debugging, but will increase the size of the HUGR package.
+                may be useful for debugging, but will increase the size of the HUGR
+                package.
         Returns:
             Package: The compiled package object.
         Raises:
@@ -456,7 +460,8 @@ class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P
 
         Args:
             debug_mode: Whether to add debug information to the compiled package. This
-            may be useful for debugging, but will increase the size of the HUGR package.
+                may be useful for debugging, but will increase the size of the HUGR
+                package.
         Returns:
             Package: The compiled package object.
         """

--- a/guppylang/src/guppylang/emulator/state.py
+++ b/guppylang/src/guppylang/emulator/state.py
@@ -107,7 +107,7 @@ class PartialVector(PartialState[StateVector]):
             base_state: The state vector over all qubits in the system.
             total_qubits: Total number of qubits in the system
             specified_qubits: List of specified qubits in the state. Those not in this
-            list are considered traced out.
+                list are considered traced out.
         """
         if len(base_state) != (1 << total_qubits):
             raise ValueError(

--- a/guppylang/src/guppylang/std/debug.py
+++ b/guppylang/src/guppylang/std/debug.py
@@ -20,7 +20,7 @@ def state_output(tag, *args) -> None:
     Args:
         tag: A string literal representing the tag of the state output.
         args: The qubits whose quantum state is to be reported. The order they are given
-        in corresponds to the order in which the state will be reported.
+            in corresponds to the order in which the state will be reported.
     """
 
 

--- a/guppylang/src/guppylang/std/platform.py
+++ b/guppylang/src/guppylang/std/platform.py
@@ -156,7 +156,7 @@ def panic(msg: str, signal: int = 1, *args):
         message: The message to display. Must be a string literal.
         signal: An optional integer for distinguishing different failure modes.
         args: Arbitrary extra inputs, will not affect the message. Only useful for
-        consuming linear values.
+            consuming linear values.
     """
 
 
@@ -210,7 +210,7 @@ def exit(msg: str, signal: int = 1, *args):
         message: The message to display. Must be a string literal.
         signal: An optional integer for distinguishing different failure modes.
         args: Arbitrary extra inputs, will not affect the message. Only useful for
-        consuming linear values.
+            consuming linear values.
     """
 
 

--- a/guppylang/src/guppylang/std/qsystem/random.py
+++ b/guppylang/src/guppylang/std/qsystem/random.py
@@ -84,7 +84,7 @@ class RNG:
 
         Args:
             delta: Number of steps to move the RNG state forward (if positive)
-            or backward (if negative).
+                or backward (if negative).
         """
 
     @guppy


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
docs: Fix formatting of multiple docstrings (#2165)
END_COMMIT_OVERRIDE