### PR TITLE
fix: check+trace more functions before compilation starts

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -274,8 +274,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             )
             # Apply instantiation of quantified type variables
             if inst:
-                assert isinstance(syn_ty, (FunctionType, FunctionDefType))
-                expr = instantiate_poly2(expr, syn_ty, inst)
+                expr = make_type_apply(expr, inst)
             return with_type(ty.substitute(subst), expr), subst
 
         # Otherwise, invoke the visitor
@@ -453,8 +452,8 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
 
         # Apply instantiation of quantified type variables
         if inst:
-            assert isinstance(synth, (FunctionType, FunctionDefType))
-            node = instantiate_poly2(node, synth, inst)
+            node = make_type_apply(node, inst)
+
         return node, subst
 
 
@@ -1668,17 +1667,19 @@ def check_inst(func_ty: FunctionType, inst: Inst, node: AstNode) -> None:
         param.check_arg(arg, node)
 
 
-def instantiate_poly2(
-    node: ast.expr, ty: FunctionType | FunctionDefType, inst: Inst
-) -> ast.expr:
-    match ty:
-        case FunctionType() as fty:
-            pass
-        case FunctionDefType(sig=fty):
-            pass
+def make_type_apply(node: ast.expr, inst: Inst) -> ast.expr:
+    """Makes a new TypeApply node, registering that the target is used with the
+    specified type arguments."""
+    # TODO perhaps we can combine this with instantiate_poly, but that
+    # requires a FunctionType
+    match node:
+        case GlobalName(def_id=def_id):
+            defn = ENGINE.get_parsed(def_id)
+            assert isinstance(defn, CheckableGenericDef)
+            ENGINE.register_generic_use(defn, inst)
         case _:
-            raise InternalGuppyError("Unexpected polymorphic type")
-    return instantiate_poly(node, fty, inst)
+            raise InternalGuppyError(f"Unhandled case: applying type args to {node}")
+    return with_loc(node, TypeApply(node, inst))
 
 
 def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
@@ -1692,16 +1693,7 @@ def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
             assert full_ty.params == ty.params
             node.func = instantiate_poly(node.func, full_ty, inst)
         else:
-            match node:
-                case GlobalName(def_id=def_id):
-                    defn = ENGINE.get_parsed(def_id)
-                    assert isinstance(defn, CheckableGenericDef)
-                    ENGINE.register_generic_use(defn, inst)
-                case _:
-                    raise InternalGuppyError(
-                        f"Unhandled case: applying type args to {node}"
-                    )
-            node = with_loc(node, TypeApply(with_type(ty, node), inst))
+            node = make_type_apply(with_type(ty, node), inst)
         return with_type(ty.instantiate(inst), node)
     return with_type(ty, node)
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -91,7 +91,7 @@ from guppylang_internals.checker.errors.type_errors import (
     UnitaryFlagMismatchError,
     WrongNumberOfArgsError,
 )
-from guppylang_internals.definition.common import Definition
+from guppylang_internals.definition.common import CheckableGenericDef, Definition
 from guppylang_internals.definition.parameter import ParamDef
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import CallableDef, ValueDef
@@ -263,8 +263,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
         # the target
         if actual := get_type_opt(expr):
             expr, subst, inst = check_type_against(actual, ty, expr, self.ctx, kind)
-            if inst:
-                expr = with_loc(expr, TypeApply(expr, inst))
+            assert len(inst) == 0
             return with_type(ty.substitute(subst), expr), subst
 
         # When checking against a variable, we have to synthesize
@@ -275,7 +274,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             )
             # Apply instantiation of quantified type variables
             if inst:
-                expr = with_loc(expr, TypeApply(expr, inst))
+                expr = make_type_apply(expr, inst)
             return with_type(ty.substitute(subst), expr), subst
 
         # Otherwise, invoke the visitor
@@ -453,7 +452,7 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
 
         # Apply instantiation of quantified type variables
         if inst:
-            node = with_loc(node, TypeApply(node, inst))
+            node = make_type_apply(node, inst)
 
         return node, subst
 
@@ -1668,6 +1667,21 @@ def check_inst(func_ty: FunctionType, inst: Inst, node: AstNode) -> None:
         param.check_arg(arg, node)
 
 
+def make_type_apply(node: ast.expr, inst: Inst) -> ast.expr:
+    """Makes a new TypeApply node, registering that the target is used with the
+    specified type arguments."""
+    # TODO perhaps we can combine this with instantiate_poly, but that
+    # requires a FunctionType
+    match node:
+        case GlobalName(def_id=def_id):
+            defn = ENGINE.get_parsed(def_id)
+            assert isinstance(defn, CheckableGenericDef)
+            ENGINE.register_generic_use(defn, inst)
+        case _:
+            raise InternalGuppyError(f"Unhandled case: applying type args to {node}")
+    return with_loc(node, TypeApply(node, inst))
+
+
 def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
     """Instantiates quantified type arguments in a function."""
     assert len(ty.params) == len(inst)
@@ -1679,7 +1693,7 @@ def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
             assert full_ty.params == ty.params
             node.func = instantiate_poly(node.func, full_ty, inst)
         else:
-            node = with_loc(node, TypeApply(with_type(ty, node), inst))
+            node = make_type_apply(with_type(ty, node), inst)
         return with_type(ty.instantiate(inst), node)
     return with_type(ty, node)
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -91,7 +91,7 @@ from guppylang_internals.checker.errors.type_errors import (
     UnitaryFlagMismatchError,
     WrongNumberOfArgsError,
 )
-from guppylang_internals.definition.common import CheckableGenericDef, Definition
+from guppylang_internals.definition.common import CheckableGenericDef, DefId, Definition
 from guppylang_internals.definition.parameter import ParamDef
 from guppylang_internals.definition.ty import TypeDef
 from guppylang_internals.definition.value import CallableDef, ValueDef
@@ -116,6 +116,7 @@ from guppylang_internals.nodes import (
     DesugaredListComp,
     DummyGenericParamValue,
     FieldAccessAndDrop,
+    GlobalCall,
     GlobalName,
     IterNext,
     LocalCall,
@@ -1667,11 +1668,27 @@ def check_inst(func_ty: FunctionType, inst: Inst, node: AstNode) -> None:
         param.check_arg(arg, node)
 
 
+def make_global_name(id: str, def_id: DefId) -> GlobalName:
+    defn = ENGINE.get_parsed(def_id)
+    if isinstance(defn, CheckableGenericDef) and not defn.params:
+        # If the defn has params, it will have to be subject to a
+        # TypeApply or turned into a GlobalCall, which will register.
+        ENGINE.register_generic_use(defn, ())
+
+    return GlobalName(id, def_id)
+
+
+def make_global_call(
+    defn: CallableDef, args: list[ast.expr], type_args: Inst
+) -> GlobalCall:
+    if isinstance(defn, CheckableGenericDef):
+        ENGINE.register_generic_use(defn, type_args)
+    return GlobalCall(defn, args, type_args)
+
+
 def make_type_apply(node: ast.expr, inst: Inst) -> ast.expr:
     """Makes a new TypeApply node, registering that the target is used with the
     specified type arguments."""
-    # TODO perhaps we can combine this with instantiate_poly, but that
-    # requires a FunctionType
     match node:
         case GlobalName(def_id=def_id):
             defn = ENGINE.get_parsed(def_id)

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -274,7 +274,8 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
             )
             # Apply instantiation of quantified type variables
             if inst:
-                expr = make_type_apply(expr, inst)
+                assert isinstance(syn_ty, (FunctionType, FunctionDefType))
+                expr = instantiate_poly2(expr, syn_ty, inst)
             return with_type(ty.substitute(subst), expr), subst
 
         # Otherwise, invoke the visitor
@@ -452,8 +453,8 @@ class ExprChecker(AstVisitor[tuple[ast.expr, Subst]]):
 
         # Apply instantiation of quantified type variables
         if inst:
-            node = make_type_apply(node, inst)
-
+            assert isinstance(synth, (FunctionType, FunctionDefType))
+            node = instantiate_poly2(node, synth, inst)
         return node, subst
 
 
@@ -1667,19 +1668,17 @@ def check_inst(func_ty: FunctionType, inst: Inst, node: AstNode) -> None:
         param.check_arg(arg, node)
 
 
-def make_type_apply(node: ast.expr, inst: Inst) -> ast.expr:
-    """Makes a new TypeApply node, registering that the target is used with the
-    specified type arguments."""
-    # TODO perhaps we can combine this with instantiate_poly, but that
-    # requires a FunctionType
-    match node:
-        case GlobalName(def_id=def_id):
-            defn = ENGINE.get_parsed(def_id)
-            assert isinstance(defn, CheckableGenericDef)
-            ENGINE.register_generic_use(defn, inst)
+def instantiate_poly2(
+    node: ast.expr, ty: FunctionType | FunctionDefType, inst: Inst
+) -> ast.expr:
+    match ty:
+        case FunctionType() as fty:
+            pass
+        case FunctionDefType(sig=fty):
+            pass
         case _:
-            raise InternalGuppyError(f"Unhandled case: applying type args to {node}")
-    return with_loc(node, TypeApply(node, inst))
+            raise InternalGuppyError("Unexpected polymorphic type")
+    return instantiate_poly(node, fty, inst)
 
 
 def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
@@ -1693,7 +1692,16 @@ def instantiate_poly(node: ast.expr, ty: FunctionType, inst: Inst) -> ast.expr:
             assert full_ty.params == ty.params
             node.func = instantiate_poly(node.func, full_ty, inst)
         else:
-            node = make_type_apply(with_type(ty, node), inst)
+            match node:
+                case GlobalName(def_id=def_id):
+                    defn = ENGINE.get_parsed(def_id)
+                    assert isinstance(defn, CheckableGenericDef)
+                    ENGINE.register_generic_use(defn, inst)
+                case _:
+                    raise InternalGuppyError(
+                        f"Unhandled case: applying type args to {node}"
+                    )
+            node = with_loc(node, TypeApply(with_type(ty, node), inst))
         return with_type(ty.instantiate(inst), node)
     return with_type(ty, node)
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -567,9 +567,9 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         match defn:
             case CallableDef() as defn:
                 ty = FunctionDefType(defn.id)
-                return with_loc(node, GlobalName(id=name, def_id=defn.id)), ty
+                return with_loc(node, make_global_name(name, defn.id)), ty
             case ValueDef() as defn:
-                return with_loc(node, GlobalName(id=name, def_id=defn.id)), defn.ty
+                return with_loc(node, make_global_name(name, defn.id)), defn.ty
             # We need a special case for enums since they don't have a `__new__` method,
             # but they have a special constructor for each variant.
             # A new enum is defined as `EnumName.Variant()`, however, since we are
@@ -586,15 +586,11 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                     raise InternalGuppyError(
                         "Valid variants should be available in `ctx.globals`"
                     )
-                return with_loc(
-                    node, GlobalName(id=name, def_id=defn.id)
-                ), constr.ty.output
+                return with_loc(node, make_global_name(name, defn.id)), constr.ty.output
             # For types, we return their `__new__` constructor
             case TypeDef() as defn:
                 if constr := ENGINE.get_instance_func(defn, "__new__"):
-                    return with_loc(
-                        node, GlobalName(id=name, def_id=constr.id)
-                    ), constr.ty
+                    return with_loc(node, make_global_name(name, constr.id)), constr.ty
                 else:
                     err = ExpectedError(
                         node,
@@ -698,8 +694,8 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                         member_ty,
                         with_loc(
                             node,
-                            GlobalName(
-                                id=node.attr, def_id=proto_def.member_defs[node.attr]
+                            make_global_name(
+                                node.attr, proto_def.member_defs[node.attr]
                             ),
                         ),
                     )
@@ -722,7 +718,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
                         "Valid variants should be available in `ctx.globals`"
                     )
                     return with_loc(
-                        node, GlobalName(id=node.attr, def_id=variant_constr.id)
+                        node, make_global_name(node.attr, variant_constr.id)
                     ), variant_constr.ty
                 else:
                     # Not a global name, thus node.value is a instantiated variant
@@ -753,7 +749,7 @@ class ExprSynthesizer(AstVisitor[tuple[ast.expr, Type]]):
         """Helper method to check if an attribute access corresponds to a method call"""
         if func := ENGINE.get_instance_func(ty, node.attr):
             name = with_type(
-                func.ty, with_loc(node, GlobalName(id=func.name, def_id=func.id))
+                func.ty, with_loc(node, make_global_name(func.name, func.id))
             )
             # Make a closure by partially applying the `self` argument
             # TODO: Try to infer some type args based on `self`
@@ -1264,7 +1260,7 @@ def function_def_value_to_function_value(
     if isinstance(ty, NestedFunctionDefType):
         return with_type(ty.sig, expr)
     name = DEF_STORE.raw_defs[ty.def_id].name
-    return with_type(ty.sig, with_loc(expr, GlobalName(id=name, def_id=ty.def_id)))
+    return with_type(ty.sig, with_loc(expr, make_global_name(name, ty.def_id)))
 
 
 def check_unitary_flags(exp: FunctionType, act: FunctionType, node: AstNode) -> None:

--- a/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/linearity_checker.py
@@ -48,8 +48,6 @@ from guppylang_internals.checker.errors.linearity import (
     UnnamedTupleNotUsedError,
 )
 from guppylang_internals.definition.custom import CustomFunctionDef
-from guppylang_internals.definition.value import CallableDef
-from guppylang_internals.engine import DEF_STORE, ENGINE
 from guppylang_internals.error import GuppyError, GuppyTypeError
 from guppylang_internals.nodes import (
     AnyCall,
@@ -81,6 +79,7 @@ from guppylang_internals.tys.ty import (
 )
 
 if TYPE_CHECKING:
+    from guppylang_internals.definition.value import CallableDef
     from guppylang_internals.diagnostic import Error
 
 
@@ -178,7 +177,7 @@ class Scope(Locals[PlaceId, Place]):
     #: defined in this or any parent scope
     used_projections: dict[PlaceId, Use]
 
-    #: Tracks all projections (not just leafs) of places that are assigned in this scope
+    #: Tracks all projections (not just leaves) of places assigned in this scope
     assigned_projections: dict[PlaceId, AstNode]
 
     #: Tracks all parents of mutated projections that were defined in a parent scope
@@ -512,12 +511,11 @@ class BBLinearityChecker(ast.NodeVisitor):
         if isinstance(node, LocalCall):
             return node.func.id if isinstance(node.func, ast.Name) else None
         elif isinstance(node, GlobalCall):
-            return DEF_STORE.raw_defs[node.def_id].name
+            return node.defn.name
         return None
 
     def visit_GlobalCall(self, node: GlobalCall) -> None:
-        func = ENGINE.get_parsed(node.def_id)
-        assert isinstance(func, CallableDef)
+        func: CallableDef = node.defn
         if isinstance(func, CustomFunctionDef) and (
             not func.has_signature or func.has_var_args
         ):

--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -6,7 +6,6 @@ from guppylang_internals.checker.cfg_checker import CheckedCFG
 from guppylang_internals.checker.core import Place
 from guppylang_internals.checker.errors.generic import InvalidUnderDagger
 from guppylang_internals.definition.value import CallableDef
-from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError, GuppyTypeError
 from guppylang_internals.nodes import (
     AbortExpr,
@@ -171,8 +170,7 @@ class BBUnitaryChecker(ast.NodeVisitor):
             raise GuppyTypeError(err)
 
     def visit_GlobalCall(self, node: GlobalCall) -> None:
-        func = ENGINE.get_parsed(node.def_id)
-        assert isinstance(func, CallableDef)
+        func: CallableDef = node.defn
         self._check_call(node, func.ty, func)
 
     def visit_LocalCall(self, node: LocalCall) -> None:

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -442,6 +442,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         elif isinstance(func_ty, FunctionDefType):
             input_len = len(func_ty.sig.inputs)
             consumed_args, other_args = args[0:input_len], args[input_len:]
+            assert (func_ty.defn.id, ()) in ENGINE.checked
             node = GlobalCall(defn=func_ty.defn, args=consumed_args, type_args=())
             out = self.visit_GlobalCall(node)
             returns = unpack_wire(out, func_ty.sig.output, self.builder, self.ctx, node)

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -442,7 +442,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
         elif isinstance(func_ty, FunctionDefType):
             input_len = len(func_ty.sig.inputs)
             consumed_args, other_args = args[0:input_len], args[input_len:]
-            node = GlobalCall(def_id=func_ty.def_id, args=consumed_args, type_args=())
+            node = GlobalCall(defn=func_ty.defn, args=consumed_args, type_args=())
             out = self.visit_GlobalCall(node)
             returns = unpack_wire(out, func_ty.sig.output, self.builder, self.ctx, node)
             return returns, other_args
@@ -451,7 +451,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
             raise InternalGuppyError("Tensor element wasn't function or tuple")
 
     def visit_GlobalCall(self, node: GlobalCall) -> Wire:
-        func = self.ctx.build_compiled_def(node.def_id, node.type_args)
+        func = self.ctx.build_compiled_def(node.defn.id, node.type_args)
         assert isinstance(func, CompiledCallableDef)
 
         if isinstance(func, CustomFunctionDef) and not func.has_signature:

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -538,13 +538,13 @@ class DefaultCallChecker(CustomCallChecker):
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
-        return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
+        return GlobalCall(defn=self.func, args=args, type_args=inst), subst
 
     @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
-        return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty
+        return GlobalCall(defn=self.func, args=args, type_args=inst), ty
 
 
 class OwnedArgumentsCallChecker(DefaultCallChecker):

--- a/guppylang-internals/src/guppylang_internals/definition/custom.py
+++ b/guppylang-internals/src/guppylang_internals/definition/custom.py
@@ -20,7 +20,11 @@ from guppylang_internals.ast_util import (
     with_type,
 )
 from guppylang_internals.checker.core import Context, Globals
-from guppylang_internals.checker.expr_checker import check_call, synthesize_call
+from guppylang_internals.checker.expr_checker import (
+    check_call,
+    make_global_call,
+    synthesize_call,
+)
 from guppylang_internals.checker.func_checker import check_signature
 from guppylang_internals.compiler.builder import (
     DFBuilder,
@@ -538,13 +542,13 @@ class DefaultCallChecker(CustomCallChecker):
     def check(self, args: list[ast.expr], ty: Type) -> tuple[ast.expr, Subst]:
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
-        return GlobalCall(defn=self.func, args=args, type_args=inst), subst
+        return make_global_call(self.func, args, inst), subst
 
     @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
-        return GlobalCall(defn=self.func, args=args, type_args=inst), ty
+        return make_global_call(self.func, args, inst), ty
 
 
 class OwnedArgumentsCallChecker(DefaultCallChecker):

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -16,7 +16,11 @@ from guppylang_internals.ast_util import (
     with_type,
 )
 from guppylang_internals.checker.core import Context, Globals
-from guppylang_internals.checker.expr_checker import check_call, synthesize_call
+from guppylang_internals.checker.expr_checker import (
+    check_call,
+    make_global_call,
+    synthesize_call,
+)
 from guppylang_internals.checker.func_checker import check_signature
 from guppylang_internals.compiler.core import CompilerContext, DFContainer
 from guppylang_internals.debug_mode import debug_mode_enabled
@@ -165,7 +169,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return node, subst
 
     @override
@@ -175,7 +179,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return with_type(ty, node), ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/declaration.py
+++ b/guppylang-internals/src/guppylang_internals/definition/declaration.py
@@ -42,7 +42,6 @@ from guppylang_internals.definition.value import (
     CompiledHugrNodeDef,
 )
 from guppylang_internals.diagnostic import Error
-from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
@@ -166,8 +165,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
-        ENGINE.register_generic_use(self, inst)
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return node, subst
 
     @override
@@ -177,8 +175,7 @@ class ParsedFunctionDecl(CheckableGenericDef, CallableDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
-        ENGINE.register_generic_use(self, inst)
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return with_type(ty, node), ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -21,7 +21,11 @@ from guppylang_internals.ast_util import (
 from guppylang_internals.checker.cfg_checker import CheckedCFG
 from guppylang_internals.checker.core import Context, Globals, Place
 from guppylang_internals.checker.errors.generic import ExpectedError
-from guppylang_internals.checker.expr_checker import check_call, synthesize_call
+from guppylang_internals.checker.expr_checker import (
+    check_call,
+    make_global_call,
+    synthesize_call,
+)
 from guppylang_internals.checker.func_checker import (
     check_global_func_def,
     check_signature,
@@ -52,7 +56,6 @@ from guppylang_internals.definition.value import (
 from guppylang_internals.engine import DEF_STORE, ENGINE
 from guppylang_internals.error import GuppyError
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
-from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap, to_span
 from guppylang_internals.tys import Effect
 from guppylang_internals.tys.arg import ConstArg, TypeArg
@@ -196,7 +199,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return node, subst
 
     @override
@@ -206,7 +209,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return with_type(ty, node), ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/function.py
+++ b/guppylang-internals/src/guppylang_internals/definition/function.py
@@ -196,8 +196,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
-        ENGINE.register_generic_use(self, inst)
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return node, subst
 
     @override
@@ -207,8 +206,7 @@ class ParsedFunctionDef(CheckableGenericDef, CallableDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
-        ENGINE.register_generic_use(self, inst)
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return with_type(ty, node), ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -17,7 +17,11 @@ from typing_extensions import override
 from guppylang_internals.ast_util import AstNode, has_empty_body, with_loc
 from guppylang_internals.checker.core import Context, Globals
 from guppylang_internals.checker.errors.comptime_errors import PytketSignatureMismatch
-from guppylang_internals.checker.expr_checker import check_call, synthesize_call
+from guppylang_internals.checker.expr_checker import (
+    check_call,
+    make_global_call,
+    synthesize_call,
+)
 from guppylang_internals.checker.func_checker import (
     check_signature,
 )
@@ -48,7 +52,6 @@ from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import GuppyError, InternalGuppyError
 from guppylang_internals.metadata.common import MetadataUnitaryFlags
 from guppylang_internals.metadata.debug_info_util import make_location_record
-from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap, Span
 from guppylang_internals.std._internal.compiler.array import (
     array_new,
@@ -366,7 +369,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return node, subst
 
     @override
@@ -376,7 +379,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return node, ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
+++ b/guppylang-internals/src/guppylang_internals/definition/pytket_circuits.py
@@ -366,7 +366,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return node, subst
 
     @override
@@ -376,7 +376,7 @@ class ParsedPytketDef(CallableDef, CompilableDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return node, ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -14,6 +14,7 @@ from guppylang_internals.ast_util import AstNode, with_loc
 from guppylang_internals.checker.core import Context, Globals
 from guppylang_internals.checker.expr_checker import (
     check_call,
+    make_global_call,
     synthesize_call,
 )
 from guppylang_internals.checker.func_checker import (
@@ -37,7 +38,6 @@ from guppylang_internals.definition.value import (
     CompiledHugrNodeDef,
 )
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
-from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
 from guppylang_internals.tracing.compile import replay_trace
 from guppylang_internals.tys import Effect
@@ -124,7 +124,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return node, subst
 
     @override
@@ -134,7 +134,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
+        node = with_loc(node, make_global_call(self, args, inst))
         return node, ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -36,6 +36,7 @@ from guppylang_internals.definition.value import (
     CompiledCallableDef,
     CompiledHugrNodeDef,
 )
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
@@ -125,6 +126,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
+        ENGINE.register_generic_use(self, inst)  # ALAN move into check_call??
         return node, subst
 
     @override
@@ -135,6 +137,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
         node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
+        ENGINE.register_generic_use(self, inst)  # ALAN move into synthesize_call??
         return node, ty
 
 

--- a/guppylang-internals/src/guppylang_internals/definition/traced.py
+++ b/guppylang-internals/src/guppylang_internals/definition/traced.py
@@ -36,7 +36,6 @@ from guppylang_internals.definition.value import (
     CompiledCallableDef,
     CompiledHugrNodeDef,
 )
-from guppylang_internals.engine import ENGINE
 from guppylang_internals.metadata.common import FunctionMetadata, add_metadata
 from guppylang_internals.nodes import GlobalCall
 from guppylang_internals.span import SourceMap
@@ -125,8 +124,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
         """Checks the return type of a function call against a given type."""
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.ty, args, ty, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
-        ENGINE.register_generic_use(self, inst)  # ALAN move into check_call??
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return node, subst
 
     @override
@@ -136,8 +134,7 @@ class TracedFunctionDef(RawTracedFunctionDef, CallableDef, CheckableGenericDef):
         """Synthesizes the return type of a function call."""
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.ty, args, node, ctx)
-        node = with_loc(node, GlobalCall(def_id=self.id, args=args, type_args=inst))
-        ENGINE.register_generic_use(self, inst)  # ALAN move into synthesize_call??
+        node = with_loc(node, GlobalCall(defn=self, args=args, type_args=inst))
         return node, ty
 
 

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -58,8 +58,15 @@ class GlobalName(ast.Name):
         # Python 3.15 validates subclass-defined AST fields in the base constructor,
         # but typeshed still exposes `ast.Name.__init__` without custom kwargs.
         super().__init__(id=id, def_id=def_id)  # type: ignore[call-arg]
+        from guppylang_internals.engine import ENGINE
+
         self.id = id
         self.def_id = def_id
+        defn = ENGINE.get_parsed(def_id)
+        if isinstance(defn, CheckableGenericDef) and not defn.params:
+            # If the defn has params, it will have to be subject to a
+            # TypeApply or turned into a GlobalCall, which will register.
+            ENGINE.register_generic_use(defn, ())
 
     # See MakeIter for explanation
     __reduce__ = object.__reduce__

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -6,6 +6,9 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from guppylang_internals.ast_util import AstNode, set_location_from
+from guppylang_internals.definition.common import CheckableGenericDef, DefId
+from guppylang_internals.definition.value import CallableDef
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.span import Span, to_span
 from guppylang_internals.tys.const import BoundConstVar, Const
 from guppylang_internals.tys.subst import Inst
@@ -22,7 +25,6 @@ if TYPE_CHECKING:
     from guppylang_internals.cfg.cfg import CFG
     from guppylang_internals.checker.cfg_checker import CheckedCFG
     from guppylang_internals.checker.core import Place, Variable
-    from guppylang_internals.definition.common import DefId
     from guppylang_internals.definition.util import CheckedField
 
 
@@ -114,7 +116,7 @@ class LocalCall(ast.expr):
 
 
 class GlobalCall(ast.expr):
-    def_id: "DefId"
+    def_id: DefId  # Allows deep-copying, whereas storing the CallableDef wouldn't
     args: list[ast.expr]
     type_args: Inst  # Inferred type arguments
 
@@ -124,12 +126,21 @@ class GlobalCall(ast.expr):
         "type_args",
     )
 
-    def __init__(self, def_id: "DefId", args: list[ast.expr], type_args: Inst) -> None:
+    @property
+    def defn(self) -> CallableDef:
+        defn = ENGINE.get_parsed(self.def_id)
+        assert isinstance(defn, CallableDef)
+        return defn
+
+    def __init__(
+        self, defn: CallableDef, args: list[ast.expr], type_args: Inst
+    ) -> None:
         super().__init__()
-        self.def_id = def_id
+        self.def_id = defn.id
         self.args = args
-        assert isinstance(type_args, tuple)
         self.type_args = type_args
+        if isinstance(defn, CheckableGenericDef):
+            ENGINE.register_generic_use(defn, type_args)
 
     # See MakeIter for explanation
     __reduce__ = object.__reduce__

--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from guppylang_internals.ast_util import AstNode, set_location_from
-from guppylang_internals.definition.common import CheckableGenericDef, DefId
+from guppylang_internals.definition.common import DefId
 from guppylang_internals.definition.value import CallableDef
 from guppylang_internals.engine import ENGINE
 from guppylang_internals.span import Span, to_span
@@ -58,15 +58,8 @@ class GlobalName(ast.Name):
         # Python 3.15 validates subclass-defined AST fields in the base constructor,
         # but typeshed still exposes `ast.Name.__init__` without custom kwargs.
         super().__init__(id=id, def_id=def_id)  # type: ignore[call-arg]
-        from guppylang_internals.engine import ENGINE
-
         self.id = id
         self.def_id = def_id
-        defn = ENGINE.get_parsed(def_id)
-        if isinstance(defn, CheckableGenericDef) and not defn.params:
-            # If the defn has params, it will have to be subject to a
-            # TypeApply or turned into a GlobalCall, which will register.
-            ENGINE.register_generic_use(defn, ())
 
     # See MakeIter for explanation
     __reduce__ = object.__reduce__
@@ -146,8 +139,6 @@ class GlobalCall(ast.expr):
         self.def_id = defn.id
         self.args = args
         self.type_args = type_args
-        if isinstance(defn, CheckableGenericDef):
-            ENGINE.register_generic_use(defn, type_args)
 
     # See MakeIter for explanation
     __reduce__ = object.__reduce__

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -19,6 +19,7 @@ from guppylang_internals.checker.expr_checker import (
     check_num_args,
     check_type_against,
     coerce_to_common,
+    make_global_call,
     synthesize_call,
     synthesize_comprehension,
     try_coerce_to,
@@ -42,7 +43,6 @@ from guppylang_internals.nodes import (
     BarrierExpr,
     DesugaredArrayComp,
     DesugaredGeneratorExpr,
-    GlobalCall,
     MakeIter,
     PlaceNode,
 )
@@ -186,7 +186,7 @@ class ArrayCopyChecker(CustomCallChecker):
                     )
                     raise GuppyTypeError(err)
         [array_arg], _, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
-        node = GlobalCall(defn=self.func, args=[array_arg], type_args=inst)
+        node = make_global_call(self.func, [array_arg], inst)
         return with_loc(self.node, node), get_type(array_arg)
 
 
@@ -280,7 +280,7 @@ class ArrayIndexChecker(CustomCallChecker):
         # self._check_constant_index_bounds(args[self.expr_index], type_args[1])
 
         # Return the synthesized node and type
-        node = GlobalCall(defn=self.func, args=args, type_args=type_args)
+        node = make_global_call(self.func, args, type_args)
         return with_loc(self.node, node), subs
 
     @override
@@ -294,7 +294,7 @@ class ArrayIndexChecker(CustomCallChecker):
         # self._check_constant_index_bounds(args[self.expr_index], type_args[1])
 
         # Return the synthesized node and type
-        node = GlobalCall(defn=self.func, args=args, type_args=type_args)
+        node = make_global_call(self.func, args, type_args)
         return with_loc(self.node, node), ty
 
 
@@ -361,9 +361,7 @@ class NewArrayChecker(CustomCallChecker):
                         args[i] = coerced
 
                 result_ty = array_type(common_ty, len(args))
-                call = GlobalCall(
-                    defn=self.func, args=args, type_args=tuple(result_ty.args)
-                )
+                call = make_global_call(self.func, args, tuple(result_ty.args))
                 return with_loc(self.node, call), result_ty
 
     @override
@@ -407,7 +405,7 @@ class NewArrayChecker(CustomCallChecker):
                             TypeArg(elem_ty.substitute(subst)),
                             ConstArg(ConstValue(nat_type(), len(args))),
                         )
-                        call = GlobalCall(self.func, args, type_args)
+                        call = make_global_call(self.func, args, type_args)
                         return with_loc(self.node, call), subst
             case type_args:
                 raise InternalGuppyError(f"Invalid array type args: {type_args}")
@@ -540,10 +538,10 @@ class WasmCallChecker(CustomCallChecker):
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
 
-        return GlobalCall(defn=self.func, args=args, type_args=inst), subst
+        return make_global_call(self.func, args, inst), subst
 
     @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
-        return GlobalCall(defn=self.func, args=args, type_args=inst), ty
+        return make_global_call(self.func, args, inst), ty

--- a/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
+++ b/guppylang-internals/src/guppylang_internals/std/_internal/checker.py
@@ -186,7 +186,7 @@ class ArrayCopyChecker(CustomCallChecker):
                     )
                     raise GuppyTypeError(err)
         [array_arg], _, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
-        node = GlobalCall(def_id=self.func.id, args=[array_arg], type_args=inst)
+        node = GlobalCall(defn=self.func, args=[array_arg], type_args=inst)
         return with_loc(self.node, node), get_type(array_arg)
 
 
@@ -280,7 +280,7 @@ class ArrayIndexChecker(CustomCallChecker):
         # self._check_constant_index_bounds(args[self.expr_index], type_args[1])
 
         # Return the synthesized node and type
-        node = GlobalCall(def_id=self.func.id, args=args, type_args=type_args)
+        node = GlobalCall(defn=self.func, args=args, type_args=type_args)
         return with_loc(self.node, node), subs
 
     @override
@@ -294,7 +294,7 @@ class ArrayIndexChecker(CustomCallChecker):
         # self._check_constant_index_bounds(args[self.expr_index], type_args[1])
 
         # Return the synthesized node and type
-        node = GlobalCall(def_id=self.func.id, args=args, type_args=type_args)
+        node = GlobalCall(defn=self.func, args=args, type_args=type_args)
         return with_loc(self.node, node), ty
 
 
@@ -362,7 +362,7 @@ class NewArrayChecker(CustomCallChecker):
 
                 result_ty = array_type(common_ty, len(args))
                 call = GlobalCall(
-                    def_id=self.func.id, args=args, type_args=tuple(result_ty.args)
+                    defn=self.func, args=args, type_args=tuple(result_ty.args)
                 )
                 return with_loc(self.node, call), result_ty
 
@@ -407,11 +407,7 @@ class NewArrayChecker(CustomCallChecker):
                             TypeArg(elem_ty.substitute(subst)),
                             ConstArg(ConstValue(nat_type(), len(args))),
                         )
-                        call = GlobalCall(
-                            self.func.id,
-                            args,
-                            type_args,
-                        )
+                        call = GlobalCall(self.func, args, type_args)
                         return with_loc(self.node, call), subst
             case type_args:
                 raise InternalGuppyError(f"Invalid array type args: {type_args}")
@@ -544,10 +540,10 @@ class WasmCallChecker(CustomCallChecker):
         # Use default implementation from the expression checker
         args, subst, inst = check_call(self.func.ty, args, ty, self.node, self.ctx)
 
-        return GlobalCall(def_id=self.func.id, args=args, type_args=inst), subst
+        return GlobalCall(defn=self.func, args=args, type_args=inst), subst
 
     @override
     def synthesize(self, args: list[ast.expr]) -> tuple[ast.expr, Type]:
         # Use default implementation from the expression checker
         args, ty, inst = synthesize_call(self.func.ty, args, self.node, self.ctx)
-        return GlobalCall(def_id=self.func.id, args=args, type_args=inst), ty
+        return GlobalCall(defn=self.func, args=args, type_args=inst), ty

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -619,7 +619,7 @@ class TracingDefMixin(DunderMixin):
                 raise GuppyComptimeError(
                     f"Cannot infer type parameters of generic function `{defn.name}`"
                 )
-            wire = state.recorder.record_load_func(defn.id, ())
+            wire = state.recorder.record_load_func(defn, ())
             return GuppyObject(defn.ty, wire, None)
         if isinstance(defn, ValueDef):
             return GuppyObject(defn.ty, state.recorder.record_load(defn))

--- a/guppylang-internals/src/guppylang_internals/tracing/recorder.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/recorder.py
@@ -5,11 +5,12 @@ from typing import TYPE_CHECKING, Any, TypeAlias, overload
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import ComptimeVariable, Place
-from guppylang_internals.definition.value import ValueDef
+from guppylang_internals.definition.common import CheckableGenericDef, DefId
+from guppylang_internals.definition.value import CallableDef, ValueDef
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.tys.ty import Type
 
 if TYPE_CHECKING:
-    from guppylang_internals.definition.common import DefId
     from guppylang_internals.tys.subst import Inst
 
 
@@ -159,12 +160,16 @@ class TraceRecorder:
         node = get_tracing_state().node
         return self._add(TraceLoad(value, node))
 
-    def record_load_func(self, def_id: "DefId", type_args: "Inst") -> TraceWire:
+    def record_load_func(self, defn: CallableDef, type_args: "Inst") -> TraceWire:
         """Records a load_function to replay during compilation"""
         from guppylang_internals.tracing.state import get_tracing_state
 
         node = get_tracing_state().node
-        return self._add(TraceFunctionLoad(def_id, type_args, node))
+
+        if isinstance(defn, CheckableGenericDef):
+            ENGINE.register_generic_use(defn, type_args)
+
+        return self._add(TraceFunctionLoad(defn.id, type_args, node))
 
     def record_call(
         self,

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -42,10 +42,6 @@ def test_check_traces_generic() -> None:
     main.check()
 
     # Order is not preserved
-    if sorted(trace_events) == [3, 5]:
-        import pytest
-
-        pytest.xfail()
     assert sorted(trace_events) == [3, 4, 5, 6]
 
 

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -35,12 +35,18 @@ def test_check_traces_generic() -> None:
     @guppy
     def main() -> None:
         x: array[int, 3] = foo()
+        foo[4]()
         y: array[int, 5] = foo()
+        foo[6]()
 
     main.check()
 
     # Order is not preserved
-    assert sorted(trace_events) == [3, 5]
+    if sorted(trace_events) == [3, 5]:
+        import pytest
+
+        pytest.xfail()
+    assert sorted(trace_events) == [3, 4, 5, 6]
 
 
 def test_flat(validate):

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -22,6 +22,29 @@ def test_check_traces() -> None:
     assert trace_events == ["traced"]
 
 
+def test_check_traces_generic() -> None:
+    trace_events = []
+
+    n = guppy.nat_var("n")
+
+    @guppy.comptime
+    def foo() -> array[int, n]:
+        trace_events.append(n)
+        return list(range(n))
+
+    @guppy
+    def main() -> None:
+        x: array[int, 3] = foo()
+        y: array[int, 5] = foo()
+
+    main.check()
+    if trace_events == []:
+        import pytest
+
+        pytest.xfail()
+    assert trace_events == [3, 5]
+
+
 def test_flat(validate):
     @guppy.comptime
     def foo() -> int:

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -5,6 +5,7 @@ from guppylang.std.qsystem.random import RNG
 
 from hugr import ops
 from hugr.std.int import IntVal
+import pytest
 
 from guppylang_internals.tracing.object import GuppyObject
 
@@ -45,7 +46,8 @@ def test_check_traces_generic() -> None:
     assert sorted(trace_events) == [3, 4, 5, 6]
 
 
-def test_check_traces_load() -> None:
+@pytest.mark.parametrize("deco", [guppy, guppy.comptime])
+def test_check_traces_load(deco) -> None:
     trace_events = []
 
     @guppy.comptime
@@ -53,7 +55,7 @@ def test_check_traces_load() -> None:
         trace_events.append("traced")
         return 1
 
-    @guppy.comptime
+    @deco
     def main() -> Function[[], int]:
         return foo
 

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -38,11 +38,9 @@ def test_check_traces_generic() -> None:
         y: array[int, 5] = foo()
 
     main.check()
-    if trace_events == []:
-        import pytest
 
-        pytest.xfail()
-    assert trace_events == [3, 5]
+    # Order is not preserved
+    assert sorted(trace_events) == [3, 5]
 
 
 def test_flat(validate):

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -45,6 +45,23 @@ def test_check_traces_generic() -> None:
     assert sorted(trace_events) == [3, 4, 5, 6]
 
 
+def test_check_traces_load() -> None:
+    trace_events = []
+
+    @guppy.comptime
+    def foo() -> int:
+        trace_events.append("traced")
+        return 1
+
+    @guppy.comptime
+    def main() -> Function[[], int]:
+        return foo
+
+    main.check()
+
+    assert trace_events == ["traced"]
+
+
 def test_flat(validate):
     @guppy.comptime
     def foo() -> int:


### PR DESCRIPTION
Even after #2104, `build_compiled_def` still calls `get_checked` which can cause more typechecking and tracing (during compilation). Specific cases addressed by this PR:
* Comptime functions with generic types
* functions that are only *loaded* (not called)
* Function Decls

...all of which are now checked before compilation. (The first two are tested.)

The "fix" in all cases is to call `ENGINE.register_generic_use` during checking of the call(er), via factory methods `make_type_apply`, `make_global_call` and `make_global_name`.