### PR TITLE
feat: Allow default running optimization level without pytket

### DIFF
--- a/guppylang/src/guppylang/optimizer.py
+++ b/guppylang/src/guppylang/optimizer.py
@@ -185,13 +185,12 @@ class OptimizationLevel(Enum):
         """Return the list of HUGR passes ran by this optimization level."""
         match self:
             case OptimizationLevel.Default:
-                # The pytket dependency could be bypassed by using the json
-                # encoding of the passes rather than the pytket objects
-                # themselves.
-                from pytket.passes import RemoveRedundancies
                 from tket import passes
 
-                return [passes.Normalize(), passes.PytketHugrPass(RemoveRedundancies())]
+                return [
+                    passes.Normalize(),
+                    passes.PytketHugrPass(_RemoveRedundanciesPass()),
+                ]
             case OptimizationLevel.Classical:
                 from tket import passes
 
@@ -287,3 +286,15 @@ class OptimizerInstance[**P, Out]:
     def compile_function(self, debug_mode: bool = False) -> Package:
         """Compile a function with the configured optimizations."""
         return _apply_passes(self.definition._compile_function(debug_mode), self.passes)
+
+
+@dataclass(frozen=True, slots=True)
+class _RemoveRedundanciesPass:
+    """Clone of pytket's RemoveRedundancies pass definition that does not
+    require pytket to be available."""
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "StandardPass": {"name": "RemoveRedundancies"},
+            "pass_class": "StandardPass",
+        }

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+import pytest
 from guppylang import (
     GuppyCompilableProgram,
     OptimizationLevel,
     OptimizerInstance,
     guppy,
 )
+from guppylang.optimizer import _RemoveRedundanciesPass
 from hugr.passes.composable import ComposablePass, PassResult
 
 if TYPE_CHECKING:
@@ -32,6 +34,16 @@ class CountingPass(ComposablePass):
 
     def with_scope(self, scope: PassScope) -> ComposablePass:
         return self
+
+
+def test_remove_redundancies_pass_definition() -> None:
+    """Keep the pytket-free pass definition in sync with pytket's serialization."""
+    pytket_passes = pytest.importorskip("pytket.passes")
+
+    assert (
+        _RemoveRedundanciesPass().to_dict()
+        == pytket_passes.RemoveRedundancies().to_dict()
+    )
 
 
 def test_opt_levels() -> None:


### PR DESCRIPTION
tket now builds WASM/emscripten wheels, so we should be able to run the default optimization passes on playpond.

Pytket does not have such wheels though, so this PR replaces the pytket import with a local pass definition instead.