### PR TITLE
fix: invalid URLs in `CHANGELOG` and `qaoa_maxcut_example` notebook

### DIFF
--- a/examples/qaoa_maxcut_example.ipynb
+++ b/examples/qaoa_maxcut_example.ipynb
@@ -266,7 +266,7 @@
    "source": [
     "We will define a Python function which will construct a Guppy program implementing QAOA for an $n$ node graph. First we create the uniform superposition state $|+\\rangle^{\\otimes n}$ and then alternate cost and mixer layers as described above.\n",
     "\n",
-    "The graph topology and the number of layers $p$ are fixed at compile time (loaded with [comptime](https://docs.quantinuum.com/guppy/language_guide/comptime.html) expressions), but the cost and mixer angles are passed as **runtime arguments**: `qaoa_instance` takes two [array](https://docs.quantinuum.com/guppy/api/generated/guppylang.std.builtins.array.html)`[float, p]` arguments. Because the angles are runtime arguments, the program can be compiled once and then re-run with different angle values — exactly what the variational optimization loop below needs."
+    "The graph topology and the number of layers $p$ are fixed at compile time (loaded with [comptime](https://docs.quantinuum.com/guppy/language_guide/comptime.html) expressions), but the cost and mixer angles are passed as **runtime arguments**: `qaoa_instance` takes two [array](https://docs.quantinuum.com/guppy/api/generated/guppylang.std.array.array.html)`[float, p]` arguments. Because the angles are runtime arguments, the program can be compiled once and then re-run with different angle values — exactly what the variational optimization loop below needs."
    ]
   },
   {

--- a/guppylang/CHANGELOG.md
+++ b/guppylang/CHANGELOG.md
@@ -1356,7 +1356,7 @@ main.compile()
 
 * Use `release-please bootstrap`'s default config ([#187](https://github.com/quantinuum/guppylang/issues/187)) ([72e666a](https://github.com/quantinuum/guppylang/commit/72e666af5a52c44a4094080a665342422a242d2b))
 
-## [0.1.0](https://github.com/quantinuum/guppy/releases/tag/v0.1.0)
+## [0.1.0](https://github.com/quantinuum/guppylang/releases/tag/v0.1.0)
 
 First release of Guppy! 🐟
 


### PR DESCRIPTION
(cherry picked from commit e90c81528aeb2b6bfbb7d19c925af02c12a16f2e)

Backport of #2265 