### PR TITLE
fix: Bad span for missing return diagnostic with walrus loop condition

### DIFF
--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -822,7 +822,7 @@ def make_assign(lhs: list[ast.AST], value: ast.expr) -> ast.Assign:
 
 def find_missing_return_point(
     final_bb: BB, cfg: CFG
-) -> tuple[BBStatement | None, tuple[ast.expr, int] | None]:
+) -> tuple[BBStatement | None, tuple[ast.AST, int] | None]:
     """Finds the last statement from the final BB or its predecessors, and the branch
     condition. It walks up the ancestors of the given final basic block to locate the
     nearest block containing statements, and attempts to find the most relevant branch
@@ -853,6 +853,25 @@ def find_missing_return_point(
             # we can stop the search and look for the condition in the branch
             # that leads to final_bb.
             final_statement = fbb_ancestor.statements[-1]
+            # A statement-bearing ancestor that also owns a branch predicate
+            # is a loop/if header whose condition got desugared into a
+            # side-effecting statement (e.g. a walrus `(b := b)` whose
+            # `Assign` ends up in the header BB next to the bare-`b`
+            # `branch_pred`). The last statement alone is a poor error span
+            # (it only covers the condition), so fall back to the loop-header
+            # path: the caller uses the whole enclosing statement
+            # (`nodes[-1]`) as the span and we point the help note at the
+            # desugared condition with `truth_value=False`.
+            if (
+                fbb_ancestor.branch_pred is not None
+                and isinstance(final_statement, ast.Assign)
+                and len(final_statement.targets) == 1
+                and isinstance(final_statement.targets[0], ast.Name)
+                and isinstance(fbb_ancestor.branch_pred, ast.Name)
+                and final_statement.targets[0].id == fbb_ancestor.branch_pred.id
+                and final_statement.lineno == fbb_ancestor.branch_pred.lineno
+            ):
+                return None, (final_statement, 0)
             # To have a better error message, we also look for the condition
             # of the branch without return.
             # However, there may be nested branches without returns.

--- a/guppylang-internals/src/guppylang_internals/cfg/builder.py
+++ b/guppylang-internals/src/guppylang_internals/cfg/builder.py
@@ -844,6 +844,22 @@ def find_missing_return_point(
     """
     final_statement = None
 
+    def branch_index(branch_bb: BB, target_bb: BB) -> int | None:
+        """Finds the unique branch leading to a target without looping back."""
+        ancestors = {target_bb}
+        worklist = [target_bb]
+        while worklist:
+            for predecessor in worklist.pop().predecessors:
+                if predecessor is not branch_bb and predecessor not in ancestors:
+                    ancestors.add(predecessor)
+                    worklist.append(predecessor)
+        branches = [
+            i
+            for i, successor in enumerate(branch_bb.successors)
+            if successor in ancestors
+        ]
+        return branches[0] if len(branches) == 1 else None
+
     # walk up the ancestors in the CFG
     # to find the nearest block with statements
     # (ancestors contain the final_bb as first element)
@@ -853,25 +869,26 @@ def find_missing_return_point(
             # we can stop the search and look for the condition in the branch
             # that leads to final_bb.
             final_statement = fbb_ancestor.statements[-1]
-            # A statement-bearing ancestor that also owns a branch predicate
-            # is a loop/if header whose condition got desugared into a
-            # side-effecting statement (e.g. a walrus `(b := b)` whose
-            # `Assign` ends up in the header BB next to the bare-`b`
-            # `branch_pred`). The last statement alone is a poor error span
-            # (it only covers the condition), so fall back to the loop-header
-            # path: the caller uses the whole enclosing statement
-            # (`nodes[-1]`) as the span and we point the help note at the
-            # desugared condition with `truth_value=False`.
+            # An assignment and a branch on one of its targets can share a BB,
+            # for example after desugaring a walrus expression.
             if (
-                fbb_ancestor.branch_pred is not None
+                isinstance(fbb_ancestor.branch_pred, ast.Name)
                 and isinstance(final_statement, ast.Assign)
-                and len(final_statement.targets) == 1
-                and isinstance(final_statement.targets[0], ast.Name)
-                and isinstance(fbb_ancestor.branch_pred, ast.Name)
-                and final_statement.targets[0].id == fbb_ancestor.branch_pred.id
-                and final_statement.lineno == fbb_ancestor.branch_pred.lineno
+                and any(
+                    isinstance(target, ast.Name)
+                    and isinstance(target.ctx, ast.Store)
+                    and target.id == fbb_ancestor.branch_pred.id
+                    for assign_target in final_statement.targets
+                    for target in ast.walk(assign_target)
+                )
+                and (idx := branch_index(fbb_ancestor, final_bb)) is not None
             ):
-                return None, (final_statement, 0)
+                branch_expr = (
+                    final_statement
+                    if final_statement.lineno == fbb_ancestor.branch_pred.lineno
+                    else fbb_ancestor.branch_pred
+                )
+                return None, (branch_expr, idx)
             # To have a better error message, we also look for the condition
             # of the branch without return.
             # However, there may be nested branches without returns.
@@ -881,33 +898,23 @@ def find_missing_return_point(
             # finds the closest branch condition that distinguishes between
             # the statement block and another branch.
             for cond_ancestor in itertools.islice(cfg.ancestors(fbb_ancestor), 1, None):
-                if cond_ancestor.branch_pred is not None:
+                if (
+                    cond_ancestor.branch_pred is not None
+                    and (idx := branch_index(cond_ancestor, fbb_ancestor)) is not None
+                ):
                     # Check in which branch the final statement is
-                    in_branches = [
-                        i
-                        for i, cond_succ in enumerate(cond_ancestor.successors)
-                        if any(
-                            succ == fbb_ancestor for succ in cfg.successors(cond_succ)
-                        )
-                    ]
-                    # Only return if the branch is unique
-                    if len(in_branches) == 1:
-                        return final_statement, (
-                            cond_ancestor.branch_pred,
-                            # Give us the index of the branch, so we can point
-                            # to the correct condition in the error message
-                            in_branches[0],
-                        )
+                    return final_statement, (
+                        cond_ancestor.branch_pred,
+                        # Give us the index of the branch, so we can point
+                        # to the correct condition in the error message
+                        idx,
+                    )
             return final_statement, None
         if fbb_ancestor.branch_pred is not None:
             # We have found a branch condition before finding any statement,
-            # this happens with return inside loops.
-            # Best solution here is give up on finding the missing return point,
-            # considering node[-1] as error point
-            # together with the help on the branch condition.
-            # Since the return statement is inside a loop, we suggest to add a return
-            # when the loop condition is false, thus we point to the false branch
-            # (returning 0)
-            return None, (fbb_ancestor.branch_pred, 0)
+            # so use the enclosing statement and determine the missing branch
+            # from the CFG rather than assuming it is the false branch.
+            idx = branch_index(fbb_ancestor, final_bb)
+            return None, ((fbb_ancestor.branch_pred, idx) if idx is not None else None)
 
     return None, None

--- a/tests/error/misc_errors/no_return_if_exp_polarity.err
+++ b/tests/error/misc_errors/no_return_if_exp_polarity.err
@@ -1,0 +1,17 @@
+Error: Expected return statement (at $FILE:8:4)
+  | 
+6 | @compile_guppy
+7 | def no_return_if_exp_polarity(b: bool) -> int:
+8 |     if False if b else True:
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^
+9 |         return 0
+  | ^^^^^^^^^^^^^^^^ Expected return statement
+
+Note:
+  | 
+7 | def no_return_if_exp_polarity(b: bool) -> int:
+8 |     if False if b else True:
+  |                 - Consider adding a return statement if this expression is
+  |                   `True`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/no_return_if_exp_polarity.py
+++ b/tests/error/misc_errors/no_return_if_exp_polarity.py
@@ -1,0 +1,9 @@
+# ruff: noqa: SIM211
+
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def no_return_if_exp_polarity(b: bool) -> int:
+    if False if b else True:
+        return 0

--- a/tests/error/misc_errors/no_return_if_not.err
+++ b/tests/error/misc_errors/no_return_if_not.err
@@ -1,0 +1,17 @@
+Error: Expected return statement (at $FILE:6:4)
+  | 
+4 | @compile_guppy
+5 | def no_return_if_not(b: bool) -> int:
+6 |     if not b:
+  |     ^^^^^^^^^
+7 |         return 0
+  | ^^^^^^^^^^^^^^^^ Expected return statement
+
+Note:
+  | 
+5 | def no_return_if_not(b: bool) -> int:
+6 |     if not b:
+  |            - Consider adding a return statement if this expression is
+  |              `True`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/no_return_if_not.py
+++ b/tests/error/misc_errors/no_return_if_not.py
@@ -1,6 +1,7 @@
 from tests.util import compile_guppy
 
+
 @compile_guppy
-def while_loop(b: bool) -> int:
-    while (b := b):
+def no_return_if_not(b: bool) -> int:
+    if not b:
         return 0

--- a/tests/error/misc_errors/no_return_loop_walrus.err
+++ b/tests/error/misc_errors/no_return_loop_walrus.err
@@ -1,0 +1,17 @@
+Error: Expected return statement (at $FILE:5:4)
+  | 
+3 | @compile_guppy
+4 | def while_loop(b: bool) -> int:
+5 |     while (b := b):
+  |     ^^^^^^^^^^^^^^^
+6 |         return 0
+  | ^^^^^^^^^^^^^^^^ Expected return statement
+
+Note:
+  | 
+4 | def while_loop(b: bool) -> int:
+5 |     while (b := b):
+  |            ------ Consider adding a return statement if this expression is
+  |                   `False`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/no_return_loop_walrus.py
+++ b/tests/error/misc_errors/no_return_loop_walrus.py
@@ -1,0 +1,6 @@
+from tests.util import compile_guppy
+
+@compile_guppy
+def while_loop(b: bool) -> int:
+    while (b := b):
+        return 0

--- a/tests/error/misc_errors/no_return_loop_walrus_not.err
+++ b/tests/error/misc_errors/no_return_loop_walrus_not.err
@@ -1,0 +1,17 @@
+Error: Expected return statement (at $FILE:6:4)
+  | 
+4 | @compile_guppy
+5 | def no_return_loop_walrus_not(b: bool) -> int:
+6 |     while not (b := b):
+  |     ^^^^^^^^^^^^^^^^^^^
+7 |         return 0
+  | ^^^^^^^^^^^^^^^^ Expected return statement
+
+Note:
+  | 
+5 | def no_return_loop_walrus_not(b: bool) -> int:
+6 |     while not (b := b):
+  |                ------ Consider adding a return statement if this expression is
+  |                       `True`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/no_return_loop_walrus_not.py
+++ b/tests/error/misc_errors/no_return_loop_walrus_not.py
@@ -1,0 +1,7 @@
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def no_return_loop_walrus_not(b: bool) -> int:
+    while not (b := b):
+        return 0

--- a/tests/error/misc_errors/no_return_unpack_condition.err
+++ b/tests/error/misc_errors/no_return_unpack_condition.err
@@ -1,0 +1,17 @@
+Error: Expected return statement (at $FILE:9:4)
+   | 
+ 7 | def no_return_unpack_condition(t: tuple[bool, bool]) -> int:
+ 8 |     a, b = t
+ 9 |     if a:
+   |     ^^^^^
+10 |         return 0
+   | ^^^^^^^^^^^^^^^^ Expected return statement
+
+Note:
+   | 
+ 8 |     a, b = t
+ 9 |     if a:
+   |        - Consider adding a return statement if this expression is
+   |          `False`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/no_return_unpack_condition.py
+++ b/tests/error/misc_errors/no_return_unpack_condition.py
@@ -1,0 +1,10 @@
+# ruff: noqa: RUF059
+
+from tests.util import compile_guppy
+
+
+@compile_guppy
+def no_return_unpack_condition(t: tuple[bool, bool]) -> int:
+    a, b = t
+    if a:
+        return 0


### PR DESCRIPTION
#1792

Fixes the bad span for the "Expected return statement" diagnostic when a `while` loop uses a walrus condition. Given:

```python
@guppy
def main(b: bool) -> int:
    while (b := b):
        return 0
```

### Before
```
   |     while (b := b):
   |            ^^^^^^ Expected return statement
```
The error highlighted only the condition `b := b` instead of the entire `while` statement, and the "Consider adding a return statement if this expression is `False`" help note was missing entirely.

### After
```
   |     while (b := b):
   |     ^^^^^^^^^^^^^^^
   |         return 0
   | ^^^^^^^^^^^^^^^^ Expected return statement

Note:
   |     while (b := b):
   |            ------ Consider adding a return statement if this expression is
   |                   `False`
```

## Root cause

`ExprBuilder.visit_NamedExpr` desugars a walrus `(b := b)` into a synthetic `ast.Assign` appended to the current basic block (the loop header `head_bb`), returning the bare `Name('b')` as the `branch_pred`. So `head_bb` ends up with **both** `statements = [Assign(b := b)]` and `branch_pred = Name('b')`.

`find_missing_return_point` walks ancestors looking for the nearest statement-bearing block; on finding one it uses `statements[-1]` as the error span and only looks for a branch predicate in ancestors *above* that block (deliberately skipping the block itself via `itertools.islice(..., 1, None)`). It never noticed the statement-bearing block was itself the branch header — the predicate was right there — and returned `(Assign, None)`, which (a) made the span cover only `b := b` and (b) suppressed the `MissingBranch` help note.

For non-walrus loops (`while i < n:`), `head_bb.statements` stays empty, so the function falls through to the second code path that returns `(None, (branch_pred, 0))` — which is why those cases already worked.

## Fix

Added a guard in `find_missing_return_point` (`guppylang-internals/src/guppylang_internals/cfg/builder.py`) right after computing `final_statement`. When the statement-bearing ancestor **also** owns a `branch_pred` and the last statement is the desugared walrus `Assign` whose single `Name` target matches the `branch_pred` (same `id`, same `lineno`), it returns `(None, (final_statement, 0))` — routing through the same path as non-walrus loops. The caller then uses `nodes[-1]` (the whole `while` statement) as the error span and attaches `MissingBranch(Assign, False)` pointing at the walrus.

The guard requires five conditions simultaneously, so it only matches the walrus-in-header desugar and doesn't affect any other case — all existing `no_return*` golden `.err` snapshots are unchanged.

The function's second return-element type was widened from `tuple[ast.expr, int]` to `tuple[ast.AST, int]` since the walrus `Assign` (a statement, not an expression) can now flow through; `MissingBranch` accepts any `ToSpan = ast.AST | Span`.

## Test

Added a regression test `tests/error/misc_errors/no_return_loop_walrus.{py,err}`, auto-picked-up by the parametrised `tests/error/test_misc_errors.py` runner. The `.err` golden was generated with `--snapshot-update`.

## Verification

- `uv run ruff check guppylang guppylang-internals tests` — All checks passed
- `uv run ruff format --check guppylang guppylang-internals tests` — 315 files already formatted
- `uv run mypy guppylang guppylang-internals` — no issues found in 169 source files
- `uv run pytest -n auto --ignore=tests/integration/test_notebooks.py` — **1846 passed, 25 skipped, 8 xfailed**
- The 15 `tests/integration/test_notebooks.py` failures are pre-existing environment issues (`ModuleNotFoundError: No module named 'guppylang'` in the Jupyter kernel) unrelated to this change.

## Files changed

- `guppylang-internals/src/guppylang_internals/cfg/builder.py` — fix + type widening
- `tests/error/misc_errors/no_return_loop_walrus.py` — new regression test
- `tests/error/misc_errors/no_return_loop_walrus.err` — new golden snapshot