### PR TITLE
feat: Lower minimal numpy version to 2.2.6

### DIFF
--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "guppylang-internals==1.0.1",
-    "numpy~=2.5",
+    "numpy~=2.0",
     "selene-hugr-qis-compiler~=0.4.2",
     "selene-sim~=0.3.0",
     "tqdm>=4.68.4",

--- a/guppylang/pyproject.toml
+++ b/guppylang/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "guppylang-internals==1.0.1",
-    "numpy~=2.0",
+    "numpy>=2.2.6,<3",
     "selene-hugr-qis-compiler~=0.4.2",
     "selene-sim~=0.3.0",
     "tqdm>=4.68.4",

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "guppylang-internals", editable = "guppylang-internals" },
-    { name = "numpy", specifier = "~=2.0" },
+    { name = "numpy", specifier = ">=2.2.6,<3" },
     { name = "pytket", specifier = ">=2.7.0" },
     { name = "selene-hugr-qis-compiler", specifier = "~=0.4.2" },
     { name = "selene-sim", specifier = "~=0.3.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -800,7 +800,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "guppylang-internals", editable = "guppylang-internals" },
-    { name = "numpy", specifier = "~=2.5" },
+    { name = "numpy", specifier = "~=2.0" },
     { name = "pytket", specifier = ">=2.7.0" },
     { name = "selene-hugr-qis-compiler", specifier = "~=0.4.2" },
     { name = "selene-sim", specifier = "~=0.3.0" },


### PR DESCRIPTION
Revert of https://github.com/Quantinuum/guppylang/pull/2006

The actual minimal possible version was found using `UV_RESOLUTION=lowest-direct`.

Minimal version resolution check: https://github.com/Quantinuum/guppylang/actions/runs/31701861394/job/94452697352