### PR TITLE
fix: Internal error in generating function span for missing return annotation error on nested functions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/span.py
+++ b/guppylang-internals/src/guppylang_internals/span.py
@@ -141,7 +141,7 @@ def function_header_span(func_def: ast.FunctionDef) -> Span:
     lines = source.splitlines()
     # `parse_source` wraps indented functions in a synthetic class so that Python can
     # parse them without changing their column offsets. The wrapper is not included in
-    # `source`, so account for its extra line when indexing into the source text.
+    # `source`, so `func_def.lineno` points 2 lines below the definition line.
     wrapper_lines = int(source[0].isspace())
     line_idx = func_def.lineno - wrapper_lines - 1
     paren_depth = 0

--- a/guppylang-internals/src/guppylang_internals/span.py
+++ b/guppylang-internals/src/guppylang_internals/span.py
@@ -139,7 +139,11 @@ def function_header_span(func_def: ast.FunctionDef) -> Span:
     assert line_offset is not None
 
     lines = source.splitlines()
-    line_idx = func_def.lineno - 1
+    # `parse_source` wraps indented functions in a synthetic class so that Python can
+    # parse them without changing their column offsets. The wrapper is not included in
+    # `source`, so account for its extra line when indexing into the source text.
+    wrapper_lines = int(source[0].isspace())
+    line_idx = func_def.lineno - wrapper_lines - 1
     paren_depth = 0
     for i, line in enumerate(lines[line_idx:], start=line_idx):
         col_begin = func_def.col_offset if i == line_idx else 0
@@ -149,7 +153,7 @@ def function_header_span(func_def: ast.FunctionDef) -> Span:
             elif char == ")":
                 paren_depth -= 1
             elif char == ":" and paren_depth == 0:
-                return Span(start, Loc(file, i + line_offset, col + 1))
+                return Span(start, Loc(file, i + line_offset + wrapper_lines, col + 1))
 
     raise InternalGuppyError("function_header_span: Could not find header colon")
 

--- a/tests/error/misc_errors/return_no_annotaded_method.err
+++ b/tests/error/misc_errors/return_no_annotaded_method.err
@@ -1,0 +1,11 @@
+Error: Missing type annotation (at $FILE:9:4)
+  | 
+7 | 
+8 |     @guppy
+9 |     def method():
+  |     ^^^^^^^^^^^^^ Return type must be annotated
+
+Help: Looks like `method` doesn't return anything. Consider annotating it with
+`-> None`.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/return_no_annotaded_method.py
+++ b/tests/error/misc_errors/return_no_annotaded_method.py
@@ -2,12 +2,17 @@
 from guppylang import guppy
 
 
-def _wrapper():
+@guppy.struct
+class struct:
+
     @guppy
-    def wrapper():
+    def method():
         return
 
-    return wrapper
+@guppy
+def main() -> None:
+    w = struct()
+    w.method()
 
 
-_wrapper().compile()
+main.compile()

--- a/tests/error/misc_errors/return_not_annotated_nested.err
+++ b/tests/error/misc_errors/return_not_annotated_nested.err
@@ -1,0 +1,11 @@
+Error: Missing type annotation (at $FILE:6:4)
+  | 
+4 | def _wrapper():
+5 |     @guppy
+6 |     def wrapper():
+  |     ^^^^^^^^^^^^^^ Return type must be annotated
+
+Help: Looks like `wrapper` doesn't return anything. Consider annotating it with
+`-> None`.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/misc_errors/return_not_annotated_nested.err
+++ b/tests/error/misc_errors/return_not_annotated_nested.err
@@ -1,8 +1,8 @@
-Error: Missing type annotation (at $FILE:6:4)
+Error: Missing type annotation (at $FILE:7:4)
   | 
-4 | def _wrapper():
-5 |     @guppy
-6 |     def wrapper():
+5 | def _wrapper():
+6 |     @guppy
+7 |     def wrapper():
   |     ^^^^^^^^^^^^^^ Return type must be annotated
 
 Help: Looks like `wrapper` doesn't return anything. Consider annotating it with

--- a/tests/error/misc_errors/return_not_annotated_nested.py
+++ b/tests/error/misc_errors/return_not_annotated_nested.py
@@ -1,0 +1,12 @@
+from guppylang import guppy
+
+
+def _wrapper():
+    @guppy
+    def wrapper():
+        return
+
+    return wrapper
+
+
+_wrapper().compile()


### PR DESCRIPTION
Fixes #2204

Indented functions are wrapped in a synthetic class before parsing so their column offsets remain intact. `function_header_span` indexed the source using AST line numbers that included that synthetic wrapper; thus `func_def.lineno` points 2 lines below the definition, and `line_idx = func_def.lineno - 1` is not sufficient to point to the line containing the `def`, causing it to miss the header colon and raise `InternalGuppyError`.

To fix this when an intended function is found (`source[0].isspace()`) we consider `line_idx = func_def.lineno - 2`.





