### PR TITLE
chore: Add llvmlite dependency constraints for non-macos platforms

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -107,8 +107,8 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
 
-      - name: Setup tmate session
-        uses: mxschmitt/action-tmate@v3
+      - name: Setup upterm session
+        uses: owenthereal/action-upterm@v1
 
       - name: Install Guppy
         run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -107,6 +107,9 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
 
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+
       - name: Install Guppy
         run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -107,9 +107,6 @@ jobs:
           version: ${{ env.UV_VERSION }}
           enable-cache: true
 
-      - name: Setup upterm session
-        uses: owenthereal/action-upterm@v1
-
       - name: Install Guppy
         run: uv sync --frozen --python ${{ env.PYTHON_VERSION }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ dev = [
   { include-group = "examples" },
   { include-group = "lint" },
   { include-group = "test" },
+  "setuptools<81.0.0",
 ]
 docs = ["furo>=2024.8.6", "sphinx >=7.2.6,<9"]
 examples = ["matplotlib>=3.11.1", "networkx>=2.6,<4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ dev = [
   { include-group = "examples" },
   { include-group = "lint" },
   { include-group = "test" },
-  "setuptools<81.0.0",
+  "setuptools<81.0.0", # Some transitive dependencies (e.g. llvmlite==0.45.1) cannot be built with v81.0.0 and higher
 ]
 docs = ["furo>=2024.8.6", "sphinx >=7.2.6,<9"]
 examples = ["matplotlib>=3.11.1", "networkx>=2.6,<4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ dev = [
   { include-group = "examples" },
   { include-group = "lint" },
   { include-group = "test" },
-  "setuptools<81.0.0", # Some transitive dependencies (e.g. llvmlite==0.45.1) cannot be built with v81.0.0 and higher
 ]
 docs = ["furo>=2024.8.6", "sphinx >=7.2.6,<9"]
 examples = ["matplotlib>=3.11.1", "networkx>=2.6,<4"]
@@ -28,6 +27,11 @@ test = [
 
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
+
+# See https://github.com/Quantinuum/selene/commit/0e8aea3f930b33f437f744306258c4bc501f0834
+constraint-dependencies = [
+  "llvmlite>0.45.1; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+]
 
 [tool.uv.workspace]
 members = ["guppylang", "guppylang-internals", "miette-py"]

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ dev = [
     { name = "pytest-snapshot", specifier = ">=0.9.0,<1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = "~=0.16.4" },
+    { name = "setuptools", specifier = "<81.0.0" },
     { name = "types-networkx", specifier = ">=3.6.1.20260612" },
 ]
 docs = [
@@ -2831,11 +2832,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "83.0.0"
+version = "80.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/95/faf61eb8363f26aa7e1d762267a8d602a1b26d4f3a1e758e92cb3cb8b054/setuptools-80.10.2.tar.gz", hash = "sha256:8b0e9d10c784bf7d262c4e5ec5d4ec94127ce206e8738f29a437945fbc219b70", size = 1200343, upload-time = "2026-01-25T22:38:17.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b8/f1f62a5e3c0ad2ff1d189590bfa4c46b4f3b6e49cef6f26c6ee4e575394d/setuptools-80.10.2-py3-none-any.whl", hash = "sha256:95b30ddfb717250edb492926c92b5221f7ef3fbcc2b07579bcd4a27da21d0173", size = 1064234, upload-time = "2026-01-25T22:38:15.216Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,6 @@ dev = [
     { name = "pytest-snapshot", specifier = ">=0.9.0,<1" },
     { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = "~=0.16.4" },
-    { name = "setuptools", specifier = "<81.0.0" },
     { name = "types-networkx", specifier = ">=3.6.1.20260612" },
 ]
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ members = [
     "guppylang-internals",
     "miette-py",
 ]
+constraints = [{ name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">0.45.1" }]
 
 [manifest.dependency-groups]
 dev = [


### PR DESCRIPTION
Recent release workflows have been battling resolving / building dependencies that are not yet fully compatible with setuptools v81.0.0 (such as llvmlite v0.45.1). We must add appropriate llvmlite constraint dependencies for now.

See https://github.com/Quantinuum/guppylang/actions/runs/34241378148/job/102112120510 for a succeeding "highest" run.