### PR TITLE
chore: Update deprecated uv prerelease mode

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ test = [
 ]
 
 [tool.uv]
-prerelease = "if-necessary-or-explicit"
+prerelease = "if-necessary"
 
 [tool.uv.workspace]
 members = ["guppylang", "guppylang-internals", "miette-py"]

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,9 @@ resolution-markers = [
     "(python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version < '3.14' and sys_platform != 'darwin')",
 ]
 
+[options]
+prerelease-mode = "if-necessary"
+
 [manifest]
 members = [
     "guppylang",


### PR DESCRIPTION
I was tired of getting this warning:

```
warning: The `if-necessary-or-explicit` pre-release mode is deprecated and will be removed in a future release. Use `if-necessary` instead.
```
