### PR TITLE
docs: Rollup of 3 docs backports

### DIFF
--- a/guppylang/src/guppylang/defs.py
+++ b/guppylang/src/guppylang/defs.py
@@ -165,16 +165,16 @@ class GuppyCompilableProgram(Protocol):
 
         Args:
             n_qubits: The number of qubits to allocate for the function. If it is not
-            provided, the function has to declare the expected number of qubits it needs
-            with the decorator `@expected_qubits`.
+                provided, the function has to declare the expected number of qubits it
+                needs with the decorator `@expected_qubits`.
             builder: An optional `EmulatorBuilder` to use for building the emulator
-            instance. If not provided, the default `EmulatorBuilder` will be used.
+                instance. If not provided, the default `EmulatorBuilder` will be used.
             libs: An optional list of additional HUGR packages to link with the compiled
-            function. This can be used to provide additional library functions that the
-            function being compiled depends on.
+                function. This can be used to provide additional library functions that
+                the function being compiled depends on.
             platform: The quantum platform to target. Defaults to ``"helios"``. Set to
-            ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
-            provided (use ``builder.with_platform()`` in that case).
+                ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
+                provided (use ``builder.with_platform()`` in that case).
 
         Returns:
             An `EmulatorInstance` that can be used to run the function in an emulator.
@@ -239,16 +239,16 @@ class GuppyFunctionDefinition(GuppyDefinition, GuppyCompilableProgram, Generic[P
 
         Args:
             n_qubits: The number of qubits to allocate for the function. If it is not
-            provided, the function has to declare the expected number of qubits it needs
-            with the decorator `@expected_qubits`.
+                provided, the function has to declare the expected number of qubits it
+                needs with the decorator `@expected_qubits`.
             builder: An optional `EmulatorBuilder` to use for building the emulator
-            instance. If not provided, the default `EmulatorBuilder` will be used.
+                instance. If not provided, the default `EmulatorBuilder` will be used.
             libs: An optional list of additional HUGR packages to link with the compiled
-            function. This can be used to provide additional library functions that the
-            function being compiled depends on.
+                function. This can be used to provide additional library functions that
+                the function being compiled depends on.
             platform: The quantum platform to target. Defaults to ``"helios"``. Set to
-            ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
-            provided (use ``builder.with_platform()`` in that case).
+                ``"sol"`` to target the Sol QIS. Ignored if an explicit ``builder`` is
+                provided (use ``builder.with_platform()`` in that case).
 
         Returns:
             An `EmulatorInstance` that can be used to run the function in an emulator.

--- a/guppylang/src/guppylang/emulator/__init__.py
+++ b/guppylang/src/guppylang/emulator/__init__.py
@@ -109,7 +109,7 @@ which is just a numpy array of complex amplitudes.
 
 In general the qubits you request state for may not be all the qubits in the fully
 entangled state, in which case the remaining qubits are traced over and a
-probabilistic distribution over statws is returned.
+probabilistic distribution over states is returned.
 
 The two methods :py:meth:`EmulatorResult.partial_states` and
 :meth:`EmulatorResult.partial_state_dicts` extract state results
@@ -119,6 +119,7 @@ from the emulator output as :py:class:`PartialVector` objects.
 
     from guppylang import guppy
     from guppylang.std.debug import state_output
+    from guppylang.std.platform import barrier
     from guppylang.std.quantum import qubit, measure, cx, h
 
     @guppy
@@ -128,6 +129,7 @@ from the emulator output as :py:class:`PartialVector` objects.
         h(q0)
         q1 = qubit()
         cx(q0, q1)
+        barrier(q0, q1)
         state_output("q0", q0)
         measure(q0)
         measure(q1)
@@ -142,6 +144,17 @@ Output is a uniform distribution over the two basis states of the qubit:
 
     [TracedState(probability=0.5, state=array([1.+0.j, 0.+0.j])),
     TracedState(probability=0.5, state=array([0.+0.j, 1.+0.j]))]
+
+.. warning::
+
+    Guppy does not in general respect the order of function calls in the source code, it
+    is constrained by the dataflow of the program. If two function calls act on
+    disjoint qubits they can slide past each other. This can interact badly with
+    entanglement since the guppy compiler does not know which qubits are entangled
+    together. In practice a gate on a qubit may be executed before a state_output on
+    another (potentially entangled) qubit, which can lead to unexpected results. To
+    avoid this, use the :py:func:`barrier` command to ensure that all operations on a
+    set of qubits are completed before the state is output.
 
 
 

--- a/guppylang/src/guppylang/emulator/state.py
+++ b/guppylang/src/guppylang/emulator/state.py
@@ -107,7 +107,7 @@ class PartialVector(PartialState[StateVector]):
             base_state: The state vector over all qubits in the system.
             total_qubits: Total number of qubits in the system
             specified_qubits: List of specified qubits in the state. Those not in this
-            list are considered traced out.
+                list are considered traced out.
         """
         if len(base_state) != (1 << total_qubits):
             raise ValueError(

--- a/guppylang/src/guppylang/std/debug.py
+++ b/guppylang/src/guppylang/std/debug.py
@@ -17,6 +17,15 @@ def state_output(tag, *args) -> None:
     This is a debugging function that works only when the program is executed
     on a supported simulator.
 
+    Guppy does not in general respect the order of function calls in the source code, it
+    is constrained by the dataflow of the program. If two function calls act on
+    disjoint qubits they can slide past each other. This can interact badly with
+    entanglement since the guppy compiler does not know which qubits are entangled
+    together. In practice a gate on a qubit may be executed before a state_output on
+    another (potentially entangled) qubit, which can lead to unexpected results. To
+    avoid this, use the :py:func:`barrier` command to ensure that all operations on a
+    set of qubits are completed before the state is output.
+
     Args:
         tag: A string literal representing the tag of the state output.
         args: The qubits whose quantum state is to be reported. The order they are given

--- a/guppylang/src/guppylang/std/debug.py
+++ b/guppylang/src/guppylang/std/debug.py
@@ -29,7 +29,7 @@ def state_output(tag, *args) -> None:
     Args:
         tag: A string literal representing the tag of the state output.
         args: The qubits whose quantum state is to be reported. The order they are given
-        in corresponds to the order in which the state will be reported.
+            in corresponds to the order in which the state will be reported.
     """
 
 

--- a/guppylang/src/guppylang/std/platform.py
+++ b/guppylang/src/guppylang/std/platform.py
@@ -153,7 +153,7 @@ def panic(msg: str, signal: int = 1, *args):
         message: The message to display. Must be a string literal.
         signal: An optional integer for distinguishing different failure modes.
         args: Arbitrary extra inputs, will not affect the message. Only useful for
-        consuming linear values.
+            consuming linear values.
     """
 
 
@@ -207,7 +207,7 @@ def exit(msg: str, signal: int = 1, *args):
         message: The message to display. Must be a string literal.
         signal: An optional integer for distinguishing different failure modes.
         args: Arbitrary extra inputs, will not affect the message. Only useful for
-        consuming linear values.
+            consuming linear values.
     """
 
 

--- a/guppylang/src/guppylang/std/qsystem/random.py
+++ b/guppylang/src/guppylang/std/qsystem/random.py
@@ -84,7 +84,7 @@ class RNG:
 
         Args:
             delta: Number of steps to move the RNG state forward (if positive)
-            or backward (if negative).
+                or backward (if negative).
         """
 
     @guppy


### PR DESCRIPTION
A rollup PR combining the backports of #2124, #2165 and #2171, to avoid CI strain.

Some minor conflicts when applying #2165 since debug args were not a thing yet.