### PR TITLE
fix: yet more check/trace before compilation

### DIFF
--- a/guppylang-internals/src/guppylang_internals/nodes.py
+++ b/guppylang-internals/src/guppylang_internals/nodes.py
@@ -58,8 +58,15 @@ class GlobalName(ast.Name):
         # Python 3.15 validates subclass-defined AST fields in the base constructor,
         # but typeshed still exposes `ast.Name.__init__` without custom kwargs.
         super().__init__(id=id, def_id=def_id)  # type: ignore[call-arg]
+        from guppylang_internals.engine import ENGINE
+
         self.id = id
         self.def_id = def_id
+        defn = ENGINE.get_parsed(def_id)
+        if isinstance(defn, CheckableGenericDef) and not defn.params:
+            # If the defn has params, it will have to be subject to a
+            # TypeApply or turned into a GlobalCall, which will register.
+            ENGINE.register_generic_use(defn, ())
 
     # See MakeIter for explanation
     __reduce__ = object.__reduce__

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -619,7 +619,7 @@ class TracingDefMixin(DunderMixin):
                 raise GuppyComptimeError(
                     f"Cannot infer type parameters of generic function `{defn.name}`"
                 )
-            wire = state.recorder.record_load_func(defn.id, ())
+            wire = state.recorder.record_load_func(defn, ())
             return GuppyObject(defn.ty, wire, None)
         if isinstance(defn, ValueDef):
             return GuppyObject(defn.ty, state.recorder.record_load(defn))

--- a/guppylang-internals/src/guppylang_internals/tracing/recorder.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/recorder.py
@@ -5,11 +5,12 @@ from typing import TYPE_CHECKING, Any, TypeAlias, overload
 
 from guppylang_internals.ast_util import AstNode
 from guppylang_internals.checker.core import ComptimeVariable, Place
-from guppylang_internals.definition.value import ValueDef
+from guppylang_internals.definition.common import CheckableGenericDef, DefId
+from guppylang_internals.definition.value import CallableDef, ValueDef
+from guppylang_internals.engine import ENGINE
 from guppylang_internals.tys.ty import Type
 
 if TYPE_CHECKING:
-    from guppylang_internals.definition.common import DefId
     from guppylang_internals.tys.subst import Inst
 
 
@@ -159,12 +160,16 @@ class TraceRecorder:
         node = get_tracing_state().node
         return self._add(TraceLoad(value, node))
 
-    def record_load_func(self, def_id: "DefId", type_args: "Inst") -> TraceWire:
+    def record_load_func(self, defn: CallableDef, type_args: "Inst") -> TraceWire:
         """Records a load_function to replay during compilation"""
         from guppylang_internals.tracing.state import get_tracing_state
 
         node = get_tracing_state().node
-        return self._add(TraceFunctionLoad(def_id, type_args, node))
+
+        if isinstance(defn, CheckableGenericDef):
+            ENGINE.register_generic_use(defn, type_args)
+
+        return self._add(TraceFunctionLoad(defn.id, type_args, node))
 
     def record_call(
         self,

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -5,6 +5,7 @@ from guppylang.std.qsystem.random import RNG
 
 from hugr import ops
 from hugr.std.int import IntVal
+import pytest
 
 from guppylang_internals.tracing.object import GuppyObject
 
@@ -45,7 +46,8 @@ def test_check_traces_generic() -> None:
     assert sorted(trace_events) == [3, 4, 5, 6]
 
 
-def test_check_traces_load() -> None:
+@pytest.mark.parametrize("deco", [guppy, guppy.comptime])
+def test_check_traces_load(deco) -> None:
     trace_events = []
 
     @guppy.comptime
@@ -53,7 +55,7 @@ def test_check_traces_load() -> None:
         trace_events.append("traced")
         return 1
 
-    @guppy.comptime
+    @deco
     def main() -> Function[[], int]:
         return foo
 

--- a/tests/integration/tracing/test_basic.py
+++ b/tests/integration/tracing/test_basic.py
@@ -45,6 +45,23 @@ def test_check_traces_generic() -> None:
     assert sorted(trace_events) == [3, 4, 5, 6]
 
 
+def test_check_traces_load() -> None:
+    trace_events = []
+
+    @guppy.comptime
+    def foo() -> int:
+        trace_events.append("traced")
+        return 1
+
+    @guppy.comptime
+    def main() -> Function[[], int]:
+        return foo
+
+    main.check()
+
+    assert trace_events == ["traced"]
+
+
 def test_flat(validate):
     @guppy.comptime
     def foo() -> int:


### PR DESCRIPTION
Follows #2210; will merge into #2210, or I can abandon that PR and target this straight into `main` so all can be reviewed together?

Yet another case, that of merely *loading* a function (comptime or otherwise, but it's the comptime ones where the difference is obvious).

I think the big question is whether we like these node "constructors" doing so much work; feels like `nodes.py` should be independent of e.g. `ENGINE`, in which case we should avoid using the constructors directly and use factory methods in the checker...indeed `make_type_apply` from #2210 is such a factory method already, so for consistency, either that should go into the `TypeApply` constructor, or we should keep all constructors minimal and add `make_global_call` and `make_global_name`. Thoughts??

registering multiple times is relatively harmless: it'll fill up the worklist, but when an already-checked item is popped off the worklist, we'll detect this (it'll be in `CompilationEngine.checked`) so not check it again.