### PR TITLE
chore: Allow rc releases as first stage of new cycle

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -49,6 +49,9 @@ on:
           - alpha-major
           - beta
           - rc
+          - rc-patch
+          - rc-minor
+          - rc-major
           - stable
           - patch
           - minor

--- a/scripts/release/compute_versions.py
+++ b/scripts/release/compute_versions.py
@@ -18,6 +18,9 @@ Bump modes:
 * ``alpha-major`` -> ``1.2.3`` becomes ``2.0.0-a0``
 * ``beta``  -> ``1.0.0-a1`` becomes ``1.0.0-b0``; ``b1`` becomes ``b2``
 * ``rc``    -> ``1.0.0-X``  becomes ``1.0.0-rc0``; ``rc1`` becomes ``rc2``
+* ``rc-patch`` -> ``1.2.3`` becomes ``1.2.4-rc0``
+* ``rc-minor`` -> ``1.2.3`` becomes ``1.3.0-rc0``
+* ``rc-major`` -> ``1.2.3`` becomes ``2.0.0-rc0``
 * ``stable``-> ``1.0.0-X``  becomes ``1.0.0`` (drops the pre-release)
 * ``patch`` -> ``1.0.1``    becomes ``1.0.2``
 * ``minor`` -> ``1.2.1``    becomes ``1.3.0``
@@ -43,6 +46,9 @@ class BumpMode(StrEnum):
     alpha_major = "alpha-major"
     beta = "beta"
     rc = "rc"
+    rc_patch = "rc-patch"
+    rc_minor = "rc-minor"
+    rc_major = "rc-major"
     stable = "stable"
     patch = "patch"
     minor = "minor"
@@ -184,6 +190,21 @@ def bump_guppylang(current: GuppyVersion, mode: str) -> GuppyVersion:
             return GuppyVersion(
                 current.major, current.minor, current.patch, PreLabel.rc, next_num
             )
+
+        case BumpMode.rc_patch:
+            return GuppyVersion(
+                current.major,
+                current.minor,
+                current.patch + 1,
+                PreLabel.rc,
+                pre_num=0,
+            )
+        case BumpMode.rc_minor:
+            return GuppyVersion(
+                current.major, current.minor + 1, 0, PreLabel.rc, pre_num=0
+            )
+        case BumpMode.rc_major:
+            return GuppyVersion(current.major + 1, 0, 0, PreLabel.rc, pre_num=0)
 
         case BumpMode.stable:
             if not current.is_prerelease:

--- a/tests/release/test_compute_versions.py
+++ b/tests/release/test_compute_versions.py
@@ -30,6 +30,10 @@ POSITIVE_BUMP_TESTS = [
     ("1.0.0-a5", "rc", "1.0.0-rc0"),
     ("1.0.0-b2", "rc", "1.0.0-rc0"),
     ("1.0.0-rc1", "rc", "1.0.0-rc2"),
+    # rc-{patch,minor,major}: start a fresh rc series off a core bump.
+    ("1.2.3", "rc-patch", "1.2.4-rc0"),
+    ("1.2.3", "rc-minor", "1.3.0-rc0"),
+    ("1.2.3", "rc-major", "2.0.0-rc0"),
     # stable: drop the pre-release suffix.
     ("1.0.0-a5", "stable", "1.0.0"),
     ("1.0.0-rc2", "stable", "1.0.0"),


### PR DESCRIPTION
(cherry picked from commit e60c3efe9e4986e5eacd8b315b42aa36f9e52116)

Backport of #2307