### PR TITLE
fix(errors): error on loading polymorphic function

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/stmt_checker.py
@@ -54,6 +54,7 @@ from guppylang_internals.checker.expr_checker import (
     check_place_assignable,
     synthesize_comprehension,
 )
+from guppylang_internals.definition.common import CheckableGenericDef
 from guppylang_internals.engine import ENGINE
 from guppylang_internals.error import (
     GuppyError,
@@ -65,6 +66,7 @@ from guppylang_internals.nodes import (
     AnyUnpack,
     ArrayUnpack,
     DesugaredArrayComp,
+    GlobalName,
     IterableUnpack,
     MakeIter,
     ModifiedBlock,
@@ -142,8 +144,15 @@ class StmtChecker(AstVisitor[BBStatement]):
 
     @_check_assign.register
     def _check_variable_assign(
-        self, lhs: ast.Name, _rhs: ast.expr, rhs_ty: Type
+        self, lhs: ast.Name, rhs: ast.expr, rhs_ty: Type
     ) -> PlaceNode:
+        if isinstance(rhs, GlobalName):
+            defn = ENGINE.get_parsed(rhs.def_id)
+            if isinstance(defn, CheckableGenericDef) and defn.params:
+                err = UnsupportedError(
+                    rhs, "Polymorphic functions as dynamic higher-order values"
+                )
+                raise GuppyError(err)
         x = lhs.id
         var = Variable(x, rhs_ty, lhs)
         self.ctx.locals[x] = var

--- a/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
+++ b/guppylang-internals/src/guppylang_internals/compiler/expr_compiler.py
@@ -16,7 +16,6 @@ from hugr import val as hv
 from guppylang_internals.ast_util import AstNode, AstVisitor, get_type
 from guppylang_internals.cfg.builder import tmp_vars
 from guppylang_internals.checker.core import Variable, contains_subscript
-from guppylang_internals.checker.errors.generic import UnsupportedError
 from guppylang_internals.compiler.builder import (
     CondBuilder,
     DFBuilder,
@@ -265,12 +264,7 @@ class ExprCompiler(CompilerBase, AstVisitor[Wire]):
 
     def visit_GlobalName(self, node: GlobalName) -> Wire:
         defn = ENGINE.get_parsed(node.def_id)
-        if isinstance(defn, CheckableGenericDef) and defn.params:
-            # TODO: This should be caught during checking
-            err = UnsupportedError(
-                node, "Polymorphic functions as dynamic higher-order values"
-            )
-            raise GuppyError(err)
+        assert not (isinstance(defn, CheckableGenericDef) and defn.params)
 
         if isinstance(get_type(node), FunctionDefType):
             # Function items don't need an actual runtime representation so we just

--- a/tests/error/poly_errors/poly_callable.err
+++ b/tests/error/poly_errors/poly_callable.err
@@ -1,0 +1,9 @@
+Error: Unsupported (at $FILE:14:9)
+   | 
+12 | @guppy
+13 | def main() -> int:
+14 |     ff = foo
+   |          ^^^ Polymorphic functions as dynamic higher-order values are not
+   |              supported
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/poly_errors/poly_callable.py
+++ b/tests/error/poly_errors/poly_callable.py
@@ -1,0 +1,23 @@
+from collections.abc import Callable
+
+from guppylang.decorator import guppy
+
+T = guppy.type_var("T")
+
+
+@guppy.declare
+def foo(x: T) -> T:
+    ...
+
+@guppy
+def main() -> int:
+    ff = foo
+    i: int = ff(3)
+    # Type inference could allow inferring a type argument above,
+    # but does not ATM; if we extend inference to do so then the below
+    # extends the test to make inference impossible:
+    #f: float = ff(3.14)
+    return i
+
+
+main.compile()

--- a/tests/error/type_errors/fun_item_ty_mismatch_generic.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch_generic.err
@@ -1,20 +1,9 @@
-Error: Different types (at $FILE:21:11)
+Error: Unsupported (at $FILE:18:14)
    | 
-19 |     else:
-20 |         baz = bar
-21 |     return baz(42)
-   |            ^^^ Variable `baz` may refer to different types
-
-Notes:
-   | 
+16 | def main(b: bool) -> int:
 17 |     if b:
 18 |         baz = foo
-   |         --- This is of type `def foo(x: T) -> T`
-19 |     else:
-20 |         baz = bar
-   |         --- This is of type `def bar(x: T) -> T`
-
-Help: Consider adding type annotations to coerce them into opaque function
-values: `baz: Function[[?T], ?T] = ...`
+   |               ^^^ Polymorphic functions as dynamic higher-order values are not
+   |                   supported
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_generic_if.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch_generic_if.err
@@ -1,0 +1,19 @@
+Error: Different types (at $FILE:17:10)
+   | 
+15 | @guppy
+16 | def main(b: bool) -> int:
+17 |     baz = foo if b else bar
+   |           ^^^^^^^^^^^^^^^^^ Expression may refer to different types
+
+Notes:
+   | 
+16 | def main(b: bool) -> int:
+17 |     baz = foo if b else bar
+   |           --- This is of type `def foo(x: T) -> T`
+   | 
+17 |     baz = foo if b else bar
+   |                         --- This is of type `def bar(x: T) -> T`
+
+Help: Consider coercing both values to `Function[[?T], ?T]`
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_generic_if.err
+++ b/tests/error/type_errors/fun_item_ty_mismatch_generic_if.err
@@ -1,19 +1,9 @@
-Error: Different types (at $FILE:17:10)
+Error: Unsupported (at $FILE:17:10)
    | 
 15 | @guppy
 16 | def main(b: bool) -> int:
 17 |     baz = foo if b else bar
-   |           ^^^^^^^^^^^^^^^^^ Expression may refer to different types
-
-Notes:
-   | 
-16 | def main(b: bool) -> int:
-17 |     baz = foo if b else bar
-   |           --- This is of type `def foo(x: T) -> T`
-   | 
-17 |     baz = foo if b else bar
-   |                         --- This is of type `def bar(x: T) -> T`
-
-Help: Consider coercing both values to `Function[[?T], ?T]`
+   |           ^^^ Polymorphic functions as dynamic higher-order values are not
+   |               supported
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/type_errors/fun_item_ty_mismatch_generic_if.py
+++ b/tests/error/type_errors/fun_item_ty_mismatch_generic_if.py
@@ -1,0 +1,21 @@
+from guppylang import guppy
+
+
+T = guppy.type_var("T")
+
+
+@guppy.declare
+def foo(x: T) -> T: ...
+
+
+@guppy.declare
+def bar(x: T) -> T: ...
+
+
+@guppy
+def main(b: bool) -> int:
+    baz = foo if b else bar
+    return baz(42)
+
+
+main.compile_function()


### PR DESCRIPTION
(Stumbled across this while investigating another issue, but nonetheless this seems an improvement.)

Currently if you assign a polymorphic function to a variable you get an error during *compilation*, not checking. Turned out we didn't have a test of this at all, so have added one...

(See new tests in [first commit](8acfaa72b5448f0c77cbae8ce52c31565853091d) which are passing on `main`)

In a couple of cases this leads to checking issuing a *different* error, and of course we never get to the one that would be issued later in compilation, so detecting the error earlier leads to a change in message.

I reason that assignment is the only case where we care:
* If the poly-function is used as an argument, type inference will be used, and infer an instantiation. We *could* do this for assignment (i.e. to find an instantiation where the variable is used only monomorphically), e.g. perhaps by searching across the basic block, so maybe #707 is in fact an understatement (type inference doesn't even work across a single BB yet...)
* For a top-level expression (`foo` where that's a poly-function), we don't need to find an instantiation, so it seems fine not to.