### PR TITLE
chore: Support decorator factories with `_dummy_custom_decorator`

### DIFF
--- a/guppylang-internals/src/guppylang_internals/decorator/gpu.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/gpu.py
@@ -93,8 +93,4 @@ def _gpu_helper[**P, T](
 if not TYPE_CHECKING and sphinx_running():
     gpu_module = _dummy_custom_decorator
 
-    # Support both forms of the decorator
-    def gpu(*args: object, **kwargs: object):  # type: ignore[no-redef]
-        if len(args) == 1 and callable(args[0]) and not kwargs:
-            return args[0]
-        return _dummy_custom_decorator(*args, **kwargs)
+    gpu = _dummy_custom_decorator()

--- a/guppylang-internals/src/guppylang_internals/decorator/gpu.py
+++ b/guppylang-internals/src/guppylang_internals/decorator/gpu.py
@@ -92,5 +92,4 @@ def _gpu_helper[**P, T](
 # Override decorators with dummy versions if we're running a sphinx build
 if not TYPE_CHECKING and sphinx_running():
     gpu_module = _dummy_custom_decorator
-
     gpu = _dummy_custom_decorator()

--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -66,7 +66,17 @@ class _DummyGuppy:
 
 def _dummy_custom_decorator(*args: Any, **kwargs: Any) -> Any:
     """Dummy version of custom decorators that are used during Sphinx builds."""
-    return lambda f: f
+    def decorator(*decorator_args: Any, **decorator_kwargs: Any) -> Any:
+        if (
+            len(decorator_args) == 1
+            and callable(decorator_args[0])
+            and not decorator_kwargs
+        ):
+            return decorator_args[0]
+
+        return lambda f: f
+
+    return decorator
 
 
 def sphinx_running() -> bool:

--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -66,6 +66,7 @@ class _DummyGuppy:
 
 def _dummy_custom_decorator(*args: Any, **kwargs: Any) -> Any:
     """Dummy version of custom decorators that are used during Sphinx builds."""
+
     def decorator(*decorator_args: Any, **decorator_kwargs: Any) -> Any:
         if (
             len(decorator_args) == 1

--- a/tests/test_dummy_decorator.py
+++ b/tests/test_dummy_decorator.py
@@ -1,0 +1,9 @@
+from guppylang_internals.dummy_decorator import _dummy_custom_decorator
+
+
+def test_dummy_custom_decorator_supports_factories():
+    @_dummy_custom_decorator("example.name")
+    def example() -> None:
+        pass
+
+    assert example.__name__ == "example"


### PR DESCRIPTION
When building sphinx docs for external modules that use `@link_name` I get an error:

```
@link_name("my_func")
TypeError: _dummy_custom_decorator.<locals>.<lambda>() takes 1 positional argument but 2 were given
```

This PR adds support for the decorator factories that return a callable decorator.