### PR TITLE
refactor: Extract stringifiers for internal definitions

### DIFF
--- a/guppylang-internals/src/guppylang_internals/definition/common.py
+++ b/guppylang-internals/src/guppylang_internals/definition/common.py
@@ -61,6 +61,13 @@ class Definition(ABC):
     name: str
     defined_at: ast.AST | None
 
+    def __str__(self) -> str:
+        return f"{self.description} {self.name}"
+
+    def caps_str(self) -> str:
+        """Returns a capitalized string representation of this definition."""
+        return f"{self.description.capitalize()} {self.name}"
+
     @property
     @abstractmethod
     def description(self) -> str:

--- a/guppylang-internals/src/guppylang_internals/definition/common.py
+++ b/guppylang-internals/src/guppylang_internals/definition/common.py
@@ -62,11 +62,11 @@ class Definition(ABC):
     defined_at: ast.AST | None
 
     def __str__(self) -> str:
-        return f"{self.description} {self.name}"
+        return f"{self.description} `{self.name}`"
 
     def caps_str(self) -> str:
         """Returns a capitalized string representation of this definition."""
-        return f"{self.description.capitalize()} {self.name}"
+        return f"{self.description.capitalize()} `{self.name}`"
 
     @property
     @abstractmethod

--- a/guppylang-internals/src/guppylang_internals/definition/common.py
+++ b/guppylang-internals/src/guppylang_internals/definition/common.py
@@ -62,10 +62,19 @@ class Definition(ABC):
     defined_at: ast.AST | None
 
     def __str__(self) -> str:
+        return self.to_str()
+
+    def to_str(self) -> str:
+        """Returns a string identifying this definition and its kind.
+        For example, "function `foo`" or "type `Bar`".
+        For a detailed representation, use `repr(defn)` instead.
+        """
         return f"{self.description} `{self.name}`"
 
-    def caps_str(self) -> str:
-        """Returns a capitalized string representation of this definition."""
+    def to_caps_str(self) -> str:
+        """Returns a capitalized string identifying this definition and its kind.
+        For example, "Function `foo`" or "Type `Bar`".
+        """
         return f"{self.description.capitalize()} `{self.name}`"
 
     @property

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -600,7 +600,7 @@ class EntryCheckMonomorphizeError(Error):
 
     @property
     def thing(self) -> str:
-        return self.defn.caps_str()
+        return self.defn.to_caps_str()
 
     @property
     def plural_s(self) -> str:
@@ -623,7 +623,7 @@ def check_entry_point_non_generic(defn: ParsedDef) -> None:
     if isinstance(defn, CheckableGenericDef) and defn.params:
         assert defn.defined_at is not None
         raise GuppyError(
-            EntryMonomorphizeError(defn.defined_at, defn.caps_str(), defn.params)
+            EntryMonomorphizeError(defn.defined_at, defn.to_caps_str(), defn.params)
         )
 
 

--- a/guppylang-internals/src/guppylang_internals/engine.py
+++ b/guppylang-internals/src/guppylang_internals/engine.py
@@ -600,7 +600,7 @@ class EntryCheckMonomorphizeError(Error):
 
     @property
     def thing(self) -> str:
-        return f"{self.defn.description.capitalize()} `{self.defn.name}`"
+        return self.defn.caps_str()
 
     @property
     def plural_s(self) -> str:
@@ -622,9 +622,8 @@ def check_entry_point_non_generic(defn: ParsedDef) -> None:
     """
     if isinstance(defn, CheckableGenericDef) and defn.params:
         assert defn.defined_at is not None
-        description = f"{defn.description.capitalize()} `{defn.name}`"
         raise GuppyError(
-            EntryMonomorphizeError(defn.defined_at, description, defn.params)
+            EntryMonomorphizeError(defn.defined_at, defn.caps_str(), defn.params)
         )
 
 

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -563,7 +563,7 @@ class TracingDefMixin(DunderMixin):
 
         if not tracing_active():
             raise GuppyComptimeError(
-                f"{self.wrapped.caps_str()} may only be called in a Guppy context"
+                f"{self.wrapped.to_caps_str()} may only be called in a Guppy context"
             )
 
         defn = ENGINE.get_parsed(self.wrapped.id)
@@ -576,7 +576,7 @@ class TracingDefMixin(DunderMixin):
                 constructor_id := DEF_STORE.type_members[defn.id].get("__new__")
             ):
                 return TracingDefMixin(DEF_STORE.raw_defs[constructor_id])(*args)
-        raise GuppyComptimeError(f"{defn.caps_str()} is not callable")
+        raise GuppyComptimeError(f"{defn.to_caps_str()} is not callable")
 
     def __getitem__(self, item: Any) -> Any:
         # If this is a type definition, then `__getitem__` might be called when
@@ -601,7 +601,7 @@ class TracingDefMixin(DunderMixin):
                     "Explicitly specifying type arguments of generic functions in a "
                     "comptime context is not supported yet"
                 )
-        raise GuppyComptimeError(f"{self.wrapped.caps_str()} is not subscriptable")
+        raise GuppyComptimeError(f"{self.wrapped.to_caps_str()} is not subscriptable")
 
     def to_guppy_object(self) -> GuppyObject:
         state = get_tracing_state()

--- a/guppylang-internals/src/guppylang_internals/tracing/object.py
+++ b/guppylang-internals/src/guppylang_internals/tracing/object.py
@@ -563,8 +563,7 @@ class TracingDefMixin(DunderMixin):
 
         if not tracing_active():
             raise GuppyComptimeError(
-                f"{self.wrapped.description.capitalize()} `{self.wrapped.name}` may "
-                "only be called in a Guppy context"
+                f"{self.wrapped.caps_str()} may only be called in a Guppy context"
             )
 
         defn = ENGINE.get_parsed(self.wrapped.id)
@@ -577,8 +576,7 @@ class TracingDefMixin(DunderMixin):
                 constructor_id := DEF_STORE.type_members[defn.id].get("__new__")
             ):
                 return TracingDefMixin(DEF_STORE.raw_defs[constructor_id])(*args)
-        err = f"{defn.description.capitalize()} `{defn.name}` is not callable"
-        raise GuppyComptimeError(err)
+        raise GuppyComptimeError(f"{defn.caps_str()} is not callable")
 
     def __getitem__(self, item: Any) -> Any:
         # If this is a type definition, then `__getitem__` might be called when
@@ -603,10 +601,7 @@ class TracingDefMixin(DunderMixin):
                     "Explicitly specifying type arguments of generic functions in a "
                     "comptime context is not supported yet"
                 )
-        raise GuppyComptimeError(
-            f"{self.wrapped.description.capitalize()} `{self.wrapped.name}` is not "
-            "subscriptable"
-        )
+        raise GuppyComptimeError(f"{self.wrapped.caps_str()} is not subscriptable")
 
     def to_guppy_object(self) -> GuppyObject:
         state = get_tracing_state()
@@ -635,6 +630,4 @@ class TracingDefMixin(DunderMixin):
             return GuppyObject(defn.ty, wire, None)
         if isinstance(defn, ValueDef):
             return GuppyObject(defn.ty, state.recorder.record_load(defn))
-        raise GuppyComptimeError(
-            f"Cannot convert {defn.description} `{defn.name}` to a Guppy object"
-        )
+        raise GuppyComptimeError(f"Cannot convert {defn} to a Guppy object")

--- a/guppylang-internals/src/guppylang_internals/tys/parsing.py
+++ b/guppylang-internals/src/guppylang_internals/tys/parsing.py
@@ -298,8 +298,7 @@ def _arg_from_instantiated_defn(
         case ParsedProtocolDef() as defn:
             return _arg_from_proto(defn, arg_nodes, node, ctx)
         case defn:
-            err = ExpectedError(node, "a type", got=f"{defn.description} `{defn.name}`")
-            raise GuppyError(err)
+            raise GuppyError(ExpectedError(node, "a type", got=str(defn)))
 
 
 def _arg_from_proto(

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -523,10 +523,7 @@ class _Guppy:
             if not isinstance(func, GuppyDefinition):
                 raise TypeError(f"Not a Guppy definition: {func}")
             if not isinstance(func.wrapped, AnyRawFunctionDef):
-                raise TypeError(
-                    f"Not a Guppy function definition: {func.wrapped.description} "
-                    f"`{func.wrapped.name}`"
-                )
+                raise TypeError(f"Not a Guppy function definition: {func.wrapped}")
             func_ids.append(func.id)
 
         def decorator(f: Callable[P, T]) -> GuppyFunctionDefinition[P, T]:

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -155,7 +155,7 @@ class GuppyEnumDefinition(GuppyDefinition):
         ):
             member_def = DEF_STORE.raw_defs[DEF_STORE.type_members[defn.id][name]]
             return TracingDefMixin(member_def)
-        raise AttributeError(f"{defn.caps_str()} has no attribute `{name}`")
+        raise AttributeError(f"{defn.to_caps_str()} has no attribute `{name}`")
 
 
 @runtime_checkable

--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -155,9 +155,7 @@ class GuppyEnumDefinition(GuppyDefinition):
         ):
             member_def = DEF_STORE.raw_defs[DEF_STORE.type_members[defn.id][name]]
             return TracingDefMixin(member_def)
-        raise AttributeError(
-            f"{defn.description.capitalize()} `{defn.name}` has no attribute `{name}`"
-        )
+        raise AttributeError(f"{defn.caps_str()} has no attribute `{name}`")
 
 
 @runtime_checkable


### PR DESCRIPTION
Many places do `f"{somedefn.description} {somedefn.name}"` on a Definition, which is quite verbose. Meanwhile the `__str__` method of Definition is not used (changing it to throw an AssertionError does not fail any tests)...hence, define the latter to the former. Since there are also cases which explicitly capitalize the description, add `.caps_str()` for that (better names welcomed?).

The main impact is if you are debugging and printing out Definitions as part of that, but you can still get the same string as before back just via `repr(d)`, so the impact is quite small.