### PR TITLE
fix: Reject unsupported statements in @guppy.unitary classes

### DIFF
--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -433,7 +433,7 @@ class InvalidExpectedQubit(Help):
 @dataclass(frozen=True)
 class InvalidUnitaryMethodHelp(Help):
     message: ClassVar[str] = (
-        f"Only guppy functions named: '__call__', '{CALL_CONTROLLED_METHOD}', "
+        f"Only Guppy functions named: '__call__', '{CALL_CONTROLLED_METHOD}', "
         f"'{CALL_CTRL_DAGGERED_METHOD}' or '{CALL_DAGGERED_METHOD}' are "
         "allowed as methods in a `@guppy.unitary` class. "
     )
@@ -474,7 +474,7 @@ def check_unitary_method[T](
         ):
             raise GuppyError(InvalidUnitaryMethodError(node, node.name, class_ast.name))
 
-        # Check that no invalid metadata are present
+        # Check that no invalid metadata is present
         method_raw_def = method.wrapped
         if method_raw_def.unitary_flags != UnitaryFlags.NoFlags:
             raise GuppyError(

--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -409,7 +409,7 @@ class InvalidUnitaryMethodError(Error):
     node_name: str
     class_name: str
     span_label: ClassVar[str] = (
-        "{node_name}` in the `@guppy.unitary` class `{class_name}`"
+        "`{node_name}` in the `@guppy.unitary` class `{class_name}`"
         " must be a guppy function"
     )
 

--- a/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
+++ b/guppylang-internals/src/guppylang_internals/checker/unitary_checker.py
@@ -1,15 +1,20 @@
 import ast
+import builtins
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from guppylang_internals.ast_util import branching_in_ast, get_type, loop_in_ast
 from guppylang_internals.cfg.bb import BBStatement
 from guppylang_internals.checker.cfg_checker import CheckedCFG
 from guppylang_internals.checker.core import Place
-from guppylang_internals.checker.errors.generic import InvalidUnderDagger
+from guppylang_internals.checker.errors.generic import (
+    InvalidUnderDagger,
+    UnexpectedError,
+)
+from guppylang_internals.checker.modifier import CustomModifierKind
 from guppylang_internals.definition.value import CallableDef
-from guppylang_internals.diagnostic import Error
-from guppylang_internals.error import GuppyError, GuppyTypeError
+from guppylang_internals.diagnostic import Error, Help
+from guppylang_internals.error import GuppyError, GuppyTypeError, pretty_errors
 from guppylang_internals.nodes import (
     AbortExpr,
     AnyCall,
@@ -21,13 +26,21 @@ from guppylang_internals.nodes import (
     StateOutputExpr,
     TensorCall,
 )
-from guppylang_internals.span import ToSpan
+from guppylang_internals.span import ToSpan, function_header_span
 from guppylang_internals.tys.errors import UnitaryCallError
 from guppylang_internals.tys.qubit import contain_qubit_ty
 from guppylang_internals.tys.ty import (
+    CALL_CONTROLLED_METHOD,
+    CALL_CTRL_DAGGERED_METHOD,
+    CALL_DAGGERED_METHOD,
     FunctionType,
     UnitaryFlags,
 )
+
+if TYPE_CHECKING:
+    from guppylang_internals.definition.function import RawFunctionDef
+
+type CustomModifiedDefinitions = dict[CustomModifierKind, RawFunctionDef]
 
 
 @dataclass(frozen=True)
@@ -388,3 +401,98 @@ def check_modified_def_combinations(
                     required_flag,
                 )
             )
+
+
+@dataclass(frozen=True)
+class InvalidUnitaryMethodError(Error):
+    title: ClassVar[str] = "Invalid `@guppy.unitary` method"
+    node_name: str
+    class_name: str
+    span_label: ClassVar[str] = (
+        "{node_name}` in the `@guppy.unitary` class `{class_name}`"
+        " must be a guppy function"
+    )
+
+
+@dataclass(frozen=True)
+class InvalidUnitaryMetadataHelp(Help):
+    message: ClassVar[str] = (
+        "This method cannot set unitary flags. To set unitary flag "
+        "to the unitary class, use the decorator on top of `__call__`."
+    )
+
+
+@dataclass(frozen=True)
+class InvalidExpectedQubit(Help):
+    message: ClassVar[str] = (
+        "This method cannot cannot use `@expected_qubits`; Use the decorator on top of "
+        "`__call__` to set the expected qubits."
+    )
+
+
+@dataclass(frozen=True)
+class InvalidUnitaryMethodHelp(Help):
+    message: ClassVar[str] = (
+        f"Only guppy functions named: '__call__', '{CALL_CONTROLLED_METHOD}', "
+        f"'{CALL_CTRL_DAGGERED_METHOD}' or '{CALL_DAGGERED_METHOD}' are "
+        "allowed as methods in a `@guppy.unitary` class. "
+    )
+
+
+@pretty_errors
+def check_unitary_method[T](
+    cls: builtins.type[T],
+    class_ast: ast.ClassDef,
+) -> CustomModifiedDefinitions:
+    """Validate a unitary class body and return its custom modifier methods.
+
+    ``methods`` contains the class's own Guppy-decorated raw function definitions.
+    The caller must already have validated ``__call__``.
+    """
+    from guppylang.defs import GuppyDefinition
+
+    from guppylang_internals.definition.function import RawFunctionDef
+
+    custom_methods: dict[CustomModifierKind, RawFunctionDef] = {}
+    valid_method_names = [kind.value for kind in CustomModifierKind] + ["__call__"]
+    for node in class_ast.body:
+        if not isinstance(node, ast.FunctionDef) or node.name not in valid_method_names:
+            raise GuppyError(
+                UnexpectedError(
+                    node, "statement", unexpected_in="in a `@guppy.unitary` class"
+                ).add_sub_diagnostic(InvalidUnitaryMethodHelp(None))
+            )
+        method_name = node.name
+        # `__call__` has already been checked in `decorator._get_unitary_call_def`
+        if method_name == "__call__":
+            continue
+        method = cls.__dict__.get(method_name)
+
+        if not (
+            isinstance(method, GuppyDefinition)
+            and isinstance(method.wrapped, RawFunctionDef)
+        ):
+            raise GuppyError(InvalidUnitaryMethodError(node, node.name, class_ast.name))
+
+        # Check that no invalid metadata are present
+        method_raw_def = method.wrapped
+        if method_raw_def.unitary_flags != UnitaryFlags.NoFlags:
+            raise GuppyError(
+                UnexpectedError(
+                    function_header_span(node),
+                    "unitary flags",
+                    unexpected_in="in the method `@guppy` decorator",
+                ).add_sub_diagnostic(InvalidUnitaryMetadataHelp(None))
+            )
+
+        if (
+            method_raw_def.metadata is not None
+            and method_raw_def.metadata.get_expected_qubits() is not None
+        ):
+            raise GuppyError(
+                UnexpectedError(
+                    function_header_span(node), "`@expected_qubits` decorator"
+                ).add_sub_diagnostic(InvalidExpectedQubit(None))
+            )
+        custom_methods[CustomModifierKind(node.name)] = method_raw_def
+    return custom_methods

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -21,6 +21,7 @@ from guppylang_internals.ast_util import annotate_location
 from guppylang_internals.checker.modifier import CustomModifierKind
 from guppylang_internals.checker.unitary_checker import (
     check_modified_def_combinations,
+    check_unitary_method,
 )
 from guppylang_internals.definition.alias import RawTypeAliasDef
 from guppylang_internals.definition.common import DefId
@@ -81,7 +82,6 @@ if TYPE_CHECKING:
     from tket.metadata import InlineAnnotationValue
 
 type Decorator[S, T] = Callable[[S], T]
-type _CustomModifiedDefinitions = dict[CustomModifierKind, RawFunctionDef]
 
 AnyRawFunctionDef = (
     RawFunctionDef,
@@ -393,9 +393,7 @@ class _Guppy:
             DEF_STORE.sources,
         )
         # Update the unitary metadata according to the custom implementations
-        custom_modified_definitions = _get_custom_modified_definitions(
-            cls, definition_span
-        )
+        custom_modified_definitions = check_unitary_method(cls, definition_span)
         for kind in CustomModifierKind:
             custom_def = custom_modified_definitions.get(kind)
             if custom_def is None:
@@ -942,64 +940,6 @@ def _get_unitary_call_def(cls: object) -> GuppyDefinition:
         f"The `@guppy.unitary` class `{cls.__name__}` requires a `@guppy` "
         f"annotated `__call__` method"
     )
-
-
-def _get_custom_modified_definitions[T](
-    cls: builtins.type[T],
-    class_ast: ast.ClassDef,
-) -> _CustomModifiedDefinitions:
-    """Validate the class body and collect its custom modifier methods."""
-    custom_methods: _CustomModifiedDefinitions = {}
-    valid_methods_names = [kind.value for kind in CustomModifierKind] + ["__call__"]
-    valid_methods_names_str = ", ".join(valid_methods_names)
-
-    for node in class_ast.body:
-        print(f"Inspecting: {node}")
-        if not isinstance(node, ast.FunctionDef) or (
-            node.name not in valid_methods_names
-        ):
-            raise TypeError(
-                f"Only guppy function named {valid_methods_names_str} are allowed as a "
-                f"method in a `@guppy.unitary` class. Found `{type(node).__name__}`.",
-            )
-        method_name = node.name
-        if method_name == "__call__":
-            # `__call__` has already been checked in `_get_unitary_call_def`
-            continue
-        method = cls.__dict__.get(method_name)
-        if not (
-            isinstance(method, GuppyDefinition)
-            and isinstance(method.wrapped, RawFunctionDef)
-        ):
-            raise TypeError(
-                f"`{method_name}` in the `@guppy.unitary` class `{cls.__name__}` must "
-                "be a guppy function"
-            )
-        _check_custom_method_metadata(method_name, method.wrapped, cls.__name__)
-        custom_methods[CustomModifierKind(method_name)] = method.wrapped
-
-    return custom_methods
-
-
-@hide_trace
-def _check_custom_method_metadata(
-    method_name: str, method: RawFunctionDef, class_name: str
-) -> None:
-    """Reject metadata that is only meaningful on a unitary class's ``__call__``."""
-    if method.unitary_flags != UnitaryFlags.NoFlags:
-        raise TypeError(
-            f"`{method_name}` in the `@guppy.unitary` class `{class_name}` cannot "
-            "set unitary flags; only `__call__` can set them"
-        )
-
-    if (
-        method.metadata is not None
-        and method.metadata.get_expected_qubits() is not None
-    ):
-        raise TypeError(
-            f"`{method_name}` in the `@guppy.unitary` class `{class_name}` cannot "
-            "use `@expected_qubits`; only `__call__` can use it"
-        )
 
 
 @pretty_errors

--- a/guppylang/src/guppylang/decorator.py
+++ b/guppylang/src/guppylang/decorator.py
@@ -387,12 +387,14 @@ class _Guppy:
         # override "__call__" with the class name, mainly for better error messages
         object.__setattr__(call_raw_func, "name", cls.__name__)
 
-        # Update the unitary metadata according to the custom implementations
-        custom_modified_definitions = _get_custom_modified_definitions(cls)
         definition_span = call_raw_func.set_unitary_class(
             cls,
             frame,
             DEF_STORE.sources,
+        )
+        # Update the unitary metadata according to the custom implementations
+        custom_modified_definitions = _get_custom_modified_definitions(
+            cls, definition_span
         )
         for kind in CustomModifierKind:
             custom_def = custom_modified_definitions.get(kind)
@@ -944,39 +946,37 @@ def _get_unitary_call_def(cls: object) -> GuppyDefinition:
 
 def _get_custom_modified_definitions[T](
     cls: builtins.type[T],
+    class_ast: ast.ClassDef,
 ) -> _CustomModifiedDefinitions:
-    """Returns the `@guppy`-annotated `daggered`, `controlled`, and `ctrl_daggered`"""
+    """Validate the class body and collect its custom modifier methods."""
     custom_methods: _CustomModifiedDefinitions = {}
-    custom_methods_names = tuple(kind.value for kind in CustomModifierKind)
+    valid_methods_names = [kind.value for kind in CustomModifierKind] + ["__call__"]
+    valid_methods_names_str = ", ".join(valid_methods_names)
 
-    for method_name, method in cls.__dict__.items():
-        if isinstance(method, GuppyDefinition) and method_name in custom_methods_names:
-            if isinstance(method.wrapped, RawFunctionDef):
-                _check_custom_method_metadata(method_name, method.wrapped, cls.__name__)
-                custom_methods[CustomModifierKind(method_name)] = method.wrapped
-            else:
-                raise TypeError(
-                    f"`{method_name}` in the `@guppy.unitary` class "
-                    f"`{cls.__name__}` must be a guppy function."
-                )
-        elif (
-            isinstance(method, GuppyDefinition)
-            and not isinstance(method, GuppyTypeVarDefinition)
-            and method_name not in custom_methods_names
-            and method_name != "__call__"
+    for node in class_ast.body:
+        print(f"Inspecting: {node}")
+        if not isinstance(node, ast.FunctionDef) or (
+            node.name not in valid_methods_names
         ):
             raise TypeError(
-                f"Only guppy function named {custom_methods_names} are allowed as a "
-                f"method in a `@guppy.unitary` class. Found `{method_name}`.",
+                f"Only guppy function named {valid_methods_names_str} are allowed as a "
+                f"method in a `@guppy.unitary` class. Found `{type(node).__name__}`.",
             )
-        elif (
-            not isinstance(method, GuppyDefinition)
-            and method_name in custom_methods_names
+        method_name = node.name
+        if method_name == "__call__":
+            # `__call__` has already been checked in `_get_unitary_call_def`
+            continue
+        method = cls.__dict__.get(method_name)
+        if not (
+            isinstance(method, GuppyDefinition)
+            and isinstance(method.wrapped, RawFunctionDef)
         ):
             raise TypeError(
                 f"`{method_name}` in the `@guppy.unitary` class `{cls.__name__}` must "
                 "be a guppy function"
             )
+        _check_custom_method_metadata(method_name, method.wrapped, cls.__name__)
+        custom_methods[CustomModifierKind(method_name)] = method.wrapped
 
     return custom_methods
 

--- a/tests/error/modifier_errors/custom_control_decorator_constraint.err
+++ b/tests/error/modifier_errors/custom_control_decorator_constraint.err
@@ -1,8 +1,8 @@
-Error: Control constraint violation (at $FILE:17:8)
+Error: Control constraint violation (at $FILE:15:8)
    | 
-15 |     @guppy(controllable=True)
-16 |     def __call__(q: qubit) -> None:
-17 |         helper(q)
+13 |     @guppy(controllable=True)
+14 |     def __call__(q: qubit) -> None:
+15 |         helper(q)
    |         ^^^^^^^^^ This function cannot be called in a controllable context
 
 Help: Consider adding the flag `(controllable=True)` to the decorator of the

--- a/tests/error/modifier_errors/custom_control_decorator_constraint.py
+++ b/tests/error/modifier_errors/custom_control_decorator_constraint.py
@@ -1,5 +1,5 @@
 from guppylang.decorator import guppy
-from guppylang.std.builtins import array
+from guppylang.std.builtins import array, nat
 from guppylang.std.quantum import qubit
 
 
@@ -10,14 +10,12 @@ def helper(q: qubit) -> None:
 
 @guppy.unitary
 class foo:
-    n = guppy.nat_var("n")
-
     @guppy(controllable=True)
     def __call__(q: qubit) -> None:
         helper(q)
 
     @guppy
-    def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+    def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
         pass
 
 

--- a/tests/error/modifier_errors/custom_control_owned_controls.err
+++ b/tests/error/modifier_errors/custom_control_owned_controls.err
@@ -1,10 +1,10 @@
-Error: Incompatible signature for custom `controlled` implementation (at $FILE:15:4)
+Error: Incompatible signature for custom `controlled` implementation (at $FILE:14:4)
    | 
-13 | 
-14 |     @guppy
-15 |     def controlled(q: qubit, controls: array[qubit, n] @ owned) -> None:
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-16 |         pass
+12 | 
+13 |     @guppy
+14 |     def controlled[n:nat](q: qubit, controls: array[qubit, n] @ owned) -> None:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+15 |         pass
    | ^^^^^^^^^^^^ Expected signature `forall n: nat. (qubit, array[qubit, n])
    |              -> None`, got `forall n: nat. (qubit, array[qubit, n]
    |              @owned) -> None`

--- a/tests/error/modifier_errors/custom_control_owned_controls.py
+++ b/tests/error/modifier_errors/custom_control_owned_controls.py
@@ -1,18 +1,17 @@
 from guppylang.decorator import guppy
-from guppylang.std.builtins import array, owned
+from guppylang.std.builtins import array, nat, owned
 from guppylang.std.quantum import qubit
 
 
 @guppy.unitary
 class foo:
-    n = guppy.nat_var("n")
 
     @guppy
     def __call__(q: qubit) -> None:
         pass
 
     @guppy
-    def controlled(q: qubit, controls: array[qubit, n] @ owned) -> None:
+    def controlled[n:nat](q: qubit, controls: array[qubit, n] @ owned) -> None:
         pass
 
 

--- a/tests/error/modifier_errors/custom_unitary_higher_order_requires_dagger.err
+++ b/tests/error/modifier_errors/custom_unitary_higher_order_requires_dagger.err
@@ -1,8 +1,8 @@
-Error: Missing protocol implementation (at $FILE:25:17)
+Error: Missing protocol implementation (at $FILE:24:17)
    | 
-23 | @guppy
-24 | def test(q: qubit) -> None:
-25 |     apply_dagger(control_only, q)
+22 | @guppy
+23 | def test(q: qubit) -> None:
+24 |     apply_dagger(control_only, q)
    |                  ^^^^^^^^^^^^ Type `def control_only(q: qubit) -> None` does not implement
    |                               protocol `Daggerable[[qubit], None]`
 

--- a/tests/error/modifier_errors/custom_unitary_higher_order_requires_dagger.py
+++ b/tests/error/modifier_errors/custom_unitary_higher_order_requires_dagger.py
@@ -1,17 +1,16 @@
 from guppylang import guppy, qubit
-from guppylang.std.builtins import Daggerable, array
+from guppylang.std.builtins import Daggerable, array, nat
 
 
 @guppy.unitary
 class control_only:
-    n = guppy.nat_var("n")
 
     @guppy
     def __call__(q: qubit) -> None:
         pass
 
     @guppy
-    def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+    def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
         pass
 
 

--- a/tests/error/modifier_errors/recursive_custom_control_increase.err
+++ b/tests/error/modifier_errors/recursive_custom_control_increase.err
@@ -1,8 +1,8 @@
-Error: Increasing control count in recursive custom modifier (at $FILE:29:12)
+Error: Increasing control count in recursive custom modifier (at $FILE:27:12)
    | 
-27 |         extra_control = qubit()
-28 |         with control(controls), control(extra_control):
-29 |             foo(q)
+25 |         extra_control = qubit()
+26 |         with control(controls), control(extra_control):
+27 |             foo(q)
    |             ^^^^^^ This recursive call increases the number of controls from 1
    |                    to 3
 

--- a/tests/error/modifier_errors/recursive_custom_control_increase.py
+++ b/tests/error/modifier_errors/recursive_custom_control_increase.py
@@ -6,8 +6,6 @@ from guppylang.std.quantum import measure, qubit
 
 @guppy.unitary
 class foo:
-    n = guppy.nat_var("n")
-
     @guppy
     def __call__(q: qubit) -> None:
         pass
@@ -17,13 +15,13 @@ class foo:
         pass
 
     @guppy
-    def controlled(q: qubit, controls: array[qubit, n]) -> None:
+    def controlled[n: nat](q: qubit, controls: array[qubit, n]) -> None:
         extra_control = qubit()
         helper(q, controls, extra_control)
         measure(extra_control)
 
     @guppy
-    def ctrl_daggered(q: qubit, controls: array[qubit, n]) -> None:
+    def ctrl_daggered[n: nat](q: qubit, controls: array[qubit, n]) -> None:
         extra_control = qubit()
         with control(controls), control(extra_control):
             foo(q)

--- a/tests/error/modifier_errors/unitary_custom_method_must_be_guppy_function.err
+++ b/tests/error/modifier_errors/unitary_custom_method_must_be_guppy_function.err
@@ -1,0 +1,13 @@
+Error: Unexpected statement (at $FILE:11:4)
+   | 
+ 9 | 
+10 |     @guppy.struct
+11 |     class daggered:
+   |     ^^^^^^^^^^^^^^^
+12 |         value: int
+   | ^^^^^^^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
+
+Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+'daggered' are allowed as methods in a `@guppy.unitary` class.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_custom_method_must_be_guppy_function.err
+++ b/tests/error/modifier_errors/unitary_custom_method_must_be_guppy_function.err
@@ -7,7 +7,7 @@ Error: Unexpected statement (at $FILE:11:4)
 12 |         value: int
    | ^^^^^^^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
 
-Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+Help: Only Guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
 'daggered' are allowed as methods in a `@guppy.unitary` class.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_custom_method_must_be_guppy_function.py
+++ b/tests/error/modifier_errors/unitary_custom_method_must_be_guppy_function.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+
+
+@guppy.unitary
+class Foo:
+    @guppy
+    def __call__() -> None:
+        pass
+
+    @guppy.struct
+    class daggered:
+        value: int

--- a/tests/error/modifier_errors/unitary_custom_method_rejects_expected_qubits.err
+++ b/tests/error/modifier_errors/unitary_custom_method_rejects_expected_qubits.err
@@ -1,0 +1,11 @@
+Error: Unexpected `@expected_qubits` decorator (at $FILE:12:4)
+   | 
+10 |     @guppy
+11 |     @expected_qubits(2)
+12 |     def controlled() -> None:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected `@expected_qubits` decorator
+
+Help: This method cannot cannot use `@expected_qubits`; Use the decorator on top
+of `__call__` to set the expected qubits.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_custom_method_rejects_expected_qubits.py
+++ b/tests/error/modifier_errors/unitary_custom_method_rejects_expected_qubits.py
@@ -1,0 +1,13 @@
+from guppylang.decorator import expected_qubits, guppy
+
+
+@guppy.unitary
+class Foo:
+    @guppy
+    def __call__() -> None:
+        pass
+
+    @guppy
+    @expected_qubits(2)
+    def controlled() -> None:
+        pass

--- a/tests/error/modifier_errors/unitary_custom_method_requires_guppy_decorator.err
+++ b/tests/error/modifier_errors/unitary_custom_method_requires_guppy_decorator.err
@@ -1,0 +1,11 @@
+Error: Invalid `@guppy.unitary` method (at $FILE:10:4)
+   | 
+ 8 |         pass
+ 9 | 
+10 |     def controlled() -> None:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^
+11 |         pass
+   | ^^^^^^^^^^^^ controlled` in the `@guppy.unitary` class `Foo` must be a
+   |              guppy function
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_custom_method_requires_guppy_decorator.err
+++ b/tests/error/modifier_errors/unitary_custom_method_requires_guppy_decorator.err
@@ -5,7 +5,7 @@ Error: Invalid `@guppy.unitary` method (at $FILE:10:4)
 10 |     def controlled() -> None:
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
 11 |         pass
-   | ^^^^^^^^^^^^ controlled` in the `@guppy.unitary` class `Foo` must be a
+   | ^^^^^^^^^^^^ `controlled` in the `@guppy.unitary` class `Foo` must be a
    |              guppy function
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_custom_method_requires_guppy_decorator.py
+++ b/tests/error/modifier_errors/unitary_custom_method_requires_guppy_decorator.py
@@ -1,0 +1,11 @@
+from guppylang.decorator import guppy
+
+
+@guppy.unitary
+class Foo:
+    @guppy
+    def __call__() -> None:
+        pass
+
+    def controlled() -> None:
+        pass

--- a/tests/error/modifier_errors/unitary_custom_method_with_unitary_flags.err
+++ b/tests/error/modifier_errors/unitary_custom_method_with_unitary_flags.err
@@ -1,0 +1,11 @@
+Error: Unexpected unitary flags (at $FILE:11:4)
+   | 
+ 9 | 
+10 |     @guppy(controllable=True)
+11 |     def daggered() -> None:
+   |     ^^^^^^^^^^^^^^^^^^^^^^^ Unexpected unitary flags in in the method `@guppy` decorator
+
+Help: This method cannot set unitary flags. To set unitary flag to the unitary
+class, use the decorator on top of `__call__`.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_custom_method_with_unitary_flags.py
+++ b/tests/error/modifier_errors/unitary_custom_method_with_unitary_flags.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+
+
+@guppy.unitary
+class Foo:
+    @guppy
+    def __call__() -> None:
+        pass
+
+    @guppy(controllable=True)
+    def daggered() -> None:
+        pass

--- a/tests/error/modifier_errors/unitary_rejects_class_statement.err
+++ b/tests/error/modifier_errors/unitary_rejects_class_statement.err
@@ -5,7 +5,7 @@ Error: Unexpected statement (at $FILE:11:4)
 11 |     dagger = helper
    |     ^^^^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
 
-Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+Help: Only Guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
 'daggered' are allowed as methods in a `@guppy.unitary` class.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_rejects_class_statement.err
+++ b/tests/error/modifier_errors/unitary_rejects_class_statement.err
@@ -1,0 +1,11 @@
+Error: Unexpected statement (at $FILE:11:4)
+   | 
+ 9 | @guppy.unitary
+10 | class Foo:
+11 |     dagger = helper
+   |     ^^^^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
+
+Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+'daggered' are allowed as methods in a `@guppy.unitary` class.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_rejects_class_statement.py
+++ b/tests/error/modifier_errors/unitary_rejects_class_statement.py
@@ -1,0 +1,15 @@
+from guppylang.decorator import guppy
+
+
+@guppy
+def helper() -> None:
+    pass
+
+
+@guppy.unitary
+class Foo:
+    dagger = helper
+
+    @guppy
+    def __call__() -> None:
+        pass

--- a/tests/error/modifier_errors/unitary_rejects_unrecognised_guppy_method.err
+++ b/tests/error/modifier_errors/unitary_rejects_unrecognised_guppy_method.err
@@ -7,7 +7,7 @@ Error: Unexpected statement (at $FILE:11:4)
 12 |         pass
    | ^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
 
-Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+Help: Only Guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
 'daggered' are allowed as methods in a `@guppy.unitary` class.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_rejects_unrecognised_guppy_method.err
+++ b/tests/error/modifier_errors/unitary_rejects_unrecognised_guppy_method.err
@@ -1,0 +1,13 @@
+Error: Unexpected statement (at $FILE:11:4)
+   | 
+ 9 | 
+10 |     @guppy
+11 |     def other() -> None:
+   |     ^^^^^^^^^^^^^^^^^^^^
+12 |         pass
+   | ^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
+
+Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+'daggered' are allowed as methods in a `@guppy.unitary` class.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_rejects_unrecognised_guppy_method.py
+++ b/tests/error/modifier_errors/unitary_rejects_unrecognised_guppy_method.py
@@ -1,0 +1,12 @@
+from guppylang.decorator import guppy
+
+
+@guppy.unitary
+class Foo:
+    @guppy
+    def __call__() -> None:
+        pass
+
+    @guppy
+    def other() -> None:
+        pass

--- a/tests/error/modifier_errors/unitary_rejects_unrecognised_python_method.err
+++ b/tests/error/modifier_errors/unitary_rejects_unrecognised_python_method.err
@@ -1,0 +1,13 @@
+Error: Unexpected statement (at $FILE:10:4)
+   | 
+ 8 |         pass
+ 9 | 
+10 |     def other() -> None:
+   |     ^^^^^^^^^^^^^^^^^^^^
+11 |         pass
+   | ^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
+
+Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+'daggered' are allowed as methods in a `@guppy.unitary` class.
+
+Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_rejects_unrecognised_python_method.err
+++ b/tests/error/modifier_errors/unitary_rejects_unrecognised_python_method.err
@@ -7,7 +7,7 @@ Error: Unexpected statement (at $FILE:10:4)
 11 |         pass
    | ^^^^^^^^^^^^ Unexpected statement in in a `@guppy.unitary` class
 
-Help: Only guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
+Help: Only Guppy functions named: '__call__', 'controlled', 'ctrl_daggered' or
 'daggered' are allowed as methods in a `@guppy.unitary` class.
 
 Guppy compilation failed due to 1 previous error

--- a/tests/error/modifier_errors/unitary_rejects_unrecognised_python_method.py
+++ b/tests/error/modifier_errors/unitary_rejects_unrecognised_python_method.py
@@ -1,0 +1,11 @@
+from guppylang.decorator import guppy
+
+
+@guppy.unitary
+class Foo:
+    @guppy
+    def __call__() -> None:
+        pass
+
+    def other() -> None:
+        pass

--- a/tests/error/poly_errors/unitary_generic_function_error.py
+++ b/tests/error/poly_errors/unitary_generic_function_error.py
@@ -1,9 +1,9 @@
 from guppylang.decorator import guppy
 
+T = guppy.type_var("T")
 
 @guppy.unitary
 class identity:
-    T = guppy.type_var("T")
 
     @guppy
     def __call__(x: T) -> T:

--- a/tests/error/test_decorator_errors.py
+++ b/tests/error/test_decorator_errors.py
@@ -37,12 +37,12 @@ def test_metadata_decorator_arguments():
             y: int
 
 
-def test_unitary_custom_method_must_be_guppy_function(use_experimental_features):
+def test_unitary_custom_method_must_be_guppy_function():
     with pytest.raises(
         TypeError,
         match=(
-            r"`daggered` in the `@guppy\.unitary` class `Foo` must be a guppy "
-            r"function"
+            r"Only guppy function named .* are allowed as a method in a "
+            r"`@guppy\.unitary` class\. Found `ClassDef`\."
         ),
     ):
 
@@ -57,7 +57,7 @@ def test_unitary_custom_method_must_be_guppy_function(use_experimental_features)
                 value: int
 
 
-def test_unitary_requires_guppy_call_method(use_experimental_features):
+def test_unitary_requires_guppy_call_method():
     with pytest.raises(
         TypeError,
         match=(
@@ -99,10 +99,11 @@ def test_unitary_rejects_keyword_arguments():
             pass
 
 
-def test_unitary_rejects_unrecognised_guppy_method(use_experimental_features):
+@pytest.mark.parametrize("decorate", [guppy, lambda f: f])
+def test_unitary_rejects_unrecognised_guppy_method(decorate):
     with pytest.raises(
         TypeError,
-        match=r"Only guppy function named .* are allowed .* Found `other`",
+        match=r"Only guppy function named .* are allowed .* Found `FunctionDef`\.",
     ):
 
         @guppy.unitary
@@ -111,12 +112,31 @@ def test_unitary_rejects_unrecognised_guppy_method(use_experimental_features):
             def __call__() -> None:
                 pass
 
-            @guppy
+            @decorate
             def other() -> None:
                 pass
 
 
-def test_unitary_custom_method_requires_guppy_decorator(use_experimental_features):
+def test_unitary_rejects_class_statement():
+    with pytest.raises(
+        TypeError,
+        match=r"Only guppy function named .* are allowed .* Found `Assign`\.",
+    ):
+
+        @guppy
+        def helper() -> None:
+            pass
+
+        @guppy.unitary
+        class Foo:
+            dagger = helper
+
+            @guppy
+            def __call__() -> None:
+                pass
+
+
+def test_unitary_custom_method_requires_guppy_decorator():
     with pytest.raises(
         TypeError,
         match=(
@@ -136,7 +156,7 @@ def test_unitary_custom_method_requires_guppy_decorator(use_experimental_feature
 
 
 @pytest.mark.parametrize("flag", ["unitary", "controllable", "daggerable"])
-def test_unitary_custom_method_rejects_unitary_flags(flag, use_experimental_features):
+def test_unitary_custom_method_rejects_unitary_flags(flag):
     with pytest.raises(
         TypeError,
         match=(
@@ -156,7 +176,7 @@ def test_unitary_custom_method_rejects_unitary_flags(flag, use_experimental_feat
                 pass
 
 
-def test_unitary_custom_method_rejects_expected_qubits(use_experimental_features):
+def test_unitary_custom_method_rejects_expected_qubits():
     with pytest.raises(
         TypeError,
         match=(

--- a/tests/error/test_decorator_errors.py
+++ b/tests/error/test_decorator_errors.py
@@ -1,5 +1,5 @@
 import pytest
-from guppylang.decorator import expected_qubits, guppy, metadata
+from guppylang.decorator import guppy, metadata
 
 
 def test_metadata_decorator_position():
@@ -35,26 +35,6 @@ def test_metadata_decorator_arguments():
         class MyStruct:
             x: int
             y: int
-
-
-def test_unitary_custom_method_must_be_guppy_function():
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"Only guppy function named .* are allowed as a method in a "
-            r"`@guppy\.unitary` class\. Found `ClassDef`\."
-        ),
-    ):
-
-        @guppy.unitary
-        class Foo:
-            @guppy
-            def __call__() -> None:
-                pass
-
-            @guppy.struct
-            class daggered:
-                value: int
 
 
 def test_unitary_requires_guppy_call_method():
@@ -97,101 +77,3 @@ def test_unitary_rejects_keyword_arguments():
         @guppy.unitary(daggerable=True)
         class Foo:
             pass
-
-
-@pytest.mark.parametrize("decorate", [guppy, lambda f: f])
-def test_unitary_rejects_unrecognised_guppy_method(decorate):
-    with pytest.raises(
-        TypeError,
-        match=r"Only guppy function named .* are allowed .* Found `FunctionDef`\.",
-    ):
-
-        @guppy.unitary
-        class Foo:
-            @guppy
-            def __call__() -> None:
-                pass
-
-            @decorate
-            def other() -> None:
-                pass
-
-
-def test_unitary_rejects_class_statement():
-    with pytest.raises(
-        TypeError,
-        match=r"Only guppy function named .* are allowed .* Found `Assign`\.",
-    ):
-
-        @guppy
-        def helper() -> None:
-            pass
-
-        @guppy.unitary
-        class Foo:
-            dagger = helper
-
-            @guppy
-            def __call__() -> None:
-                pass
-
-
-def test_unitary_custom_method_requires_guppy_decorator():
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"`controlled` in the `@guppy\.unitary` class `Foo` must be a guppy "
-            r"function"
-        ),
-    ):
-
-        @guppy.unitary
-        class Foo:
-            @guppy
-            def __call__() -> None:
-                pass
-
-            def controlled() -> None:
-                pass
-
-
-@pytest.mark.parametrize("flag", ["unitary", "controllable", "daggerable"])
-def test_unitary_custom_method_rejects_unitary_flags(flag):
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"`daggered` in the `@guppy\.unitary` class `Foo` cannot set unitary "
-            r"flags; only `__call__` can set them"
-        ),
-    ):
-
-        @guppy.unitary
-        class Foo:
-            @guppy
-            def __call__() -> None:
-                pass
-
-            @guppy(**{flag: True})
-            def daggered() -> None:
-                pass
-
-
-def test_unitary_custom_method_rejects_expected_qubits():
-    with pytest.raises(
-        TypeError,
-        match=(
-            r"`controlled` in the `@guppy\.unitary` class `Foo` cannot use "
-            r"`@expected_qubits`; only `__call__` can use it"
-        ),
-    ):
-
-        @guppy.unitary
-        class Foo:
-            @guppy
-            def __call__() -> None:
-                pass
-
-            @guppy
-            @expected_qubits(2)
-            def controlled() -> None:
-                pass

--- a/tests/integration/test_custom_modifier_callgraph.py
+++ b/tests/integration/test_custom_modifier_callgraph.py
@@ -19,14 +19,12 @@ from guppylang_internals.tys.const import ConstValue
 
 @guppy.unitary
 class _same_count_recursive_gate:
-    n = guppy.nat_var("n")
-
     @guppy
     def __call__(q: qubit) -> None:
         pass
 
     @guppy
-    def controlled(q: qubit, controls: array[qubit, n]) -> None:
+    def controlled[n: nat](q: qubit, controls: array[qubit, n]) -> None:
         _same_count_helper(q, controls)
 
 
@@ -46,14 +44,12 @@ def test_effects_after_custom_modifier_resolution_is_removed():
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             panic("parent effect")
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy
@@ -83,14 +79,12 @@ def test_effects_after_custom_modifier_resolution_is_added():
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, controls: array[qubit, n]) -> None:
             panic("custom effect")
 
     @guppy
@@ -132,14 +126,12 @@ def test_non_recursive_control_count_increase_is_allowed():
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy
@@ -170,14 +162,12 @@ def test_modifier_context_propagates_through_higher_order_and_helper_calls():
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
         @guppy
@@ -185,7 +175,7 @@ def test_modifier_context_propagates_through_higher_order_and_helper_calls():
             pass
 
         @guppy
-        def ctrl_daggered(q: qubit, _controls: array[qubit, n]) -> None:
+        def ctrl_daggered[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy(unitary=True)
@@ -261,14 +251,12 @@ def test_propagated_context_does_not_change_unmodified_invocation():
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy(controllable=True)

--- a/tests/integration/test_modifier.py
+++ b/tests/integration/test_modifier.py
@@ -391,20 +391,16 @@ def test_custom_unitary_higher_order_callables(validate):
 
     @guppy.unitary
     class custom_control:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy.unitary
     class custom_unitary:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
@@ -414,11 +410,11 @@ def test_custom_unitary_higher_order_callables(validate):
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
         @guppy
-        def ctrl_daggered(q: qubit, _controls: array[qubit, n]) -> None:
+        def ctrl_daggered[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy.unitary
@@ -467,14 +463,12 @@ def test_custom_unitary_higher_order_callables(validate):
 def test_controlled_impl_is_executed(run_int_fn):
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             x(q)
 
     @guppy
@@ -496,14 +490,12 @@ def test_controlled_impl_through_higher_order_call_is_executed(run_int_fn):
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             x(q)
 
     @guppy(controllable=True)
@@ -530,14 +522,12 @@ def test_controlled_impl_through_helper_is_executed(run_int_fn):
 
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             x(q)
 
     @guppy(controllable=True)
@@ -585,14 +575,12 @@ def test_daggered_impl_is_executed(run_int_fn):
 def test_ctrl_daggered_impl_is_executed(run_int_fn):
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy(unitary=True)
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def ctrl_daggered(q: qubit, _controls: array[qubit, n]) -> None:
+        def ctrl_daggered[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             x(q)
 
     @guppy
@@ -612,16 +600,12 @@ def test_ctrl_daggered_impl_is_executed(run_int_fn):
 def test_custom_modifier_use_default_when_missing_implementation(run_int_fn):
     @guppy.unitary
     class controllable_gate:
-        n = guppy.nat_var("n")
-
         @guppy(controllable=True)
         def __call__(q: qubit) -> None:
             x(q)
 
     @guppy.unitary
     class daggerable_gate:
-        n = guppy.nat_var("n")
-
         @guppy(daggerable=True)
         def __call__(q: qubit) -> None:
             x(q)
@@ -649,18 +633,16 @@ def test_custom_modifier_use_default_when_missing_implementation(run_int_fn):
 def test_double_daggered(run_int_fn):
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy(unitary=True)
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             x(q)
 
         @guppy
-        def ctrl_daggered(q: qubit, _controls: array[qubit, n]) -> None:
+        def ctrl_daggered[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy(unitary=True)
@@ -685,14 +667,12 @@ def test_double_daggered(run_int_fn):
 def test_two_control_counts_distinct_runtime(run_int_fn):
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             x(q)
 
     @guppy
@@ -918,11 +898,8 @@ def test_custom_modifier(validate):
 
     @guppy.unitary
     class foo:
-        n = guppy.nat_var("n")
-        c = guppy.nat_var("c")
-
         @guppy
-        def __call__(q1: array[qubit, n]) -> None:
+        def __call__[n: nat](q1: array[qubit, n]) -> None:
             # since we have custom implementations of the modifiers, there are no
             # restrictions on the body of the function
             q = qubit()
@@ -934,15 +911,19 @@ def test_custom_modifier(validate):
             measure(q)
 
         @guppy
-        def daggered(q1: array[qubit, n]) -> None:
+        def daggered[n: nat](q1: array[qubit, n]) -> None:
             ext_helper(q1[0])
 
         @guppy
-        def controlled(q1: array[qubit, n], _controls: array[qubit, c]) -> None:
+        def controlled[n: nat, c: nat](
+            q1: array[qubit, n], _controls: array[qubit, c]
+        ) -> None:
             h(_controls[0])
 
         @guppy
-        def ctrl_daggered(q1: array[qubit, n], _controls: array[qubit, c]) -> None:
+        def ctrl_daggered[n: nat, c: nat](
+            q1: array[qubit, n], _controls: array[qubit, c]
+        ) -> None:
             h(_controls[0])
 
     @guppy
@@ -1009,7 +990,6 @@ def test_std(validate):
     from guppylang.std.option import Option
 
     y = 42
-
     n = guppy.nat_var("n")
 
     @guppy.comptime(daggerable=True)

--- a/tests/integration/test_poly.py
+++ b/tests/integration/test_poly.py
@@ -14,6 +14,9 @@ from guppylang.std.quantum import discard, h, qubit
 from guppylang.std.builtins import Function
 
 
+c = guppy.nat_var("c")
+
+
 def test_id(validate):
     T = guppy.type_var("T")
 
@@ -72,8 +75,6 @@ def test_generic_functions_in_unitary_class(validate):
 
     @guppy.unitary
     class foo:
-        c = guppy.nat_var("c")
-
         @guppy
         def __call__(q: qubit) -> None:
             n = identity(1)

--- a/tests/metadata/test_modifier_metadata.py
+++ b/tests/metadata/test_modifier_metadata.py
@@ -3,7 +3,7 @@
 from guppylang import guppy
 from guppylang.std.angles import angle
 from guppylang.std.array import array
-from guppylang.std.builtins import control, dagger, power, qubit
+from guppylang.std.builtins import control, dagger, nat, power, qubit
 from guppylang.std.quantum import discard, rx
 from guppylang_internals.metadata.common import (
     ControlledImplementations,
@@ -260,8 +260,6 @@ def test_unitary_metadata_function_definition(use_experimental_features):
 def test_custom_modifier_metadata():
     @guppy.unitary
     class custom_gate:
-        n = guppy.nat_var("n")
-
         @guppy
         def __call__(q: qubit) -> None:
             pass
@@ -271,11 +269,11 @@ def test_custom_modifier_metadata():
             pass
 
         @guppy
-        def controlled(q: qubit, _controls: array[qubit, n]) -> None:
+        def controlled[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
         @guppy
-        def ctrl_daggered(q: qubit, _controls: array[qubit, n]) -> None:
+        def ctrl_daggered[n: nat](q: qubit, _controls: array[qubit, n]) -> None:
             pass
 
     @guppy


### PR DESCRIPTION
Previously, we were only checking for methods, ensuring that a `guppy.unitary` class contains only certains guppy methods (`__call__`, `daggered`, `controlled`, `ctrl_daggered`).
Thus, the assignments were allowed in the unitary class definition, and it was possible to have programs such as:
```python
@guppy
def daggered(q: qubit) -> None:
    x(q)

@guppy.unitary
class U1:

    @guppy(unitary=True)
    def __call__(q: qubit) -> None:
        h(q)

    daggered = daggered

@guppy.unitary
class U2:
    @guppy
    def __call__(q: qubit) -> None:
        z(q)

    daggered = daggered
```
leading to various compilation problems (and potential bugs).

This PR ensures that only 4 guppy methods (`__call__`, `daggered`, `controlled`, `ctrl_daggered`) are allowed in a `guppy.unitary` definition. In doing so, it improves the errors generated when a non-allowed element is found in the class, changing the previous `TypeError` to a proper `GuppyError`

The PR looks big, but it is mostly refactoring and test updating.