### PR TITLE
feat(emulator): Add Traces and Metrics to EmulatorResult

### DIFF
--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -93,6 +93,30 @@ See the :py:class:`EmulatorInstance` documentation for a full list of options an
 defaults.
 
 
+Program analysis
+----------------
+
+Instruction traces, circuits, and execution metrics can be collected by configuring the
+emulator instance. Configure the desired analyses before calling either ``run`` or
+``run_per_shot`` and retrieve their per-shot data from the result:
+
+.. code-block:: python
+
+    emulator = foo.emulator(n_qubits=1).with_trace().with_metrics()
+    result = emulator.run()
+
+    trace = result.traces()[0]
+    circuit = result.circuits()[0]
+    metrics = result.metrics()[0]
+
+Trace collection records the executed instruction stream. It can differ between shots
+because of measurement-controlled branches or other sources of nondeterminism, such as
+random-number generation or stochastic error models. Each :py:class:`Trace` contains
+ordered events from the user program, runtime, error model, and simulator; its
+``get_*_trace()`` methods select events from a single execution stage. Circuit
+conversion is performed only when :py:meth:`EmulatorResult.circuits` is called.
+
+
 Noisy simulation
 -----------------
 
@@ -277,7 +301,15 @@ standard library used:
 from .builder import EmulatorBuilder, Platform
 from .exceptions import EmulatorError
 from .instance import EmulatorInstance
-from .result import EmulatorResult, QsysShot, TaggedResult
+from .result import (
+    EmulatorResult,
+    MetricGroup,
+    MetricValue,
+    QsysShot,
+    ShotMetrics,
+    TaggedResult,
+    Trace,
+)
 from .state import PartialState, PartialVector, StateVector, TracedState
 
 __all__ = [
@@ -285,11 +317,15 @@ __all__ = [
     "EmulatorError",
     "EmulatorInstance",
     "EmulatorResult",
+    "MetricGroup",
+    "MetricValue",
     "PartialState",
     "PartialVector",
     "Platform",
     "QsysShot",
+    "ShotMetrics",
     "StateVector",
     "TaggedResult",
+    "Trace",
     "TracedState",
 ]

--- a/guppylang/src/guppylang/emulator/instance.py
+++ b/guppylang/src/guppylang/emulator/instance.py
@@ -13,7 +13,7 @@ from selene_argreader_plugin import ArgProvider
 from selene_sim.backends.bundled_error_models import IdealErrorModel
 from selene_sim.backends.bundled_runtimes import SimpleRuntime
 from selene_sim.backends.bundled_simulators import Coinflip, Quest, Stim
-from selene_sim.event_hooks import EventHook, NoEventHook
+from selene_sim.event_hooks.event_hook import EventHook, MultiEventHook, NoEventHook
 from tqdm import tqdm
 
 from ._args import (
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
     from selene_core.error_model import ErrorModel
     from selene_core.runtime import Runtime
     from selene_core.simulator import Simulator
+    from selene_sim.event_hooks.instruction_log import CircuitExtractor
+    from selene_sim.event_hooks.metrics import MetricStore
     from selene_sim.instance import SeleneInstance
 
     from ._args import EntrypointArgSpec
@@ -72,6 +74,8 @@ class _Options:
     # unstable:
     _results_logfile: Path | None = None
     _display_progress_bar: bool = False
+    _trace_enabled: bool = False
+    _metrics_enabled: bool = False
 
 
 @dataclass(frozen=True)
@@ -156,6 +160,16 @@ class EmulatorInstance:
         Defaults to 1, meaning no parallelisation."""
         return self._options._n_processes
 
+    @property
+    def trace_enabled(self) -> bool:
+        """Whether instruction tracing is enabled for emulator executions."""
+        return self._options._trace_enabled
+
+    @property
+    def metrics_enabled(self) -> bool:
+        """Whether metric collection is enabled for emulator executions."""
+        return self._options._metrics_enabled
+
     def with_n_qubits(self, value: int) -> Self:
         """Set the number of qubits available in the emulator instance."""
         return replace(self, _n_qubits=value)
@@ -181,9 +195,35 @@ class EmulatorInstance:
         return self._with_option(_error_model=value)
 
     def with_event_hook(self, value: EventHook) -> Self:
-        """Set the event hook used for the emulator instance.
-        Defaults to NoEventHook."""
+        """Set a custom Selene event hook for the emulator instance.
+
+        When :meth:`with_trace` or :meth:`with_metrics` is enabled, the custom
+        hook is composed with fresh, result-owned analysis hooks for each
+        execution. All hooks receive each event, even when the custom hook
+        handles it, so custom event processing cannot prevent trace or metric
+        collection. Analysis hooks supplied explicitly here remain caller-owned
+        and are not exposed through :class:`EmulatorResult` accessors.
+
+        Defaults to :class:`~selene_sim.event_hooks.event_hook.NoEventHook`.
+        """
         return self._with_option(_event_hook=value)
+
+    def with_trace(self, value: bool = True) -> Self:
+        """Enable collection of per-shot instruction traces.
+
+        Traces can be retrieved from the :class:`EmulatorResult` returned by
+        :meth:`run` or :meth:`run_per_shot`. The same instruction log can also be
+        converted to circuits with :meth:`EmulatorResult.circuits`.
+        """
+        return self._with_option(_trace_enabled=value)
+
+    def with_metrics(self, value: bool = True) -> Self:
+        """Enable collection of per-shot emulator metrics.
+
+        Metrics can be retrieved from the :class:`EmulatorResult` returned by
+        :meth:`run` or :meth:`run_per_shot`.
+        """
+        return self._with_option(_metrics_enabled=value)
 
     def with_verbose(self, value: bool) -> Self:
         """Set whether to print verbose output during the emulator execution.
@@ -260,13 +300,13 @@ class EmulatorInstance:
                     "This entrypoint takes no runtime arguments, but got: "
                     + ", ".join(f"`{name}`" for name in args)
                 )
-            return self._collect_results(self._run_instance())
+            return self._run_and_collect_results()
 
         validate_record(self._arg_specs, args)
         provider = ArgProvider()
         provider.set_constant_args(**_to_provider_args(args))
         with provider:
-            return self._collect_results(self._run_instance())
+            return self._run_and_collect_results()
 
     def run_per_shot(self, args: Sequence[Mapping[str, ArgValue]]) -> EmulatorResult:
         """Run the emulator with a different set of runtime arguments per shot.
@@ -308,10 +348,56 @@ class EmulatorInstance:
         provider = ArgProvider()
         provider.set_variable_args([_to_provider_args(record) for record in args])
         with provider:
-            return instance._collect_results(instance._run_instance())
+            return instance._run_and_collect_results()
+
+    def _run_and_collect_results(self) -> EmulatorResult:
+        """Run the instance and retain any configured analysis collectors."""
+        event_hook, circuit_extractor, metric_store = self._analysis_event_hook()
+        return self._collect_results(
+            self._run_instance(event_hook),
+            circuit_extractor=circuit_extractor,
+            metric_store=metric_store,
+        )
+
+    def _analysis_event_hook(
+        self,
+    ) -> tuple[EventHook, CircuitExtractor | None, MetricStore | None]:
+        """Construct fresh analysis hooks for one emulator execution."""
+        circuit_extractor: CircuitExtractor | None = None
+        metric_store: MetricStore | None = None
+        event_hooks: list[EventHook] = []
+
+        if type(self._options._event_hook) is not NoEventHook:
+            event_hooks.append(self._options._event_hook)
+
+        if self.trace_enabled:
+            from selene_sim.event_hooks.instruction_log import CircuitExtractor
+
+            circuit_extractor = CircuitExtractor()  # type: ignore[no-untyped-call]
+            event_hooks.append(circuit_extractor)
+
+        if self.metrics_enabled:
+            from selene_sim.event_hooks.metrics import MetricStore
+
+            metric_store = MetricStore()  # type: ignore[no-untyped-call]
+            event_hooks.append(metric_store)
+
+        if not event_hooks:
+            return NoEventHook(), circuit_extractor, metric_store
+        if len(event_hooks) == 1:
+            return event_hooks[0], circuit_extractor, metric_store
+        return (
+            MultiEventHook(event_hooks=event_hooks, short_circuit=False),
+            circuit_extractor,
+            metric_store,
+        )
 
     def _collect_results(
-        self, result_stream: Iterator[Iterator[TaggedResult]]
+        self,
+        result_stream: Iterator[Iterator[TaggedResult]],
+        *,
+        circuit_extractor: CircuitExtractor | None = None,
+        metric_store: MetricStore | None = None,
     ) -> EmulatorResult:
         """Drain a shot result stream into an :class:`EmulatorResult`."""
         all_results: list[QsysShot] = []
@@ -324,21 +410,33 @@ class EmulatorInstance:
                 # In this case, casting a wide net on exceptions is
                 # suitable.
                 raise EmulatorError(
-                    completed_shots=EmulatorResult(all_results),
+                    completed_shots=EmulatorResult(
+                        all_results,
+                        _circuit_extractor=circuit_extractor,
+                        _metric_store=metric_store,
+                    ),
                     failing_shot=shot_results,
                     underlying_exception=e,
                 ) from None
             all_results.append(shot_results)
-        return EmulatorResult(all_results)
+        return EmulatorResult(
+            all_results,
+            _circuit_extractor=circuit_extractor,
+            _metric_store=metric_store,
+        )
 
-    def _run_instance(self) -> Iterator[Iterator[TaggedResult]]:
+    def _run_instance(
+        self, event_hook: EventHook | None = None
+    ) -> Iterator[Iterator[TaggedResult]]:
         """Run the Selene instance with the given simulator lazily."""
         return self._instance.run_shots(
             simulator=self.simulator,
             runtime=self.runtime,
             n_qubits=self.n_qubits,
             n_shots=self.shots,
-            event_hook=self._options._event_hook,
+            event_hook=(
+                event_hook if event_hook is not None else self._options._event_hook
+            ),
             error_model=self.error_model,
             verbose=self.verbose,
             timeout=self.timeout,

--- a/guppylang/src/guppylang/emulator/result.py
+++ b/guppylang/src/guppylang/emulator/result.py
@@ -185,9 +185,9 @@ class EmulatorResult(QsysResult):
         <https://docs.quantinuum.com/tket/api-docs/circuit.html>`_ representing
         the stream of gates output by the user program at emulation time.
 
-        Circuits are extracted from each shot's trace in the compiler's compiled
-        gateset, typically the primitive gateset of the hardware platform being
-        emulated.
+        Circuits are extracted from each shot's trace in the gateset produced by
+        compilation, typically the primitive gateset of the hardware platform
+        being emulated.
 
         Enable trace collection with :meth:`EmulatorInstance.with_trace` before
         running the emulator. ``pytket`` availability is checked before conversion.

--- a/guppylang/src/guppylang/emulator/result.py
+++ b/guppylang/src/guppylang/emulator/result.py
@@ -182,8 +182,12 @@ class EmulatorResult(QsysResult):
 
     def circuits(self) -> list[Circuit]:
         """Return `pytket Circuit objects
-        <https://docs.quantinuum.com/tket/api-docs/circuit.html>`_ for each
-        emulated shot.
+        <https://docs.quantinuum.com/tket/api-docs/circuit.html>`_ representing
+        the stream of gates output by the user program at emulation time.
+
+        Circuits are extracted from each shot's trace in the compiler's compiled
+        gateset, typically the primitive gateset of the hardware platform being
+        emulated.
 
         Enable trace collection with :meth:`EmulatorInstance.with_trace` before
         running the emulator. ``pytket`` availability is checked before conversion.

--- a/guppylang/src/guppylang/emulator/result.py
+++ b/guppylang/src/guppylang/emulator/result.py
@@ -173,12 +173,9 @@ class EmulatorResult(QsysResult):
                 "Trace collection was not enabled; call `with_trace()` before running "
                 "the emulator."
             )
-        # Selene starts collection before parsing a shot, so an interrupted shot may
-        # have analysis data without a corresponding entry in ``self.results``.
-        return [
-            shot.get_trace()
-            for shot in self._circuit_extractor.shots[: len(self.results)]
-        ]
+        # Retain every started shot. Selene currently leaves failed-shot analysis
+        # empty (an upstream bug), but future partial analysis must remain visible.
+        return [shot.get_trace() for shot in self._circuit_extractor.shots]
 
     def circuits(self) -> list[Circuit]:
         """Return `pytket Circuit objects
@@ -206,12 +203,9 @@ class EmulatorResult(QsysResult):
                     "`circuits()`."
                 ) from None
             raise
-        # Selene starts collection before parsing a shot, so an interrupted shot may
-        # have analysis data without a corresponding entry in ``self.results``.
-        return [
-            shot.get_user_circuit()
-            for shot in self._circuit_extractor.shots[: len(self.results)]
-        ]
+        # Retain every started shot. Selene currently leaves failed-shot analysis
+        # empty (an upstream bug), but future partial analysis must remain visible.
+        return [shot.get_user_circuit() for shot in self._circuit_extractor.shots]
 
     def metrics(self) -> list[ShotMetrics]:
         """Return collected metrics for each emulated shot.
@@ -227,6 +221,6 @@ class EmulatorResult(QsysResult):
                 "Metric collection was not enabled; call `with_metrics()` before "
                 "running the emulator."
             )
-        # Selene starts collection before parsing a shot, so an interrupted shot may
-        # have analysis data without a corresponding entry in ``self.results``.
-        return self._metric_store.shots[: len(self.results)]
+        # Retain every started shot. Selene currently leaves failed-shot analysis
+        # empty (an upstream bug), but future partial analysis must remain visible.
+        return self._metric_store.shots

--- a/guppylang/src/guppylang/emulator/result.py
+++ b/guppylang/src/guppylang/emulator/result.py
@@ -4,9 +4,11 @@ Emulation results and post-processing.
 
 from __future__ import annotations
 
+from importlib import import_module
 from typing import TYPE_CHECKING
 
 from hugr.qsystem.result import QsysResult, QsysShot, TaggedResult
+from selene_core.trace import Trace
 from selene_sim.backends.bundled_simulators import Quest
 
 from .state import PartialVector
@@ -16,14 +18,29 @@ if TYPE_CHECKING:
 
     from hugr.qsystem.result import DataValue
     from pytket.backends.backendresult import BackendResult
+    from pytket.circuit import Circuit
     from selene_quest_plugin.state import SeleneQuestState
+    from selene_sim.event_hooks.instruction_log import CircuitExtractor
+    from selene_sim.event_hooks.metrics import MetricStore
+
+
+#: A scalar metric value emitted by an emulator component.
+type MetricValue = float | int | bool | str
+#: Named scalar metrics emitted by one emulator component.
+type MetricGroup = dict[str, MetricValue]
+#: Component metrics collected for one emulated shot.
+type ShotMetrics = dict[str, MetricGroup]
 
 # Re-exports QsysResult, QsysShot, and TaggedResult - breaking changes to those upstream
 # classes should be treated as breaking changes to this module.
 __all__ = [
     "EmulatorResult",
+    "MetricGroup",
+    "MetricValue",
     "QsysShot",
+    "ShotMetrics",
     "TaggedResult",
+    "Trace",
 ]
 
 
@@ -58,13 +75,24 @@ class EmulatorResult(QsysResult):
 
     # cache for extracted partial states, since extraction cleans up the files
     _partial_states: list[list[tuple[str, PartialVector]]] | None = None
+    _circuit_extractor: CircuitExtractor | None
+    _metric_store: MetricStore | None
     #: List of QsysShot objects, each representing a single shot's results.
     results: list[QsysShot]
 
     # Re-define parent methods for documentation purposes
 
-    def __init__(self, results: list[QsysShot] | None = None):
+    def __init__(
+        self,
+        results: list[QsysShot] | None = None,
+        *,
+        _circuit_extractor: CircuitExtractor | None = None,
+        _metric_store: MetricStore | None = None,
+    ):
         super().__init__(results=results)
+        self._partial_states = None
+        self._circuit_extractor = _circuit_extractor
+        self._metric_store = _metric_store
 
     def register_counts(
         self, strict_names: bool = False, strict_lengths: bool = False
@@ -127,3 +155,74 @@ class EmulatorResult(QsysResult):
                 for shot in self.results
             ]
         return self._partial_states
+
+    def traces(self) -> list[Trace]:
+        """Return the per-shot record of instructions emitted during emulation.
+
+        Each :py:class:`Trace` is an ordered collection of events emitted by the
+        user program, runtime, error model, and simulator. Use its
+        ``get_user_program_trace()``, ``get_runtime_trace()``,
+        ``get_error_model_trace()``, and ``get_simulator_trace()`` methods to
+        inspect an individual execution stage.
+
+        Enable trace collection with :meth:`EmulatorInstance.with_trace` before
+        running the emulator.
+        """
+        if self._circuit_extractor is None:
+            raise RuntimeError(
+                "Trace collection was not enabled; call `with_trace()` before running "
+                "the emulator."
+            )
+        # Selene starts collection before parsing a shot, so an interrupted shot may
+        # have analysis data without a corresponding entry in ``self.results``.
+        return [
+            shot.get_trace()
+            for shot in self._circuit_extractor.shots[: len(self.results)]
+        ]
+
+    def circuits(self) -> list[Circuit]:
+        """Return `pytket Circuit objects
+        <https://docs.quantinuum.com/tket/api-docs/circuit.html>`_ for each
+        emulated shot.
+
+        Enable trace collection with :meth:`EmulatorInstance.with_trace` before
+        running the emulator. ``pytket`` availability is checked before conversion.
+        """
+        if self._circuit_extractor is None:
+            raise RuntimeError(
+                "Trace collection was not enabled; call `with_trace()` before running "
+                "the emulator."
+            )
+        try:
+            import_module("pytket")
+        except ModuleNotFoundError as e:
+            if e.name == "pytket":
+                raise ImportError(
+                    "Circuit extraction requires pytket. Install pytket to use "
+                    "`circuits()`."
+                ) from None
+            raise
+        # Selene starts collection before parsing a shot, so an interrupted shot may
+        # have analysis data without a corresponding entry in ``self.results``.
+        return [
+            shot.get_user_circuit()
+            for shot in self._circuit_extractor.shots[: len(self.results)]
+        ]
+
+    def metrics(self) -> list[ShotMetrics]:
+        """Return collected metrics for each emulated shot.
+
+        Metrics include gate-count and allocation statistics for the user program
+        and the operations emitted after runtime processing.
+
+        Enable metric collection with :meth:`EmulatorInstance.with_metrics` before
+        running the emulator.
+        """
+        if self._metric_store is None:
+            raise RuntimeError(
+                "Metric collection was not enabled; call `with_metrics()` before "
+                "running the emulator."
+            )
+        # Selene starts collection before parsing a shot, so an interrupted shot may
+        # have analysis data without a corresponding entry in ``self.results``.
+        return self._metric_store.shots[: len(self.results)]

--- a/tests/emulator/test_instance.py
+++ b/tests/emulator/test_instance.py
@@ -142,6 +142,24 @@ def test_emulator_instance_with_event_hook():
     assert new_instance._options._event_hook == event_hook
 
 
+def test_emulator_instance_with_analysis_configuration():
+    """Analysis configuration is immutable and independently toggleable."""
+    instance = EmulatorInstance(_instance=Mock(), _n_qubits=1)
+
+    assert instance.trace_enabled is False
+    assert instance.metrics_enabled is False
+
+    configured = instance.with_trace().with_metrics()
+    assert configured.trace_enabled is True
+    assert configured.metrics_enabled is True
+    assert instance.trace_enabled is False
+    assert instance.metrics_enabled is False
+
+    disabled = configured.with_trace(False).with_metrics(False)
+    assert disabled.trace_enabled is False
+    assert disabled.metrics_enabled is False
+
+
 def test_emulator_instance_with_verbose():
     """Test with_verbose method."""
     mock_selene_instance = Mock()

--- a/tests/emulator/test_result.py
+++ b/tests/emulator/test_result.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import Mock, patch
 
+import pytest
 from guppylang.emulator.result import EmulatorResult
+from hugr.qsystem.result import QsysShot
+
+if TYPE_CHECKING:
+    from guppylang.emulator import MetricGroup, MetricValue, ShotMetrics
 
 
 @patch("guppylang.emulator.result.Quest")
@@ -48,3 +54,41 @@ def test_emulator_result_methods_comprehensive(mock_quest):
         assert mock_quest.extract_states.call_count == 2
         # Verify PartialVector._from_inner called for each state
         assert mock_pv._from_inner.call_count == 3
+
+
+def test_emulator_result_analysis_requires_collection():
+    """Analysis accessors explain how to enable their collection."""
+    result = EmulatorResult()
+
+    with pytest.raises(RuntimeError, match=r"with_trace\(\)"):
+        result.traces()
+    with pytest.raises(RuntimeError, match=r"with_trace\(\)"):
+        result.circuits()
+    with pytest.raises(RuntimeError, match=r"with_metrics\(\)"):
+        result.metrics()
+
+
+def test_emulator_result_analysis_accessors():
+    """Analysis accessors return the data recorded by their collectors."""
+    trace, circuit = Mock(), Mock()
+    shot = Mock()
+    shot.get_trace.return_value = trace
+    shot.get_user_circuit.return_value = circuit
+    circuit_extractor = Mock(shots=[shot])
+    metric_store = Mock(shots=[{"user_program": {"measure_count": 1}}])
+    result = EmulatorResult(
+        [QsysShot()],
+        _circuit_extractor=circuit_extractor,
+        _metric_store=metric_store,
+    )
+
+    assert result.traces() == [trace]
+
+    with patch("guppylang.emulator.result.import_module"):
+        assert result.circuits() == [circuit]
+
+    assert result.metrics() == [{"user_program": {"measure_count": 1}}]
+    metric_value: MetricValue = 1
+    metric_group: MetricGroup = {"measure_count": metric_value}
+    shot_metrics: ShotMetrics = {"user_program": metric_group}
+    assert shot_metrics == {"user_program": {"measure_count": 1}}

--- a/tests/integration/snapshots/test_emulator_analysis_metrics.json
+++ b/tests/integration/snapshots/test_emulator_analysis_metrics.json
@@ -1,0 +1,82 @@
+[
+  {
+    "emulator": {
+      "shot_number": 0
+    },
+    "post_runtime": {
+      "custom_op_batch_count": 0,
+      "custom_op_individual_count": 0,
+      "measure_batch_count": 1,
+      "measure_individual_count": 1,
+      "measure_leaked_batch_count": 0,
+      "measure_leaked_individual_count": 0,
+      "reset_batch_count": 1,
+      "reset_individual_count": 1,
+      "rxy_batch_count": 1,
+      "rxy_individual_count": 1,
+      "rz_batch_count": 1,
+      "rz_individual_count": 1,
+      "rzz_batch_count": 0,
+      "rzz_individual_count": 0,
+      "total_duration_ns": 0
+    },
+    "simulator": {
+      "observed_bias": 0.0
+    },
+    "user_program": {
+      "currently_allocated": 0,
+      "global_barrier_count": 0,
+      "local_barrier_count": 0,
+      "max_allocated": 1,
+      "measure_leaked_request_count": 0,
+      "measure_read_count": 1,
+      "measure_request_count": 1,
+      "qalloc_count": 1,
+      "qfree_count": 1,
+      "reset_count": 1,
+      "rxy_count": 1,
+      "rz_count": 1,
+      "rzz_count": 0
+    }
+  },
+  {
+    "emulator": {
+      "shot_number": 1
+    },
+    "post_runtime": {
+      "custom_op_batch_count": 0,
+      "custom_op_individual_count": 0,
+      "measure_batch_count": 2,
+      "measure_individual_count": 2,
+      "measure_leaked_batch_count": 0,
+      "measure_leaked_individual_count": 0,
+      "reset_batch_count": 2,
+      "reset_individual_count": 2,
+      "rxy_batch_count": 1,
+      "rxy_individual_count": 1,
+      "rz_batch_count": 1,
+      "rz_individual_count": 1,
+      "rzz_batch_count": 0,
+      "rzz_individual_count": 0,
+      "total_duration_ns": 0
+    },
+    "simulator": {
+      "observed_bias": 1.0
+    },
+    "user_program": {
+      "currently_allocated": 0,
+      "global_barrier_count": 0,
+      "local_barrier_count": 0,
+      "max_allocated": 1,
+      "measure_leaked_request_count": 0,
+      "measure_read_count": 2,
+      "measure_request_count": 2,
+      "qalloc_count": 2,
+      "qfree_count": 2,
+      "reset_count": 2,
+      "rxy_count": 1,
+      "rz_count": 1,
+      "rzz_count": 0
+    }
+  }
+]

--- a/tests/integration/snapshots/test_emulator_analysis_traces.json
+++ b/tests/integration/snapshots/test_emulator_analysis_traces.json
@@ -1,0 +1,670 @@
+[
+  {
+    "events": [
+      {
+        "event": {
+          "gate_name": "QAlloc",
+          "kind": "Gate",
+          "params": [],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 0,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "index": 1,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "index": 0,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 0,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 2,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 1,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 1,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 3,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 2,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 2,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 4,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 3,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 3,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "QFree",
+          "kind": "Gate",
+          "params": [],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 5,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 6,
+          "kind": "UserProgram"
+        }
+      }
+    ]
+  },
+  {
+    "events": [
+      {
+        "event": {
+          "gate_name": "QAlloc",
+          "kind": "Gate",
+          "params": [],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 0,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "index": 1,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "index": 0,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 0,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 2,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 1,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rxy",
+          "kind": "Gate",
+          "params": [
+            1.5707963267948966,
+            -1.5707963267948966
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 1,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 3,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 2,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "Rz",
+          "kind": "Gate",
+          "params": [
+            3.141592653589793
+          ],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 2,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 4,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 3,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 3,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "QFree",
+          "kind": "Gate",
+          "params": [],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 5,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 6,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "QAlloc",
+          "kind": "Gate",
+          "params": [],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 7,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "index": 8,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "index": 4,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "kind": "Reset",
+          "qubit": 0
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 4,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 9,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "end_time": 0,
+          "kind": "Runtime",
+          "start_time": 0
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "index": 5,
+          "kind": "ErrorModel"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 0
+        },
+        "source": {
+          "duration_ns": 0,
+          "index": 5,
+          "kind": "Simulator"
+        }
+      },
+      {
+        "event": {
+          "gate_name": "QFree",
+          "kind": "Gate",
+          "params": [],
+          "predicates": [],
+          "qubits": [
+            0
+          ]
+        },
+        "source": {
+          "index": 10,
+          "kind": "UserProgram"
+        }
+      },
+      {
+        "event": {
+          "kind": "Measurement",
+          "qubit": 1
+        },
+        "source": {
+          "index": 11,
+          "kind": "UserProgram"
+        }
+      }
+    ]
+  }
+]

--- a/tests/integration/test_emulator.py
+++ b/tests/integration/test_emulator.py
@@ -62,6 +62,65 @@ def test_basic_emulation() -> None:
     assert res == expected
 
 
+def test_emulator_analysis() -> None:
+    """Analysis data is collected per shot without changing the run API."""
+
+    @guppy
+    def main() -> None:
+        q = qubit()
+        h(q)
+        outcome = measure(q).read()
+        output("outcome", outcome)
+        if outcome:
+            output("branch", measure(qubit()).read())
+
+    result = (
+        main.emulator(2)
+        .coinflip_sim()
+        .with_seed(42)
+        .with_shots(2)
+        .with_trace()
+        .with_metrics()
+        .run()
+    )
+
+    traces = result.traces()
+    metrics = result.metrics()
+
+    assert len(result.results) == 2
+    assert len(traces) == 2
+    assert len(result.circuits()) == 2
+    assert len(metrics) == 2
+    assert [shot["emulator"]["shot_number"] for shot in metrics] == [0, 1]
+    assert [shot["simulator"]["observed_bias"] for shot in metrics] == [0.0, 1.0]
+    assert [shot["user_program"]["qalloc_count"] for shot in metrics] == [1, 2]
+    assert [shot["user_program"]["measure_request_count"] for shot in metrics] == [1, 2]
+    assert [shot["post_runtime"]["measure_individual_count"] for shot in metrics] == [
+        1,
+        2,
+    ]
+
+    user_trace_events = [trace.get_user_program_trace().events for trace in traces]
+    assert [len(events) for events in user_trace_events] == [7, 12]
+    assert [[event.event.kind for event in events] for events in user_trace_events] == [
+        ["Gate", "Reset", "Gate", "Gate", "Measurement", "Gate", "Measurement"],
+        [
+            "Gate",
+            "Reset",
+            "Gate",
+            "Gate",
+            "Measurement",
+            "Gate",
+            "Measurement",
+            "Gate",
+            "Reset",
+            "Measurement",
+            "Gate",
+            "Measurement",
+        ],
+    ]
+
+
 def test_all_options() -> None:
     """Test that all configuration options are properly set and accessible."""
 

--- a/tests/integration/test_emulator.py
+++ b/tests/integration/test_emulator.py
@@ -1,3 +1,6 @@
+import json
+from pathlib import Path
+
 from guppylang.decorator import expected_qubits, guppy
 from guppylang.defs import GuppyFunctionDefinition
 from guppylang.emulator.exceptions import EmulatorBuildError
@@ -62,7 +65,7 @@ def test_basic_emulation() -> None:
     assert res == expected
 
 
-def test_emulator_analysis() -> None:
+def test_emulator_analysis(snapshot, request) -> None:
     """Analysis data is collected per shot without changing the run API."""
 
     @guppy
@@ -84,41 +87,24 @@ def test_emulator_analysis() -> None:
         .run()
     )
 
-    traces = result.traces()
-    metrics = result.metrics()
-
     assert len(result.results) == 2
-    assert len(traces) == 2
     assert len(result.circuits()) == 2
-    assert len(metrics) == 2
-    assert [shot["emulator"]["shot_number"] for shot in metrics] == [0, 1]
-    assert [shot["simulator"]["observed_bias"] for shot in metrics] == [0.0, 1.0]
-    assert [shot["user_program"]["qalloc_count"] for shot in metrics] == [1, 2]
-    assert [shot["user_program"]["measure_request_count"] for shot in metrics] == [1, 2]
-    assert [shot["post_runtime"]["measure_individual_count"] for shot in metrics] == [
-        1,
-        2,
-    ]
-
-    user_trace_events = [trace.get_user_program_trace().events for trace in traces]
-    assert [len(events) for events in user_trace_events] == [7, 12]
-    assert [[event.event.kind for event in events] for events in user_trace_events] == [
-        ["Gate", "Reset", "Gate", "Gate", "Measurement", "Gate", "Measurement"],
-        [
-            "Gate",
-            "Reset",
-            "Gate",
-            "Gate",
-            "Measurement",
-            "Gate",
-            "Measurement",
-            "Gate",
-            "Reset",
-            "Measurement",
-            "Gate",
-            "Measurement",
-        ],
-    ]
+    snapshot.snapshot_dir = str(Path(request.fspath).parent / "snapshots")
+    snapshot.assert_match(
+        json.dumps(result.metrics(), indent=2, sort_keys=True),
+        f"{request.node.name}_metrics.json",
+    )
+    snapshot.assert_match(
+        json.dumps(
+            [
+                trace.clear_simulator_perf_timing().model_dump()
+                for trace in result.traces()
+            ],
+            indent=2,
+            sort_keys=True,
+        ),
+        f"{request.node.name}_traces.json",
+    )
 
 
 def test_all_options() -> None:


### PR DESCRIPTION
Closes #2218 

Built with Codex iteration.

- Adds metric and trace enabling toggles to EmulatorInstance builder
- Creates invocation-local event hooks for selene
- Extracts traces and metrics and adds them to new fields in EmulatorResult
- New methods in EmulatorResult to extract Trace, pytket Circuit (from trace) and Metrics
- Example in emulator docs
