### PR TITLE
chore: Add llvmlite dependency constraints for non-macos platforms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,11 @@ test = [
 [tool.uv]
 prerelease = "if-necessary-or-explicit"
 
+# See https://github.com/Quantinuum/selene/commit/0e8aea3f930b33f437f744306258c4bc501f0834
+constraint-dependencies = [
+  "llvmlite>0.45.1; sys_platform != 'darwin' or platform_machine != 'x86_64'",
+]
+
 [tool.uv.workspace]
 members = ["guppylang", "guppylang-internals", "miette-py"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,7 @@ members = [
     "guppylang-internals",
     "miette-py",
 ]
+constraints = [{ name = "llvmlite", marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'", specifier = ">0.45.1" }]
 
 [manifest.dependency-groups]
 dev = [


### PR DESCRIPTION
(cherry picked from commit 664d8039e9ef8e301de054072fbf12ebc92d0be5)

Backport of #2300