### PR TITLE
test: Add test for debug tracing of comptime functions

### DIFF
--- a/tests/stack_traces/comptime.err
+++ b/tests/stack_traces/comptime.err
@@ -1,0 +1,16 @@
+Panic (#1001): Always panics
+Guppy traceback (most recent call last):
+   File "$PATH_TO_FILE/comptime.py", line 7, in __hugr__.panicking_func.7:
+     | 
+   5 | @guppy.comptime
+   6 | def panicking_func() -> None:
+   7 |     panic("Always panics")
+     |     ^ Always panics
+   
+   File "$PATH_TO_FILE/comptime.py", line 12, in __hugr__.main.1:
+      | 
+   10 | @guppy.comptime
+   11 | def main() -> None:
+   12 |     panicking_func()
+      |     ^
+

--- a/tests/stack_traces/comptime.py
+++ b/tests/stack_traces/comptime.py
@@ -1,0 +1,15 @@
+from guppylang import guppy
+from guppylang.std.platform import panic
+
+
+@guppy.comptime
+def panicking_func() -> None:
+    panic("Always panics")
+
+
+@guppy.comptime
+def main() -> None:
+    panicking_func()
+
+
+main.with_minimal_opt().emulator(n_qubits=1, debug_mode=True).run()


### PR DESCRIPTION
See https://github.com/Quantinuum/guppylang/issues/2319 for the names but I think the tests could go in now as the issue isn't critical for use