### PR TITLE
feat: Accept bytes into emulator builder

### DIFF
--- a/guppylang/src/guppylang/emulator/builder.py
+++ b/guppylang/src/guppylang/emulator/builder.py
@@ -133,7 +133,7 @@ class EmulatorBuilder:
 
     def build(
         self,
-        package: Package,
+        package: Package | bytes,
         n_qubits: int,
         arg_specs: Sequence[EntrypointArgSpec] = (),
     ) -> EmulatorInstance:


### PR DESCRIPTION
The underlying builder already accepts bytes, so this is literally just a type widening.

Putting this up for backport since it is very minimal but very useful for reducing uneccesary serialisation roundtrips in `guppyft`.