### PR TITLE
docs: state that `power` is experimental in the API docs

### DIFF
--- a/guppylang/src/guppylang/std/lang.py
+++ b/guppylang/src/guppylang/std/lang.py
@@ -66,7 +66,12 @@ def dagger(*args: Any, **kwargs: Any) -> Generator[None]:
 
 
 def power(*args: Any, **kwargs: Any) -> Generator[None]:
-    """Dummy function to support `with power(...):` blocks in Guppy code."""
+    """Dummy function to support `with power(...):` blocks in Guppy code.
+
+    .. warning::
+
+        ``power`` is an experimental feature and is not fully operational yet.
+    """
     raise GuppyComptimeError(_MODIFIER_COMPTIME_ERROR.format(modifier="power"))
 
 


### PR DESCRIPTION
The `power` modifier is not fully operational yet, but the generated API docs for `guppylang.std.lang.power` did not communicate that.