### PR TITLE
test: Pull out error test case collection to common utility

### DIFF
--- a/tests/error/test_alias_errors.py
+++ b/tests/error/test_alias_errors.py
@@ -1,22 +1,10 @@
-import pathlib
-
 import pytest
 from guppylang import guppy
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "alias_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("alias_errors"))
 def test_alias_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)
 

--- a/tests/error/test_array_errors.py
+++ b/tests/error/test_array_errors.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from tests.error.util import run_error_test, collect_error_test_cases
@@ -21,7 +23,7 @@ skipped_files = {
 
 files = [
     pytest.param(file, marks=pytest.mark.skip(reason="The index bounds checking is currently disabled (https://github.com/Quantinuum/guppylang/issues/1669)."))
-    if any(skipped_name in file for skipped_name in skipped_files)
+    if any(skipped_name in Path(file).name for skipped_name in skipped_files)
     else file
     for file in files
 ]

--- a/tests/error/test_array_errors.py
+++ b/tests/error/test_array_errors.py
@@ -1,14 +1,9 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "array_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
+
+files = collect_error_test_cases("array_errors")
 
 skipped_files = {
     "array_index_equal_size.py",
@@ -24,12 +19,11 @@ skipped_files = {
     "non_array_subscript.py",
 }
 
-# Turn paths into strings, otherwise pytest doesn't display the names
 files = [
-    pytest.param(str(f), marks=pytest.mark.skip(reason="The index bounds checking is currently disabled (https://github.com/Quantinuum/guppylang/issues/1669)."))
-    if f.name in skipped_files
-    else str(f)
-    for f in files
+    pytest.param(file, marks=pytest.mark.skip(reason="The index bounds checking is currently disabled (https://github.com/Quantinuum/guppylang/issues/1669)."))
+    if any(skipped_name in file for skipped_name in skipped_files)
+    else file
+    for file in files
 ]
 
 

--- a/tests/error/test_comprehension_errors.py
+++ b/tests/error/test_comprehension_errors.py
@@ -1,21 +1,10 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 from tests.conftest import experimental_features_enabled
 
-path = pathlib.Path(__file__).parent.resolve() / "comprehension_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
-
-
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("comprehension_errors"))
 def test_comprehension_errors(file, capsys, snapshot):
     with experimental_features_enabled():
         run_error_test(file, capsys, snapshot)

--- a/tests/error/test_comptime_arg_errors.py
+++ b/tests/error/test_comptime_arg_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "comptime_arg_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("comptime_arg_errors"))
 def test_comptime_arg_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_comptime_expr_errors.py
+++ b/tests/error/test_comptime_expr_errors.py
@@ -1,24 +1,8 @@
-from importlib.util import find_spec
-
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-path = pathlib.Path(__file__).parent.resolve() / "comptime_expr_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file()
-    and x.suffix == ".py"
-    and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
-
-
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("comptime_expr_errors"))
 def test_comptime_expr_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_enum_errors.py
+++ b/tests/error/test_enum_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "enum_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("enum_errors"))
 def test_enum_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_errors_on_usage.py
+++ b/tests/error/test_errors_on_usage.py
@@ -1,21 +1,13 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-from tests.conftest import experimental_features_enabled
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "errors_on_usage"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# TODO: Skip functional tests for now
-files = [f for f in files if "functional" not in f.name]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases(
+    "errors_on_usage",
+    # TODO: Skip functional tests for now
+    exclude=lambda path: path.is_file() and "functional" in path.name,
+)
 
 # Snapshot tests that require experimental features.
 tests_that_require_experimental_features = [

--- a/tests/error/test_experimental_errors.py
+++ b/tests/error/test_experimental_errors.py
@@ -1,21 +1,10 @@
-import pathlib
 import pytest
 
 from guppylang.experimental import are_experimental_features_enabled, set_experimental_features_enabled
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "experimental_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("experimental_errors"))
 def test_experimental_errors(file, capsys, snapshot):
     original = are_experimental_features_enabled()
     set_experimental_features_enabled(False)

--- a/tests/error/test_inout_errors.py
+++ b/tests/error/test_inout_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "inout_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("inout_errors"))
 def test_inout_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_iter_errors.py
+++ b/tests/error/test_iter_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "iter_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("iter_errors"))
 def test_iter_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_library_errors.py
+++ b/tests/error/test_library_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "library_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("library_errors"))
 def test_library_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_linear_errors.py
+++ b/tests/error/test_linear_errors.py
@@ -1,21 +1,13 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-from tests.conftest import experimental_features_enabled
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "linear_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# TODO: Skip functional tests for now
-files = [f for f in files if "functional" not in f.name]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases(
+    "linear_errors",
+    # TODO: Skip functional tests for now
+    exclude=lambda path: path.is_file() and "functional" in path.name,
+)
 
 # Snapshot tests that require experimental features.
 tests_that_require_experimental_features = [

--- a/tests/error/test_misc_errors.py
+++ b/tests/error/test_misc_errors.py
@@ -1,21 +1,14 @@
-import pathlib
 import pytest
 
 from guppylang import guppy
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "misc_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# TODO: Skip functional tests for now
-files = [f for f in files if "functional" not in f.name]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases(
+    "misc_errors",
+    # TODO: Skip functional tests for now
+    exclude=lambda path: path.is_file() and "functional" in path.name,
+)
 
 
 @pytest.mark.parametrize("file", files)

--- a/tests/error/test_modifier_errors.py
+++ b/tests/error/test_modifier_errors.py
@@ -1,18 +1,9 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-from tests.conftest import experimental_features_enabled
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "modifier_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases("modifier_errors")
 
 # Snapshot tests that require experimental features.
 tests_that_require_experimental_features = [

--- a/tests/error/test_nested_errors.py
+++ b/tests/error/test_nested_errors.py
@@ -1,21 +1,10 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 from tests.conftest import experimental_features_enabled
 
-path = pathlib.Path(__file__).parent.resolve() / "nested_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
-
-
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("nested_errors"))
 def test_nested_errors(file, capsys, snapshot):
     with experimental_features_enabled():
         run_error_test(file, capsys, snapshot)

--- a/tests/error/test_output_errors.py
+++ b/tests/error/test_output_errors.py
@@ -1,21 +1,13 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "output_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# TODO: Skip functional tests for now
-files = [f for f in files if "functional" not in f.name]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
-
+files = collect_error_test_cases(
+    "output_errors",
+    # TODO: Skip functional tests for now
+    exclude=lambda path: path.is_file() and "functional" in path.name,
+)
 
 @pytest.mark.parametrize("file", files)
 def test_misc_errors(file, capsys, snapshot):

--- a/tests/error/test_overload_errors.py
+++ b/tests/error/test_overload_errors.py
@@ -1,22 +1,11 @@
-import pathlib
 import pytest
 from guppylang import guppy
 from guppylang.std.quantum import qubit
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "overload_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("overload_errors"))
 def test_overload_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)
 

--- a/tests/error/test_poly_errors.py
+++ b/tests/error/test_poly_errors.py
@@ -1,18 +1,9 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-from tests.conftest import experimental_features_enabled
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "poly_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases("poly_errors")
 
 # Snapshot tests that require experimental features.
 tests_that_require_experimental_features = [

--- a/tests/error/test_poly_errors_py312.py
+++ b/tests/error/test_poly_errors_py312.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "poly_errors_py312"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("poly_errors_py312"))
 def test_poly_errors_py312(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_protocol_errors.py
+++ b/tests/error/test_protocol_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "protocol_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("protocol_errors"))
 def test_protocol_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_protocol_errors_py312.py
+++ b/tests/error/test_protocol_errors_py312.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "protocol_errors_py312"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("protocol_errors_py312"))
 def test_protocol_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_self_errors.py
+++ b/tests/error/test_self_errors.py
@@ -1,22 +1,10 @@
-import pathlib
 import pytest
-import sys
 
 from guppylang import guppy
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "self_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("self_errors"))
 def test_misc_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)
 

--- a/tests/error/test_struct_errors.py
+++ b/tests/error/test_struct_errors.py
@@ -1,19 +1,8 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "struct_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("struct_errors"))
 def test_struct_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/test_tensor_errors.py
+++ b/tests/error/test_tensor_errors.py
@@ -1,21 +1,10 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
+from tests.error.util import run_error_test, collect_error_test_cases
 from tests.conftest import experimental_features_enabled
 
-path = pathlib.Path(__file__).parent.resolve() / "tensor_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
 
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
-
-
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("tensor_errors"))
 def test_type_errors(file, capsys, snapshot):
     with experimental_features_enabled():
         run_error_test(file, capsys, snapshot)

--- a/tests/error/test_tracing_errors.py
+++ b/tests/error/test_tracing_errors.py
@@ -1,19 +1,9 @@
-import pathlib
 import pytest
 
 from guppylang_internals.tracing.state import reset_state
-from tests.error.util import run_error_test
-from tests.conftest import experimental_features_enabled
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "tracing_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases("tracing_errors")
 
 # Snapshot tests that require experimental features.
 tests_that_require_experimental_features = [

--- a/tests/error/test_type_errors.py
+++ b/tests/error/test_type_errors.py
@@ -1,21 +1,12 @@
-import pathlib
 import pytest
 
-from tests.error.util import run_error_test
-from tests.conftest import experimental_features_enabled
+from tests.error.util import run_error_test, collect_error_test_cases
 
-path = pathlib.Path(__file__).parent.resolve() / "type_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# TODO: Skip functional tests for now
-files = [f for f in files if "functional" not in f.name]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+files = collect_error_test_cases(
+    "type_errors",
+    # TODO: Skip functional tests for now
+    exclude=lambda path: path.is_file() and "functional" in path.name,
+)
 
 # Snapshot tests that require experimental features.
 tests_that_require_experimental_features = [

--- a/tests/error/test_wasm_errors.py
+++ b/tests/error/test_wasm_errors.py
@@ -1,20 +1,8 @@
-import pathlib
 import pytest
 
-from guppylang import guppy
-from tests.error.util import run_error_test
-
-path = pathlib.Path(__file__).parent.resolve() / "wasm_errors"
-files = [
-    x
-    for x in path.iterdir()
-    if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
-]
-
-# Turn paths into strings, otherwise pytest doesn't display the names
-files = [str(f) for f in files]
+from tests.error.util import run_error_test, collect_error_test_cases
 
 
-@pytest.mark.parametrize("file", files)
+@pytest.mark.parametrize("file", collect_error_test_cases("wasm_errors"))
 def test_wasm_errors(file, capsys, snapshot):
     run_error_test(file, capsys, snapshot)

--- a/tests/error/util.py
+++ b/tests/error/util.py
@@ -23,6 +23,8 @@ def collect_error_test_cases(
     relative to the parent directory of this file.
 
     Returns a list of file paths that can be processed by pytest.mark.parametrize."""
+    # __file__ works since the current file is in the same directory as all the error
+    # test cases. If it is moved, this definition needs to be updated.
     path = pathlib.Path(__file__).parent.resolve() / directory
     files = [
         x

--- a/tests/error/util.py
+++ b/tests/error/util.py
@@ -3,6 +3,7 @@ import inspect
 import pathlib
 import re
 import sys
+from typing import Callable
 
 import pytest
 from hugr import tys
@@ -12,6 +13,28 @@ from guppylang_internals.decorator import custom_type
 from guppylang_internals.diagnostic import DiagnosticsRenderer, wrap
 from tests.util import get_wasm_file
 from tests.conftest import experimental_features_enabled
+
+def collect_error_test_cases(
+    directory: str,
+    *,
+    exclude: Callable[[pathlib.Path], bool] = lambda _: False,
+) -> list[str]:
+    """Collects all error test cases (*.py, but not __init__.py) in the given directory
+    relative to the parent directory of this file.
+
+    Returns a list of file paths that can be processed by pytest.mark.parametrize."""
+    path = pathlib.Path(__file__).parent.resolve() / directory
+    files = [
+        x
+        for x in path.iterdir()
+        if x.is_file() and x.suffix == ".py" and x.name != "__init__.py"
+    ]
+    files = [f for f in files if not exclude(f)]
+
+    # Turn paths into strings, otherwise pytest doesn't display the names
+    files = [str(f) for f in files]
+
+    return files
 
 # Regular expression to match the `~~~~~^^^~~~` highlights that are printed in
 # tracebacks from Python 3.11 onwards. We strip those out so we can use the same golden


### PR DESCRIPTION
Pulls out a very common pattern for error tests to improve maintenance burden and reduce code duplication. I got too annoyed with this apparently.

Note that no actual test cases have been modified.