### PR TITLE
fix: Resolve calls to nested functions iff capturing closures are disabled

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1421,8 +1421,16 @@ def function_def_value_to_function_value(
     their expression must be preserved to retain a possible closure.
     """
     if isinstance(ty, NestedFunctionDefType):
-        return with_type(ty.sig, expr)
-    name = DEF_STORE.raw_defs[ty.def_id].name
+        from guppylang_internals.experimental import check_capturing_closures_enabled
+
+        try:
+            check_capturing_closures_enabled(expr)
+            # Expression must be preserved to retain a possible closure.
+            return with_type(ty.sig, expr)
+        except GuppyError:
+            name = ENGINE.get_parsed(ty.def_id).name
+    else:
+        name = DEF_STORE.raw_defs[ty.def_id].name
     return with_type(ty.sig, with_loc(expr, make_global_name(name, ty.def_id)))
 
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1430,9 +1430,8 @@ def function_def_value_to_function_value(
             return with_type(ty.sig, expr)
         except GuppyError:
             # Capturing closures disabled
-            name = ENGINE.get_parsed(ty.def_id).name
-    else:
-        name = DEF_STORE.raw_defs[ty.def_id].name
+            pass
+    name = ENGINE.get_parsed(ty.def_id).name
     return with_type(ty.sig, with_loc(expr, make_global_name(name, ty.def_id)))
 
 

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -1425,9 +1425,11 @@ def function_def_value_to_function_value(
 
         try:
             check_capturing_closures_enabled(expr)
-            # Expression must be preserved to retain a possible closure.
+            # We don't record whether individual nested functions capture anything,
+            # so conservatively assume it might.
             return with_type(ty.sig, expr)
         except GuppyError:
+            # Capturing closures disabled
             name = ENGINE.get_parsed(ty.def_id).name
     else:
         name = DEF_STORE.raw_defs[ty.def_id].name

--- a/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/expr_checker.py
@@ -107,6 +107,7 @@ from guppylang_internals.error import (
     saved_exception_hook,
 )
 from guppylang_internals.experimental import (
+    are_capturing_closures_enabled,
     check_function_tensors_enabled,
     check_lists_enabled,
 )
@@ -1420,17 +1421,10 @@ def function_def_value_to_function_value(
     uniquely identifies them. Nested functions are materialised as local values, so
     their expression must be preserved to retain a possible closure.
     """
-    if isinstance(ty, NestedFunctionDefType):
-        from guppylang_internals.experimental import check_capturing_closures_enabled
-
-        try:
-            check_capturing_closures_enabled(expr)
-            # We don't record whether individual nested functions capture anything,
-            # so conservatively assume it might.
-            return with_type(ty.sig, expr)
-        except GuppyError:
-            # Capturing closures disabled
-            pass
+    if isinstance(ty, NestedFunctionDefType) and are_capturing_closures_enabled():
+        # We don't record whether individual nested functions capture anything,
+        # so conservatively assume it might.
+        return with_type(ty.sig, expr)
     name = ENGINE.get_parsed(ty.def_id).name
     return with_type(ty.sig, with_loc(expr, make_global_name(name, ty.def_id)))
 

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -238,8 +238,6 @@ def check_nested_func_def(
     mono_args: Inst = ()
 
     # Store nested functions in the call graph under their own DefIDs,
-    # although calls to them are not resolved yet
-    # (https://github.com/Quantinuum/guppylang/issues/2272)
     ENGINE.register_call_graph_node((def_id, mono_args))
     globals = ctx.globals
 

--- a/guppylang-internals/src/guppylang_internals/checker/func_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/func_checker.py
@@ -237,7 +237,7 @@ def check_nested_func_def(
     def_id = DefId.fresh()
     mono_args: Inst = ()
 
-    # Store nested functions in the call graph under their own DefIDs,
+    # Store nested functions in the call graph under their own DefIDs.
     ENGINE.register_call_graph_node((def_id, mono_args))
     globals = ctx.globals
 

--- a/guppylang-internals/src/guppylang_internals/experimental.py
+++ b/guppylang-internals/src/guppylang_internals/experimental.py
@@ -81,8 +81,12 @@ def check_lists_enabled(loc: AstNode | None = None) -> None:
         raise GuppyError(err)
 
 
+def are_capturing_closures_enabled() -> bool:
+    return EXPERIMENTAL_FEATURES_ENABLED
+
+
 def check_capturing_closures_enabled(loc: AstNode | None = None) -> None:
-    if not EXPERIMENTAL_FEATURES_ENABLED:
+    if not are_capturing_closures_enabled():
         raise GuppyError(UnsupportedError(loc, "Capturing closures"))
 
 

--- a/tests/integration/test_nested.py
+++ b/tests/integration/test_nested.py
@@ -2,19 +2,19 @@ from guppylang import guppy
 from tests.util import compile_guppy
 
 
-def test_basic(validate):
-    @compile_guppy
+def test_basic(run_int_fn):
+    @guppy
     def foo(x: int) -> int:
         def bar(y: int) -> int:
-            return y
+            return y * 2
 
         return bar(x + 1)
 
-    validate(foo)
+    run_int_fn(foo, expected=12, args=[5])
 
 
-def test_call_twice(validate):
-    @compile_guppy
+def test_call_twice(run_int_fn):
+    @guppy
     def foo(x: int) -> int:
         def bar(y: int) -> int:
             return y + 3
@@ -24,11 +24,12 @@ def test_call_twice(validate):
         else:
             return bar(2 * x)
 
-    validate(foo)
+    run_int_fn(foo, expected=13, args=[5])
+    run_int_fn(foo, expected=9, args=[6])
 
 
-def test_redefine(validate):
-    @compile_guppy
+def test_redefine(run_int_fn):
+    @guppy
     def foo(x: int) -> int:
         def bar(y: int) -> int:
             return y + 3
@@ -41,13 +42,13 @@ def test_redefine(validate):
         b = bar(0)
         return a + b
 
-    validate(foo)
+    run_int_fn(foo, expected=5, args=[2])
 
 
-def test_define_twice(validate):
+def test_define_twice(run_int_fn):
     from guppylang.std.builtins import Function  # noqa: TC002
 
-    @compile_guppy
+    @guppy
     def foo(x: int) -> int:
         if x == 0:
 
@@ -64,11 +65,12 @@ def test_define_twice(validate):
 
         return bar(x)
 
-    validate(foo)
+    run_int_fn(foo, expected=3, args=[0])
+    run_int_fn(foo, expected=1, args=[43])
 
 
-def test_nested_deep(validate):
-    @compile_guppy
+def test_nested_deep(run_int_fn):
+    @guppy
     def foo(x: int) -> int:
         def bar(y: int) -> int:
             def baz(z: int) -> int:
@@ -78,20 +80,20 @@ def test_nested_deep(validate):
 
         return bar(x + 1)
 
-    validate(foo)
+    run_int_fn(foo, expected=29, args=[5])
 
 
-def test_recurse(validate):
-    @compile_guppy
+def test_recurse(run_int_fn):
+    @guppy
     def foo(x: int) -> int:
         def bar(y: int) -> int:
             if y == 0:
-                return 0
+                return 1
             return 2 * bar(y - 1)
 
         return bar(x)
 
-    validate(foo)
+    run_int_fn(foo, expected=32, args=[5])
 
 
 def test_capture_arg(validate, use_experimental_features):

--- a/tests/integration/test_side_effect_ordering.py
+++ b/tests/integration/test_side_effect_ordering.py
@@ -2,11 +2,9 @@
 side-effects.
 """
 
-import pytest
 from hugr import ops, Hugr, Node
 from hugr.std import PRELUDE
 from hugr import ops as hops
-from hugr import InPort
 
 from guppylang import guppy
 from guppylang.std.builtins import owned, panic
@@ -412,20 +410,15 @@ def test_nested_panicking_calls(validate):
     main_calls = [
         node
         for node, data in hugr.nodes()
-        if isinstance(data.op, hops.CallIndirect) and main_node in ancestors(hugr, node)
+        if isinstance(data.op, hops.Call) and main_node in ancestors(hugr, node)
     ]
 
-    def get_called_func_name(call_indirect):
-        [loadfunc] = hugr.linked_ports(InPort(call_indirect, 0))
-        assert isinstance(hugr[loadfunc.node].op, hops.LoadFunc)
-        [func] = hugr.linked_ports(InPort(loadfunc.node, 0))
-        assert isinstance(hugr[func.node].op, hops.FuncDefn)
-        return hugr[func.node].op.f_name
-
     assert [
-        "panicking_function" in get_called_func_name(node) for node in main_calls
+        "panicking_function" in get_called_func_name(hugr, node) for node in main_calls
     ] == [True, False, False, True]
-    assert ["pure_function" in get_called_func_name(node) for node in main_calls] == [
+    assert [
+        "pure_function" in get_called_func_name(hugr, node) for node in main_calls
+    ] == [
         False,
         True,
         True,
@@ -451,14 +444,6 @@ def test_nested_panicking_calls(validate):
     assert not has_order_path(hugr, panic_call2, pure_call2)
     for op in [panic_call1, pure_call1, panic_op]:
         assert not has_order_path(hugr, pure_call2, op)
-
-    # For the time being:
-    check_order(hugr, [panic_call1, pure_call1, panic_op, pure_call2, panic_call2])
-    pytest.xfail(
-        "Calls to nested functions are not resolved in checking,"
-        " leading to spurious order edges - see"
-        " https://github.com/Quantinuum/guppylang/issues/2272"
-    )
 
     # Otherwise - the desired outcome when previous is fixed:
     for pure_call in [pure_call1, pure_call2]:

--- a/tests/test_callgraph.py
+++ b/tests/test_callgraph.py
@@ -1,4 +1,3 @@
-import pytest
 from guppylang import guppy
 from guppylang_internals.engine import ENGINE
 
@@ -64,11 +63,6 @@ def test_recursive():
     assert mono_id in ENGINE.call_graph[mono_id]  # factorial calls itself
 
 
-@pytest.mark.xfail(
-    match="0 == 1",
-    reason="Nested functions are resolved as indirect calls to unknown target"
-    " (see https://github.com/Quantinuum/guppylang/issues/2272)",
-)
 def test_nested_function():
     """Test that nested function calls are recorded in the call graph."""
 


### PR DESCRIPTION
fixes #2272

Existing `function_def_value_to_function_value` bailed out for nested functions in case they were not global names but closures. However this can only be the case if experimental features (specifically, capturing closures) are enabled: https://github.com/Quantinuum/guppylang/blob/702bcb09d2aae7c918c0311c6ff4bc5ed6abdb45/guppylang-internals/src/guppylang_internals/checker/func_checker.py#L215-L219

So for the meantime an easy fix is to allow resolving to a GlobalCall if-and-only-if experimental features are off. (When we enable captures, we may want to enable a better fix, for example, recording in the `CheckedNestedFunctionDef` whether that particular function had captures or not.)