### PR TITLE
chore: Support decorator factories with `_dummy_custom_decorator`

### DIFF
--- a/guppylang-internals/src/guppylang_internals/dummy_decorator.py
+++ b/guppylang-internals/src/guppylang_internals/dummy_decorator.py
@@ -63,7 +63,18 @@ class _DummyGuppy:
 
 def _dummy_custom_decorator(*args: Any, **kwargs: Any) -> Any:
     """Dummy version of custom decorators that are used during Sphinx builds."""
-    return lambda f: f
+
+    def decorator(*decorator_args: Any, **decorator_kwargs: Any) -> Any:
+        if (
+            len(decorator_args) == 1
+            and callable(decorator_args[0])
+            and not decorator_kwargs
+        ):
+            return decorator_args[0]
+
+        return lambda f: f
+
+    return decorator
 
 
 def sphinx_running() -> bool:

--- a/tests/test_dummy_decorator.py
+++ b/tests/test_dummy_decorator.py
@@ -1,0 +1,9 @@
+from guppylang_internals.dummy_decorator import _dummy_custom_decorator
+
+
+def test_dummy_custom_decorator_supports_factories():
+    @_dummy_custom_decorator("example.name")
+    def example() -> None:
+        pass
+
+    assert example.__name__ == "example"


### PR DESCRIPTION
(cherry picked from commit eb760de3f9c4b6c3c568f8616d6e73084a1e297f)

Backport of #2287 