### PR TITLE
fix: chore: Update `guppylang/pyproject.toml` to use the proper `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ def teleport(src: qubit @ owned, tgt: qubit) -> None:
     if measure(tmp):
         x(tgt)
 
+
 teleport.check()
 ```
 

--- a/guppylang/README.md
+++ b/guppylang/README.md
@@ -48,7 +48,7 @@ teleport.check()
 
 📒 [Example notebooks][examples]
 
-[examples]: ../examples/
+[examples]: https://github.com/quantinuum/guppylang/tree/main/examples
 [guide]: https://docs.quantinuum.com/guppy/language_guide/language_guide_index.html
 [website]: https://guppylang.org
 

--- a/guppylang/README.md
+++ b/guppylang/README.md
@@ -1,3 +1,6 @@
+![](https://raw.githubusercontent.com/quantinuum/guppylang/refs/heads/main/assets/guppy_logo.svg)
+
+
 # Guppy
 
 [![pypi][]](https://pypi.org/project/guppylang/)
@@ -33,12 +36,21 @@ def teleport(src: qubit @ owned, tgt: qubit) -> None:
     if measure(tmp):
         x(tgt)
 
+
 teleport.check()
 ```
 
-More examples and tutorials are available [here][examples].
+## Documentation
 
-[examples]: https://github.com/quantinuum/guppylang/tree/main/examples
+🌐 [Guppy website][website]
+
+📖 [Language guide][guide]
+
+📒 [Example notebooks][examples]
+
+[examples]: ../examples/
+[guide]: https://docs.quantinuum.com/guppy/language_guide/language_guide_index.html
+[website]: https://guppylang.org
 
 ## Install
 
@@ -48,11 +60,10 @@ Guppy can be installed via `pip`. Requires Python >= 3.10.
 pip install guppylang
 ```
 
-## Development
 
-See [DEVELOPMENT.md] information on how to develop and contribute to this package.
+## Attribution
 
-  [DEVELOPMENT.md]: https://github.com/quantinuum/guppylang/blob/main/DEVELOPMENT.md
+If you use this software, please cite it using [CITATIONS.bib](https://github.com/quantinuum/guppylang/blob/main/CITATIONS.bib) or [CITATION.cff](https://github.com/quantinuum/guppylang/blob/main/CITATION.cff) (click "Cite this repository" in the About section of the repository landing page).
 
 ## License
 

--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 requires-python = ">=3.12,<4"
 description = "Pythonic quantum-classical programming language"
 license = { file = "LICENCE" }
-readme = "../README.md"
+dynamic = ["readme"]
 authors = [
     { name = "Mark Koch", email = "mark.koch@quantinuum.com" },
     { name = "TKET development team", email = "tket-support@quantinuum.com" },
@@ -42,5 +42,12 @@ homepage = "https://github.com/quantinuum/guppylang"
 repository = "https://github.com/quantinuum/guppylang"
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
+
+# Pull the PyPI readme from the repository-root README (outside this package dir).
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "../README.md"

--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.1"
 requires-python = ">=3.12,<4"
 description = "Pythonic quantum-classical programming language"
 license = { file = "LICENCE" }
-dynamic = ["readme"]
+readme = "README.md"
 authors = [
     { name = "Mark Koch", email = "mark.koch@quantinuum.com" },
     { name = "TKET development team", email = "tket-support@quantinuum.com" },
@@ -42,12 +42,5 @@ homepage = "https://github.com/quantinuum/guppylang"
 repository = "https://github.com/quantinuum/guppylang"
 
 [build-system]
-requires = ["hatchling", "hatch-fancy-pypi-readme"]
+requires = ["hatchling"]
 build-backend = "hatchling.build"
-
-# Pull the PyPI readme from the repository-root README (outside this package dir).
-[tool.hatch.metadata.hooks.fancy-pypi-readme]
-content-type = "text/markdown"
-
-[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
-path = "../README.md"


### PR DESCRIPTION
Hatchling (now resolved to 1.32.0) enforces that the readme path must live inside the project directory. Since in guppylang we point to the repo-root README  validation raises: `ValueError: Readme path must be within the project directory: ../README.md`


To fix this issue, we changed the README in `guppylang/pyproject.toml` to use the `guppylang` root one. We also updated the info in that README.
