### PR TITLE
fix: Unsupported inheritance error for guppy-defined bases

### DIFF
--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -541,6 +541,18 @@ class TracingDefMixin(DunderMixin):
 
     wrapped: Definition
 
+    def __mro_entries__(self, bases: tuple[type, ...]) -> tuple[type, ...]:
+        """Resolve Guppy definitions used as Python class bases.
+
+        This lets class creation proceed so Guppy can report unsupported
+        inheritance with its regular diagnostics during struct/enum/protocol parsing.
+        """
+        if isinstance(self.wrapped, TypeDef):
+            python_class = getattr(self.wrapped, "python_class", None)
+            if isinstance(python_class, type):
+                return (python_class,)
+        return ()
+
     @property
     def id(self) -> DefId:
         return self.wrapped.id

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -243,7 +243,7 @@ class _Guppy:
             # Prior to Python 3.13, the `__firstlineno__` attribute on classes is not
             # set. However, we need this information to precisely look up the source for
             # the class later. If it's not there, we can set it from the calling frame:
-            if not hasattr(cls, "__firstlineno__"):
+            if "__firstlineno__" not in cls.__dict__:
                 cls.__firstlineno__ = frame.f_lineno  # type: ignore[attr-defined]
             # We're pretending to return the class unchanged, but in fact we return
             # a `GuppyDefinition` that handles the comptime logic
@@ -287,7 +287,7 @@ class _Guppy:
             # Prior to Python 3.13, the `__firstlineno__` attribute on classes is not
             # set. However, we need this information to precisely look up the source for
             # the class later. If it's not there, we can set it from the calling frame:
-            if not hasattr(cls, "__firstlineno__"):
+            if "__firstlineno__" not in cls.__dict__:
                 cls.__firstlineno__ = frame.f_lineno  # type: ignore[attr-defined]
             # We're pretending to return the class unchanged, but in fact we return
             # a `GuppyDefinition` that handles the comptime logic
@@ -786,7 +786,9 @@ def _set_firstlineno(cls: builtins.type[T], frame: FrameType) -> builtins.type[T
     However, we need this information to precisely look up the source for the
     class later. If it's not there, we can set it from the calling frame.
     """
-    if not hasattr(cls, "__firstlineno__"):
+    # Use the class dict directly: inherited `__firstlineno__` from a base class would
+    # point to the wrong source block for this class.
+    if "__firstlineno__" not in cls.__dict__:
         cls.__firstlineno__ = frame.f_lineno  # type: ignore[attr-defined]
     return cls
 

--- a/tests/error/struct_errors/other_struct_inheritance.err
+++ b/tests/error/struct_errors/other_struct_inheritance.err
@@ -1,0 +1,8 @@
+Error: Unsupported (at $FILE:9:18)
+  | 
+7 | 
+8 | @guppy.struct
+9 | class OtherStruct(MyStruct):
+  |                   ^^^^^^^^ Struct inheritance is not supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/struct_errors/other_struct_inheritance.py
+++ b/tests/error/struct_errors/other_struct_inheritance.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+
+
+@guppy.struct
+class MyStruct:
+    x: bool
+
+@guppy.struct
+class OtherStruct(MyStruct):
+    pass
+
+OtherStruct.compile()


### PR DESCRIPTION
Trying to inherit from a guppy defined struct (as opposed to a python class as struct inheritance error tests we've had so far were testing for) wasn't reaching the inheritance unsupported error handling as we would get an error during parsing of the struct name instead. Resolving the guppy definition base as a python class allows us to reach the expected error. 

Closes #2201