### PR TITLE
feat(quantum): add abstract qubit protocol

### DIFF
--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -78,6 +78,8 @@ class AbstractQubit:
     def controlled_rotate_z(self: Self, target: Self, theta: angle) -> None: ...
 
     @guppy.require(unitary=True)
+    # TODO: Provide defaults for derived operations such as Toffoli once protocol
+    # default methods are supported (#2205).
     def toffoli(self: Self, control2: Self, target: Self) -> None: ...
 
     @guppy.require(unitary=True)

--- a/guppylang/src/guppylang/std/quantum/__init__.py
+++ b/guppylang/src/guppylang/std/quantum/__init__.py
@@ -1,8 +1,8 @@
 """Guppy standard module for quantum operations."""
 
-# mypy: disable-error-code="empty-body, misc, valid-type"
+# mypy: disable-error-code="arg-type, empty-body, misc, untyped-decorator, valid-type"
 
-from typing import no_type_check
+from typing import Self, no_type_check
 
 from guppylang_internals.decorator import custom_function, custom_type, hugr_op
 from guppylang_internals.std._internal.compiler.quantum import (
@@ -22,26 +22,200 @@ from guppylang.std.mem import with_owned
 from guppylang.std.option import Option
 
 
+@guppy.protocol
+class AbstractQubit:
+    """Abstract interface implemented by qubits accepted by quantum operations."""
+
+    @guppy.require(unitary=True)
+    def hadamard(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def controlled_z(self: Self, target: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def controlled_y(self: Self, target: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def controlled_x(self: Self, target: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def phase_t(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def phase_s(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def sqrt_x(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def pauli_x(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def pauli_y(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def pauli_z(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def phase_t_dagger(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def phase_s_dagger(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def sqrt_x_dagger(self: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def rotate_z(self: Self, theta: angle) -> None: ...
+
+    @guppy.require(unitary=True)
+    def rotate_x(self: Self, theta: angle) -> None: ...
+
+    @guppy.require(unitary=True)
+    def rotate_y(self: Self, theta: angle) -> None: ...
+
+    @guppy.require(unitary=True)
+    def controlled_rotate_z(self: Self, target: Self, theta: angle) -> None: ...
+
+    @guppy.require(unitary=True)
+    def toffoli(self: Self, control2: Self, target: Self) -> None: ...
+
+    @guppy.require(unitary=True)
+    def controlled_hadamard(self: Self, target: Self) -> None: ...
+
+    @guppy.require
+    def measure(self: Self @ owned) -> "Measurement": ...
+
+    @guppy.require
+    def project_z(self: Self) -> "Measurement": ...
+
+    @guppy.require
+    def discard(self: Self @ owned) -> None: ...
+
+    @guppy.require
+    def reset(self: Self) -> None: ...
+
+
 @custom_type(ht.Qubit, copyable=False, droppable=False)
 class qubit:
     @hugr_op(quantum_op("QAlloc"), effects=[Effect.ANY])
     @no_type_check
     def __new__() -> "qubit": ...
 
+    @guppy(unitary=True)
+    @no_type_check
+    def hadamard(self: "qubit") -> None:
+        _h(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def controlled_z(self: "qubit", target: "qubit") -> None:
+        _cz(self, target)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def controlled_y(self: "qubit", target: "qubit") -> None:
+        _cy(self, target)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def controlled_x(self: "qubit", target: "qubit") -> None:
+        _cx(self, target)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def phase_t(self: "qubit") -> None:
+        _t(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def phase_s(self: "qubit") -> None:
+        _s(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def sqrt_x(self: "qubit") -> None:
+        _v(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def pauli_x(self: "qubit") -> None:
+        _x(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def pauli_y(self: "qubit") -> None:
+        _y(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def pauli_z(self: "qubit") -> None:
+        _z(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def phase_t_dagger(self: "qubit") -> None:
+        _tdg(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def phase_s_dagger(self: "qubit") -> None:
+        _sdg(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def sqrt_x_dagger(self: "qubit") -> None:
+        _vdg(self)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def rotate_z(self: "qubit", theta: angle) -> None:
+        _rz(self, theta)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def rotate_x(self: "qubit", theta: angle) -> None:
+        _rx(self, theta)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def rotate_y(self: "qubit", theta: angle) -> None:
+        _ry(self, theta)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def controlled_rotate_z(self: "qubit", target: "qubit", theta: angle) -> None:
+        _crz(self, target, theta)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def toffoli(self: "qubit", control2: "qubit", target: "qubit") -> None:
+        _toffoli(self, control2, target)
+
+    @guppy(unitary=True)
+    @no_type_check
+    def controlled_hadamard(self: "qubit", target: "qubit") -> None:
+        _ch(self, target)
+
     @guppy
     @no_type_check
     def measure(self: "qubit" @ owned) -> "Measurement":
-        return measure(self)
+        return _measure(self)
 
     @guppy
     @no_type_check
     def project_z(self: "qubit") -> "Measurement":
-        return project_z(self)
+        return _project_z(self)
 
     @guppy
     @no_type_check
     def discard(self: "qubit" @ owned) -> None:
-        discard(self)
+        _discard(self)
+
+    @guppy
+    @no_type_check
+    def reset(self: "qubit") -> None:
+        _reset(self)
 
 
 @custom_type(
@@ -75,7 +249,7 @@ def maybe_qubit() -> Option[qubit]:
 
 @hugr_op(quantum_op("H"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def h(q: qubit) -> None:
+def _h(q: qubit) -> None:
     r"""Hadamard gate command
 
     .. math::
@@ -89,7 +263,7 @@ def h(q: qubit) -> None:
 
 @hugr_op(quantum_op("CZ"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def cz(control: qubit, target: qubit) -> None:
+def _cz(control: qubit, target: qubit) -> None:
     r"""Controlled-Z gate command.
 
     cz(control, target)
@@ -109,7 +283,7 @@ def cz(control: qubit, target: qubit) -> None:
 
 @hugr_op(quantum_op("CY"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def cy(control: qubit, target: qubit) -> None:
+def _cy(control: qubit, target: qubit) -> None:
     r"""Controlled-Y gate command.
 
     cy(control, target)
@@ -129,7 +303,7 @@ def cy(control: qubit, target: qubit) -> None:
 
 @hugr_op(quantum_op("CX"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def cx(control: qubit, target: qubit) -> None:
+def _cx(control: qubit, target: qubit) -> None:
     r"""Controlled-X gate command.
 
     cx(control, target)
@@ -149,7 +323,7 @@ def cx(control: qubit, target: qubit) -> None:
 
 @hugr_op(quantum_op("T"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def t(q: qubit) -> None:
+def _t(q: qubit) -> None:
     r"""T gate.
 
     .. math::
@@ -164,7 +338,7 @@ def t(q: qubit) -> None:
 
 @hugr_op(quantum_op("S"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def s(q: qubit) -> None:
+def _s(q: qubit) -> None:
     r"""S gate.
 
     .. math::
@@ -179,7 +353,7 @@ def s(q: qubit) -> None:
 
 @hugr_op(quantum_op("V"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def v(q: qubit) -> None:
+def _v(q: qubit) -> None:
     r"""V gate.
 
     .. math::
@@ -194,7 +368,7 @@ def v(q: qubit) -> None:
 
 @hugr_op(quantum_op("X"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def x(q: qubit) -> None:
+def _x(q: qubit) -> None:
     r"""X gate.
 
     .. math::
@@ -209,7 +383,7 @@ def x(q: qubit) -> None:
 
 @hugr_op(quantum_op("Y"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def y(q: qubit) -> None:
+def _y(q: qubit) -> None:
     r"""Y gate.
 
     .. math::
@@ -224,7 +398,7 @@ def y(q: qubit) -> None:
 
 @hugr_op(quantum_op("Z"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def z(q: qubit) -> None:
+def _z(q: qubit) -> None:
     r"""Z gate.
 
     .. math::
@@ -239,7 +413,7 @@ def z(q: qubit) -> None:
 
 @hugr_op(quantum_op("Tdg"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def tdg(q: qubit) -> None:
+def _tdg(q: qubit) -> None:
     r"""Tdg gate.
 
     .. math::
@@ -254,7 +428,7 @@ def tdg(q: qubit) -> None:
 
 @hugr_op(quantum_op("Sdg"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def sdg(q: qubit) -> None:
+def _sdg(q: qubit) -> None:
     r"""Sdg gate.
 
     .. math::
@@ -269,7 +443,7 @@ def sdg(q: qubit) -> None:
 
 @hugr_op(quantum_op("Vdg"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def vdg(q: qubit) -> None:
+def _vdg(q: qubit) -> None:
     r"""Vdg gate.
 
     .. math::
@@ -284,7 +458,7 @@ def vdg(q: qubit) -> None:
 
 @custom_function(RotationCompiler("Rz"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def rz(q: qubit, angle: angle) -> None:
+def _rz(q: qubit, angle: angle) -> None:
     r"""Rz gate.
 
     .. math::
@@ -300,7 +474,7 @@ def rz(q: qubit, angle: angle) -> None:
 
 @custom_function(RotationCompiler("Rx"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def rx(q: qubit, angle: angle) -> None:
+def _rx(q: qubit, angle: angle) -> None:
     r"""Rx gate.
 
     .. math::
@@ -315,7 +489,7 @@ def rx(q: qubit, angle: angle) -> None:
 
 @custom_function(RotationCompiler("Ry"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def ry(q: qubit, angle: angle) -> None:
+def _ry(q: qubit, angle: angle) -> None:
     r"""Ry gate.
 
     .. math::
@@ -330,7 +504,7 @@ def ry(q: qubit, angle: angle) -> None:
 
 @custom_function(RotationCompiler("CRz"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def crz(control: qubit, target: qubit, angle: angle) -> None:
+def _crz(control: qubit, target: qubit, angle: angle) -> None:
     r"""Controlled-Rz gate command.
 
     crz(control, target, theta)
@@ -350,7 +524,7 @@ def crz(control: qubit, target: qubit, angle: angle) -> None:
 
 @hugr_op(quantum_op("Toffoli"), unitary_flags=UnitaryFlags.Unitary)
 @no_type_check
-def toffoli(control1: qubit, control2: qubit, target: qubit) -> None:
+def _toffoli(control1: qubit, control2: qubit, target: qubit) -> None:
     r"""A Toffoli gate command. Also sometimes known as a CCX gate.
 
     toffoli(control1, control2, target)
@@ -374,29 +548,29 @@ def toffoli(control1: qubit, control2: qubit, target: qubit) -> None:
 
 @guppy
 @no_type_check
-def project_z(q: qubit) -> Measurement:
+def _project_z(q: qubit) -> Measurement:
     """Project a single qubit into the Z-basis (a non-destructive measurement)."""
 
     # TODO revert to using "tket.quantum.Measure" op with InOutMeasureCompiler
     # once bool -> Measurement is available https://github.com/Quantinuum/tket2/issues/1732
     def helper(q: qubit @ owned) -> tuple[Measurement, qubit]:
-        return measure(q), qubit()
+        return _measure(q), qubit()
 
     m = with_owned(q, helper)
     if m:
-        x(q)
+        _x(q)
     return m
 
 
 @hugr_op(quantum_op("QFree"), effects=[Effect.ANY])
 @no_type_check
-def discard(q: qubit @ owned) -> None:
+def _discard(q: qubit @ owned) -> None:
     """Discard a single qubit."""
 
 
 @hugr_op(quantum_op("MeasureFree"), effects=[Effect.ANY])
 @no_type_check
-def measure(q: qubit @ owned) -> Measurement:
+def _measure(q: qubit @ owned) -> Measurement:
     """Request a destructive lazy measurement of a qubit, returning a `Measurement`
     value. Call `.read()` on the value to block until the result is available.
     """
@@ -404,31 +578,11 @@ def measure(q: qubit @ owned) -> Measurement:
 
 @hugr_op(quantum_op("Reset"))
 @no_type_check
-def reset(q: qubit) -> None:
+def _reset(q: qubit) -> None:
     """Reset a single qubit to the :math:`|0\\rangle` state."""
 
 
 N = guppy.nat_var("N")
-
-
-@guppy
-@no_type_check
-def measure_array(qubits: array[qubit, N] @ owned) -> array[Measurement, N]:
-    """Request a destructive lazy measurement of an array of qubits, returning an array
-    of `Measurement` values. Call `.read()` on each value or `collect_measurements(...)`
-    on the whole array to block until results are available.
-    """
-    return array(measure(q) for q in qubits)
-
-
-@guppy
-@no_type_check
-def discard_array(qubits: array[qubit, N] @ owned) -> None:
-    """Discard an array of qubits."""
-    for i in range(N):
-        if not qubits.is_borrowed(i):
-            discard(qubits.take(i))
-    qubits.discard_all_taken()
 
 
 @guppy
@@ -445,9 +599,9 @@ def collect_measurements(
 # -------NON-PRIMITIVE-------
 
 
-@guppy
+@guppy(unitary=True)
 @no_type_check
-def ch(control: qubit, target: qubit) -> None:
+def _ch(control: qubit, target: qubit) -> None:
     r"""Controlled-H gate command.
 
     ch(control, target)
@@ -464,6 +618,186 @@ def ch(control: qubit, target: qubit) -> None:
         \end{pmatrix}
     """
     # based on https://quantumcomputing.stackexchange.com/a/15737
-    ry(target, -pi / 4)
-    cz(control, target)
-    ry(target, pi / 4)
+    _ry(target, -pi / 4)
+    _cz(control, target)
+    _ry(target, pi / 4)
+
+
+@guppy(unitary=True)
+@no_type_check
+def h[Q: AbstractQubit](q: Q) -> None:
+    """Apply a Hadamard gate."""
+    q.hadamard()
+
+
+@guppy(unitary=True)
+@no_type_check
+def cz[Q: AbstractQubit](control: Q, target: Q) -> None:
+    """Apply a controlled-Z gate."""
+    control.controlled_z(target)
+
+
+@guppy(unitary=True)
+@no_type_check
+def cy[Q: AbstractQubit](control: Q, target: Q) -> None:
+    """Apply a controlled-Y gate."""
+    control.controlled_y(target)
+
+
+@guppy(unitary=True)
+@no_type_check
+def cx[Q: AbstractQubit](control: Q, target: Q) -> None:
+    """Apply a controlled-X gate."""
+    control.controlled_x(target)
+
+
+@guppy(unitary=True)
+@no_type_check
+def t[Q: AbstractQubit](q: Q) -> None:
+    """Apply a T gate."""
+    q.phase_t()
+
+
+@guppy(unitary=True)
+@no_type_check
+def s[Q: AbstractQubit](q: Q) -> None:
+    """Apply an S gate."""
+    q.phase_s()
+
+
+@guppy(unitary=True)
+@no_type_check
+def v[Q: AbstractQubit](q: Q) -> None:
+    """Apply a V gate."""
+    q.sqrt_x()
+
+
+@guppy(unitary=True)
+@no_type_check
+def x[Q: AbstractQubit](q: Q) -> None:
+    """Apply a Pauli-X gate."""
+    q.pauli_x()
+
+
+@guppy(unitary=True)
+@no_type_check
+def y[Q: AbstractQubit](q: Q) -> None:
+    """Apply a Pauli-Y gate."""
+    q.pauli_y()
+
+
+@guppy(unitary=True)
+@no_type_check
+def z[Q: AbstractQubit](q: Q) -> None:
+    """Apply a Pauli-Z gate."""
+    q.pauli_z()
+
+
+@guppy(unitary=True)
+@no_type_check
+def tdg[Q: AbstractQubit](q: Q) -> None:
+    """Apply a T-dagger gate."""
+    q.phase_t_dagger()
+
+
+@guppy(unitary=True)
+@no_type_check
+def sdg[Q: AbstractQubit](q: Q) -> None:
+    """Apply an S-dagger gate."""
+    q.phase_s_dagger()
+
+
+@guppy(unitary=True)
+@no_type_check
+def vdg[Q: AbstractQubit](q: Q) -> None:
+    """Apply a V-dagger gate."""
+    q.sqrt_x_dagger()
+
+
+@guppy(unitary=True)
+@no_type_check
+def rz[Q: AbstractQubit](q: Q, theta: angle) -> None:
+    """Apply an Rz rotation."""
+    q.rotate_z(theta)
+
+
+@guppy(unitary=True)
+@no_type_check
+def rx[Q: AbstractQubit](q: Q, theta: angle) -> None:
+    """Apply an Rx rotation."""
+    q.rotate_x(theta)
+
+
+@guppy(unitary=True)
+@no_type_check
+def ry[Q: AbstractQubit](q: Q, theta: angle) -> None:
+    """Apply an Ry rotation."""
+    q.rotate_y(theta)
+
+
+@guppy(unitary=True)
+@no_type_check
+def crz[Q: AbstractQubit](control: Q, target: Q, theta: angle) -> None:
+    """Apply a controlled-Rz rotation."""
+    control.controlled_rotate_z(target, theta)
+
+
+@guppy(unitary=True)
+@no_type_check
+def toffoli[Q: AbstractQubit](control1: Q, control2: Q, target: Q) -> None:
+    """Apply a Toffoli gate."""
+    control1.toffoli(control2, target)
+
+
+@guppy
+@no_type_check
+def project_z[Q: AbstractQubit](q: Q) -> Measurement:
+    """Project a qubit into the Z basis without consuming it."""
+    return q.project_z()
+
+
+@guppy
+@no_type_check
+def discard[Q: AbstractQubit](q: Q @ owned) -> None:
+    """Discard a qubit."""
+    q.discard()
+
+
+@guppy
+@no_type_check
+def measure[Q: AbstractQubit](q: Q @ owned) -> Measurement:
+    """Request a destructive lazy measurement of a qubit."""
+    return q.measure()
+
+
+@guppy
+@no_type_check
+def reset[Q: AbstractQubit](q: Q) -> None:
+    """Reset a qubit to the |0> state."""
+    q.reset()
+
+
+@guppy
+@no_type_check
+def measure_array[Q: AbstractQubit](
+    qubits: array[Q, N] @ owned,
+) -> array[Measurement, N]:
+    """Request destructive lazy measurements of an array of qubits."""
+    return array(measure(q) for q in qubits)
+
+
+@guppy
+@no_type_check
+def discard_array[Q: AbstractQubit](qubits: array[Q, N] @ owned) -> None:
+    """Discard an array of qubits."""
+    for i in range(N):
+        if not qubits.is_borrowed(i):
+            discard(qubits.take(i))
+    qubits.discard_all_taken()
+
+
+@guppy(unitary=True)
+@no_type_check
+def ch[Q: AbstractQubit](control: Q, target: Q) -> None:
+    """Apply a controlled-Hadamard gate."""
+    control.controlled_hadamard(target)

--- a/guppylang/src/guppylang/std/quantum/functional.py
+++ b/guppylang/src/guppylang/std/quantum/functional.py
@@ -12,12 +12,12 @@ from guppylang.decorator import guppy
 # mypy: disable-error-code="empty-body, misc, valid-type"
 from guppylang.std.angles import angle
 from guppylang.std.lang import owned
-from guppylang.std.quantum import Measurement, qubit
+from guppylang.std.quantum import AbstractQubit, Measurement
 
 
 @guppy
 @no_type_check
-def h(q: qubit @ owned) -> qubit:
+def h[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Hadamard gate command."""
     quantum.h(q)
     return q
@@ -25,7 +25,7 @@ def h(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def cz(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
+def cz[Q: AbstractQubit](control: Q @ owned, target: Q @ owned) -> tuple[Q, Q]:
     """Functional CZ gate command."""
     quantum.cz(control, target)
     return control, target
@@ -33,7 +33,7 @@ def cz(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
 
 @guppy
 @no_type_check
-def cx(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
+def cx[Q: AbstractQubit](control: Q @ owned, target: Q @ owned) -> tuple[Q, Q]:
     """Functional CX gate command."""
     quantum.cx(control, target)
     return control, target
@@ -41,7 +41,7 @@ def cx(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
 
 @guppy
 @no_type_check
-def cy(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
+def cy[Q: AbstractQubit](control: Q @ owned, target: Q @ owned) -> tuple[Q, Q]:
     """Functional CY gate command."""
     quantum.cy(control, target)
     return control, target
@@ -49,7 +49,7 @@ def cy(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
 
 @guppy
 @no_type_check
-def t(q: qubit @ owned) -> qubit:
+def t[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional T gate command."""
     quantum.t(q)
     return q
@@ -57,7 +57,7 @@ def t(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def s(q: qubit @ owned) -> qubit:
+def s[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional S gate command."""
     quantum.s(q)
     return q
@@ -65,7 +65,7 @@ def s(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def v(q: qubit @ owned) -> qubit:
+def v[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional V gate command."""
     quantum.v(q)
     return q
@@ -73,7 +73,7 @@ def v(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def x(q: qubit @ owned) -> qubit:
+def x[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional X gate command."""
     quantum.x(q)
     return q
@@ -81,7 +81,7 @@ def x(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def y(q: qubit @ owned) -> qubit:
+def y[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Y gate command."""
     quantum.y(q)
     return q
@@ -89,7 +89,7 @@ def y(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def z(q: qubit @ owned) -> qubit:
+def z[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Z gate command."""
     quantum.z(q)
     return q
@@ -97,7 +97,7 @@ def z(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def tdg(q: qubit @ owned) -> qubit:
+def tdg[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Tdg gate command."""
     quantum.tdg(q)
     return q
@@ -105,7 +105,7 @@ def tdg(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def sdg(q: qubit @ owned) -> qubit:
+def sdg[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Sdg gate command."""
     quantum.sdg(q)
     return q
@@ -113,7 +113,7 @@ def sdg(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def vdg(q: qubit @ owned) -> qubit:
+def vdg[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Vdg gate command."""
     quantum.vdg(q)
     return q
@@ -121,7 +121,7 @@ def vdg(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def rz(q: qubit @ owned, angle: angle) -> qubit:
+def rz[Q: AbstractQubit](q: Q @ owned, angle: angle) -> Q:
     """Functional Rz gate command."""
     quantum.rz(q, angle)
     return q
@@ -129,7 +129,7 @@ def rz(q: qubit @ owned, angle: angle) -> qubit:
 
 @guppy
 @no_type_check
-def rx(q: qubit @ owned, angle: angle) -> qubit:
+def rx[Q: AbstractQubit](q: Q @ owned, angle: angle) -> Q:
     """Functional Rx gate command."""
     quantum.rx(q, angle)
     return q
@@ -137,7 +137,7 @@ def rx(q: qubit @ owned, angle: angle) -> qubit:
 
 @guppy
 @no_type_check
-def ry(q: qubit @ owned, angle: angle) -> qubit:
+def ry[Q: AbstractQubit](q: Q @ owned, angle: angle) -> Q:
     """Functional Ry gate command."""
     quantum.ry(q, angle)
     return q
@@ -145,9 +145,9 @@ def ry(q: qubit @ owned, angle: angle) -> qubit:
 
 @guppy
 @no_type_check
-def crz(
-    control: qubit @ owned, target: qubit @ owned, angle: angle
-) -> tuple[qubit, qubit]:
+def crz[Q: AbstractQubit](
+    control: Q @ owned, target: Q @ owned, angle: angle
+) -> tuple[Q, Q]:
     """Functional CRz gate command."""
     quantum.crz(control, target, angle)
     return control, target
@@ -155,9 +155,9 @@ def crz(
 
 @guppy
 @no_type_check
-def toffoli(
-    control1: qubit @ owned, control2: qubit @ owned, target: qubit @ owned
-) -> tuple[qubit, qubit, qubit]:
+def toffoli[Q: AbstractQubit](
+    control1: Q @ owned, control2: Q @ owned, target: Q @ owned
+) -> tuple[Q, Q, Q]:
     """Functional Toffoli gate command."""
     quantum.toffoli(control1, control2, target)
     return control1, control2, target
@@ -165,7 +165,7 @@ def toffoli(
 
 @guppy
 @no_type_check
-def reset(q: qubit @ owned) -> qubit:
+def reset[Q: AbstractQubit](q: Q @ owned) -> Q:
     """Functional Reset command."""
     quantum.reset(q)
     return q
@@ -173,7 +173,7 @@ def reset(q: qubit @ owned) -> qubit:
 
 @guppy
 @no_type_check
-def project_z(q: qubit @ owned) -> tuple[qubit, Measurement]:
+def project_z[Q: AbstractQubit](q: Q @ owned) -> tuple[Q, Measurement]:
     """Functional project_z command."""
     b = quantum.project_z(q)
     return q, b
@@ -184,7 +184,7 @@ def project_z(q: qubit @ owned) -> tuple[qubit, Measurement]:
 
 @guppy
 @no_type_check
-def ch(control: qubit @ owned, target: qubit @ owned) -> tuple[qubit, qubit]:
+def ch[Q: AbstractQubit](control: Q @ owned, target: Q @ owned) -> tuple[Q, Q]:
     """Functional Controlled-H gate command."""
     quantum.ch(control, target)
     return control, target

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,5 +1,5 @@
 # See https://docs.astral.sh/ruff/rules/
-target-version = "py310"
+target-version = "py312"
 
 line-length = 88
 

--- a/tests/integration/test_quantum.py
+++ b/tests/integration/test_quantum.py
@@ -1,6 +1,6 @@
 """Various tests for the functions defined in `guppylang.prelude.quantum`."""
 
-from typing import no_type_check
+from typing import Self, no_type_check
 
 from guppylang.std.angles import angle
 
@@ -16,6 +16,7 @@ from guppylang.std.quantum import (
     measure_array,
     discard_array,
     Measurement,
+    AbstractQubit,
 )
 from guppylang.std.quantum.functional import (
     cx,
@@ -42,6 +43,118 @@ from guppylang.std.quantum.functional import (
 )
 
 from tests.util import guppy
+
+
+def test_abstract_qubit(validate):
+    @guppy.struct
+    class WrappedQubit:
+        inner: qubit
+
+        @guppy(unitary=True)
+        def hadamard(self) -> None:
+            q.h(self.inner)
+
+        @guppy(unitary=True)
+        def controlled_z(self, target: Self) -> None:
+            q.cz(self.inner, target.inner)
+
+        @guppy(unitary=True)
+        def controlled_y(self, target: Self) -> None:
+            q.cy(self.inner, target.inner)
+
+        @guppy(unitary=True)
+        def controlled_x(self, target: Self) -> None:
+            q.cx(self.inner, target.inner)
+
+        @guppy(unitary=True)
+        def phase_t(self) -> None:
+            q.t(self.inner)
+
+        @guppy(unitary=True)
+        def phase_s(self) -> None:
+            q.s(self.inner)
+
+        @guppy(unitary=True)
+        def sqrt_x(self) -> None:
+            q.v(self.inner)
+
+        @guppy(unitary=True)
+        def pauli_x(self) -> None:
+            q.x(self.inner)
+
+        @guppy(unitary=True)
+        def pauli_y(self) -> None:
+            q.y(self.inner)
+
+        @guppy(unitary=True)
+        def pauli_z(self) -> None:
+            q.z(self.inner)
+
+        @guppy(unitary=True)
+        def phase_t_dagger(self) -> None:
+            q.tdg(self.inner)
+
+        @guppy(unitary=True)
+        def phase_s_dagger(self) -> None:
+            q.sdg(self.inner)
+
+        @guppy(unitary=True)
+        def sqrt_x_dagger(self) -> None:
+            q.vdg(self.inner)
+
+        @guppy(unitary=True)
+        def rotate_z(self, theta: angle) -> None:
+            q.rz(self.inner, theta)
+
+        @guppy(unitary=True)
+        def rotate_x(self, theta: angle) -> None:
+            q.rx(self.inner, theta)
+
+        @guppy(unitary=True)
+        def rotate_y(self, theta: angle) -> None:
+            q.ry(self.inner, theta)
+
+        @guppy(unitary=True)
+        def controlled_rotate_z(self, target: Self, theta: angle) -> None:
+            q.crz(self.inner, target.inner, theta)
+
+        @guppy(unitary=True)
+        def toffoli(self, control2: Self, target: Self) -> None:
+            q.toffoli(self.inner, control2.inner, target.inner)
+
+        @guppy(unitary=True)
+        def controlled_hadamard(self, target: Self) -> None:
+            q.ch(self.inner, target.inner)
+
+        @guppy
+        def measure(self: Self @ owned) -> Measurement:
+            return q.measure(self.inner)
+
+        @guppy
+        def project_z(self) -> Measurement:
+            return q.project_z(self.inner)
+
+        @guppy
+        def discard(self: Self @ owned) -> None:
+            q.discard(self.inner)
+
+        @guppy
+        def reset(self) -> None:
+            q.reset(self.inner)
+
+    @guppy
+    def use[Q: AbstractQubit](q1: Q @ owned, q2: Q @ owned) -> tuple[Q, Q]:
+        q.h(q1)
+        q.cx(q1, q2)
+        q.ry(q1, angle(0.5))
+        q1, q2 = cx(q1, q2)
+        return q1, q2
+
+    @guppy
+    def test() -> tuple[WrappedQubit, WrappedQubit]:
+        return use(WrappedQubit(qubit()), WrappedQubit(qubit()))
+
+    validate(test.compile_function())
 
 
 def test_alloc(validate):


### PR DESCRIPTION
## Summary

- add the public `AbstractQubit` protocol with descriptive (more verbose than stdlib functions), `Self`-typed quantum operations
- make the built-in `qubit` implement the protocol and retain the existing short-form `std.quantum` API as generic delegates
- generalize functional and array quantum operations, with integration coverage for a distinct protocol implementation
- ideally should follow: https://github.com/Quantinuum/guppylang/issues/2119

## Follow-up

Derived quantum operations such as Toffoli are currently required protocol members. Providing defaults for these operations is tracked by #2205; the protocol contains a matching TODO.
